### PR TITLE
fix(calendar): Fix drag-to-create in week/day view

### DIFF
--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -203,6 +203,7 @@ export function EventBlock({
 
   return (
     <div
+      onMouseDown={(e) => e.stopPropagation()}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}

--- a/src/components/calendar/useDragCreate.ts
+++ b/src/components/calendar/useDragCreate.ts
@@ -44,8 +44,8 @@ export function useDragCreate(
   const onColumnMouseDown = useCallback(
     (e: import("react").MouseEvent<HTMLDivElement>, day: Date) => {
       if (e.button !== 0) return;
-      if (e.target !== e.currentTarget) return;
       if (!onRequestCreate) return;
+      const columnEl = e.currentTarget as HTMLDivElement;
       const rect = columnEl.getBoundingClientRect();
       const y = e.clientY - rect.top;
       const state: DragState = { day, startY: y, currY: y, columnEl };


### PR DESCRIPTION
## Problem

Das Anlegen von Terminen per Drag in der Wochen- und Tagesansicht hat nicht funktioniert.

## Ursache

**`useDragCreate.ts`**: Die Prüfung `e.target !== e.currentTarget` hat den Drag-Start immer geblockt, weil die Stunden-Linien (`<div>`) die gesamte Spalte ausfüllen. Beim Klick ist `e.target` daher immer ein Kind-Element, nie die Spalte selbst.

## Fixes

- **`useDragCreate.ts`**: Fehlerhafte `e.target !== e.currentTarget`-Prüfung entfernt
- **`EventBlock.tsx`**: `onMouseDown` mit `e.stopPropagation()` ergänzt, damit Klicks auf bestehende Events keinen neuen Drag-Create auslösen