### PR TITLE
feat: lokale PostgreSQL via Docker + Setup-Doku für B2 (Issue #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,14 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/learnmanagement"
+# LearnHub Umgebungsvariablen (Vorlage).
+#
+# Diese Datei wird ins Repository eingecheckt und enthaelt KEINE echten Secrets.
+# Fuer die lokale Entwicklung:
+#   1. Diese Datei nach `.env.local` kopieren:  cp .env.example .env.local
+#   2. `.env.local` ist in .gitignore und bleibt lokal.
+#   3. Werte unten passen 1:1 zu `docker-compose.yml` (Schritt B2) und
+#      funktionieren ohne Anpassung mit der lokalen Docker-DB.
+
+# Verbindungs-URL fuer die lokale PostgreSQL-Datenbank.
+# Aufbau:  postgresql://<user>:<passwort>@<host>:<port>/<datenbank>
+# Die Werte spiegeln POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB aus
+# docker-compose.yml wider.
+DATABASE_URL="postgresql://learnhub:learnhub_dev@localhost:5432/learnhub"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Bevor du startest, brauchst du auf deinem Rechner:
 
 Docker Desktop muss nach der Installation einmal manuell gestartet werden und im Hintergrund laufen, damit `docker compose`-Befehle funktionieren.
 
+### Erster Start von Docker Desktop
+
+Beim allerersten Start fragt Docker einmalig nach Setup-Entscheidungen. Empfohlener Ablauf:
+
+1. Docker Desktop aus dem Programme-Ordner (oder via Spotlight) starten.
+2. Dialog „Finish setting up Docker Desktop" → **„Use recommended settings"** ausgewaehlt lassen, auf **„Finish"** klicken.
+3. macOS fordert das Login-Passwort an — wird einmalig fuer die Installation der Privileged-Helper-Tools gebraucht.
+4. Sign-In-Screen / Onboarding-Tutorial → **„Skip"** / „Continue without sign in" waehlen. Ein Docker-Account ist fuer LearnHub nicht erforderlich.
+5. In der macOS-Menueleiste oben rechts erscheint ein **Wal-Symbol**. Solange es animiert ist, startet Docker. Sobald das Symbol still steht, ist Docker bereit und `docker`-Befehle funktionieren.
+
+Der erste Start kann 1–3 Minuten dauern. Spaetere Starts brauchen nur wenige Sekunden.
+
 ---
 
 ## Erstes Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,130 @@
 # LearnHub
 
-## Setup
+LearnHub ist eine webbasierte Lernmanagement-Anwendung fuer Studierende. Sie buendelt Lernplaene, Aufgaben und Kalendertermine in einer Oberflaeche und berechnet aus Zieldatum, Aufwand und verfuegbarer Lernzeit einen nachvollziehbaren Lernplan.
 
-- `npm install`
-- `npm run dev`
+Ausfuehrliche Beschreibung im [Product Requirements Document](./docs/prd.md). Architektur- und Stack-Entscheidungen in [docs/tech-stack.md](./docs/tech-stack.md).
+
+---
+
+## Voraussetzungen
+
+Bevor du startest, brauchst du auf deinem Rechner:
+
+- **Node.js 20** oder neuer — [nodejs.org](https://nodejs.org/) oder `nvm`
+- **Docker Desktop** (fuer die lokale PostgreSQL-Datenbank) — [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
+- **Git** — vorinstalliert auf macOS und Linux, auf Windows ueber [git-scm.com](https://git-scm.com/)
+
+Docker Desktop muss nach der Installation einmal manuell gestartet werden und im Hintergrund laufen, damit `docker compose`-Befehle funktionieren.
+
+---
+
+## Erstes Setup
+
+Aus dem Stand „frischer Checkout" zum laufenden Dev-Server:
+
+```bash
+# 1. Repository klonen
+git clone https://github.com/Fabsi07/LearnHub.git
+cd LearnHub
+
+# 2. Node-Pakete installieren
+npm install
+
+# 3. Umgebungsvariablen vorbereiten
+cp .env.example .env.local
+
+# 4. Lokale PostgreSQL via Docker starten
+docker compose up -d
+
+# 5. Datenbank-Schema anwenden und Prisma-Client generieren
+npm run prisma:migrate
+npm run prisma:generate
+
+# 6. Entwicklungs-Server starten
+npm run dev
+```
+
+Anschliessend ist die App unter [http://localhost:3000](http://localhost:3000) erreichbar.
+
+---
+
+## Taegliche Befehle
+
+| Was | Befehl |
+| --- | --- |
+| Dev-Server starten | `npm run dev` |
+| Datenbank starten (Container im Hintergrund) | `docker compose up -d` |
+| Datenbank stoppen (Daten bleiben erhalten) | `docker compose down` |
+| Datenbank vollstaendig zuruecksetzen (Daten loeschen!) | `docker compose down -v` |
+| Status der DB pruefen | `docker compose ps` |
+| DB-Logs anschauen | `docker compose logs -f db` |
+| Build pruefen | `npm run build` |
+| Linter | `npm run lint` |
+
+---
+
+## Datenbank und Prisma
+
+Die lokale PostgreSQL laeuft als Docker-Container, beschrieben in [docker-compose.yml](./docker-compose.yml). Die Verbindungs-URL steht in `.env.local`. Beide Werte muessen zusammenpassen — wenn du das eine aenderst, das andere mitziehen.
+
+| Befehl | Was passiert |
+| --- | --- |
+| `npm run prisma:migrate` | Vergleicht das Prisma-Schema mit der Datenbank, erzeugt bei Bedarf eine neue Migration unter `prisma/migrations/` und wendet sie an |
+| `npm run prisma:generate` | Erzeugt den typisierten Prisma-Client unter `node_modules/@prisma/client` auf Basis des aktuellen Schemas |
+
+Nach Aenderungen am Schema (`prisma/schema.prisma`) immer beide Befehle ausfuehren.
+
+---
+
+## Troubleshooting
+
+### Docker-Befehle schlagen mit „Cannot connect to the Docker daemon" fehl
+
+Docker Desktop laeuft nicht. Oeffne die Docker-Desktop-App, warte bis das Wal-Symbol in der Menueleiste ruhig wird (kein Lade-Animation mehr), dann den Befehl wiederholen.
+
+### Port 5432 ist bereits belegt
+
+Wahrscheinlich laeuft schon eine andere PostgreSQL auf deinem Rechner (native Installation, oder ein anderer Container). Pruefen mit:
+
+```bash
+lsof -i :5432
+```
+
+Loesung: die andere Instanz stoppen oder in `docker-compose.yml` das Port-Mapping aendern (z.B. `"5433:5432"`) und in `.env.local` die DATABASE_URL anpassen.
+
+### `npm run prisma:migrate` faellt mit „Can't reach database server"
+
+Der Container laeuft nicht oder die DATABASE_URL stimmt nicht. Pruefen:
+
+```bash
+docker compose ps         # Status: db sollte "running" / "healthy" sein
+docker compose logs db    # Auf Fehler in den Logs achten
+```
+
+Falls der Container nicht laeuft: `docker compose up -d`. Falls die URL nicht stimmt: `.env.local` mit `docker-compose.yml` abgleichen.
+
+### `npm run prisma:generate` zeigt eine Major-Version-Warnung
+
+Aktuell laeuft das Projekt bewusst auf Prisma 6 (Team-Abstimmung, siehe Issue B1). Die Warnung auf eine spaetere Version kann ignoriert werden.
+
+### Aenderungen am Schema werden nicht uebernommen
+
+Pruefe ob `npm run prisma:generate` nach der Schema-Aenderung gelaufen ist. TypeScript-Typen sind erst nach `generate` aktuell. Bei hartnaeckigen Problemen: `node_modules/.prisma` loeschen und `npm install` neu laufen lassen.
+
+### Datenbank-Daten loswerden und frisch starten
+
+```bash
+docker compose down -v    # Container + Volume entfernen
+docker compose up -d      # Container neu erstellen
+npm run prisma:migrate    # Schema neu anwenden
+```
+
+---
+
+## Projekt-Dokumentation
+
+- [Product Requirements Document](./docs/prd.md) — fachlicher Funktionsumfang
+- [Tech-Stack](./docs/tech-stack.md) — eingesetzte Technologien und Begruendung
+- [Auth-Konzept](./docs/auth-concept.md) — Login, Sessions, Schutzlogik
+- [Manueller Abnahmetest](./docs/testing/manual-acceptance-test.md) — Test-Checkliste fuer UC1–UC6
+- [Algorithmus-Konzept](./docs/Algorithmus/) — Entwurf fuer den Lernplan-Algorithmus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       POSTGRES_PASSWORD: learnhub_dev
       POSTGRES_DB: learnhub
     ports:
-      - "5432:5432"
+      # Nur an localhost binden — andere Geraete im selben Netz koennen
+      # den Port nicht erreichen, das Default-Passwort wird damit irrelevant
+      # fuer externe Angreifer.
+      - "127.0.0.1:5432:5432"
     volumes:
       - learnhub_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+# Lokale PostgreSQL-Datenbank fuer LearnHub-Entwicklung.
+#
+# Befehle (im Projekt-Root ausfuehren):
+#   Starten:  docker compose up -d
+#   Status:   docker compose ps
+#   Logs:     docker compose logs -f db
+#   Stoppen:  docker compose down
+#   Reset:    docker compose down -v   (loescht auch alle DB-Daten)
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: learnhub-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: learnhub
+      POSTGRES_PASSWORD: learnhub_dev
+      POSTGRES_DB: learnhub
+    ports:
+      - "5432:5432"
+    volumes:
+      - learnhub_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U learnhub -d learnhub"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  learnhub_pgdata:


### PR DESCRIPTION
## Summary
- Neue `docker-compose.yml` für lokale PostgreSQL (Image `postgres:16-alpine`, Healthcheck, persistentes Volume)
- `.env.example` aktualisiert: Werte passen jetzt 1:1 zur Docker-Konfiguration
- README ausgebaut: Voraussetzungen, Erstes Setup, tägliche Befehle, Datenbank/Prisma, Troubleshooting
- Docker-Desktop-Erstinstallation in der README dokumentiert (Permission-Dialog, Sign-In skippen, Wal-Symbol abwarten)
- Port-Binding auf `127.0.0.1` beschränkt — andere im Netzwerk können den Port nicht erreichen, Default-Passwort wird damit für externe Angreifer irrelevant

## Designentscheidungen (im Team abgestimmt)
- **Docker statt nativer PostgreSQL** — im Team abgestimmt
- **`postgres:16-alpine`** — stabile Major-Version, schlankes Image
- **Default-User `learnhub` / Passwort `learnhub_dev` / DB `learnhub`** — für lokale Dev OK, da Port nur an localhost gebunden ist und keine echten Daten in der DB liegen
- **Named Volume** statt Bind-Mount — schneller auf macOS, cross-platform-kompatibel

## Akzeptanzkriterien #35
- [x] `.env.local`-Variablen sind dokumentiert (`.env.example` + README)
- [x] Entscheidung Docker vs. native PostgreSQL getroffen
- [x] Lokaler Datenbankstart nachvollziehbar beschrieben (README Schritt-für-Schritt)
- [x] Prisma-Migration und Client-Generierung beschrieben (README)
- [x] Hinweise für häufige Fehler enthalten (README Troubleshooting)
- [ ] Verifikation auf frischem Checkout — bitte beim Review prüfen

## Was bewusst NICHT in diesem PR ist
- Erste Migration ausführen / Migration-Dateien einchecken → Issue B3 (#41)
- App-Code für DB-Zugriff → Feature-Tickets später

## Test plan
- [ ] `docker compose up -d` startet den Container ohne Fehler
- [ ] `docker compose ps` zeigt den Container als `healthy`
- [ ] Verbindung via `psql` möglich: `docker compose exec db psql -U learnhub -d learnhub`
- [ ] README ist auf einem frischen Checkout (oder fremdem Mac) nachvollziehbar

Closes #35