### PR TITLE
feat: Registrierungs-Flow für C2 (Issue #42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@base-ui/react": "^1.4.1",
         "@prisma/client": "^6.19.3",
         "@tailwindcss/postcss": "^4.2.4",
+        "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.11.0",
@@ -22,9 +23,11 @@
         "shadcn": "^4.5.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.4",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -74,6 +77,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -706,6 +710,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1778,6 +1783,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2353,6 +2359,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2365,6 +2378,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2382,6 +2396,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2463,6 +2478,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2995,6 +3011,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3404,6 +3421,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -3470,6 +3496,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4555,6 +4582,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4724,6 +4752,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5052,6 +5081,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5892,6 +5922,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8256,6 +8287,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -8433,6 +8465,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8445,6 +8478,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9006,6 +9040,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/shadcn/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/sharp": {
@@ -9610,6 +9653,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9843,6 +9887,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10322,10 +10367,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@base-ui/react": "^1.4.1",
     "@prisma/client": "^6.19.3",
     "@tailwindcss/postcss": "^4.2.4",
+    "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
@@ -25,9 +26,11 @@
     "shadcn": "^4.5.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.4",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { hashPassword } from "@/lib/auth/password";
+import { createSession } from "@/lib/auth/session";
+
+const registerSchema = z.object({
+  email: z.string().trim().email("Bitte gib eine gültige E-Mail-Adresse an."),
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Bitte gib einen Anzeigenamen an.")
+    .max(80, "Der Anzeigename darf hoechstens 80 Zeichen lang sein."),
+  password: z
+    .string()
+    .min(8, "Das Passwort muss mindestens 8 Zeichen lang sein."),
+  rememberMe: z.boolean().optional().default(false),
+});
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Ungültiger Anfrage-Body." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ungültige Eingabe." },
+      { status: 400 },
+    );
+  }
+
+  const { email, displayName, password, rememberMe } = parsed.data;
+  const normalizedEmail = email.toLowerCase();
+
+  const existing = await prisma.user.findUnique({
+    where: { email: normalizedEmail },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "Diese E-Mail-Adresse ist bereits registriert." },
+      { status: 409 },
+    );
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  const user = await prisma.user.create({
+    data: {
+      email: normalizedEmail,
+      displayName,
+      passwordHash,
+    },
+  });
+
+  await createSession(user.id, rememberMe);
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,9 +8,11 @@ const registerSchema = z.object({
   email: z.string().trim().email("Bitte gib eine gültige E-Mail-Adresse an."),
   displayName: z
     .string()
+  displayName: z
+    .string()
     .trim()
     .min(1, "Bitte gib einen Anzeigenamen an.")
-    .max(80, "Der Anzeigename darf hoechstens 80 Zeichen lang sein."),
+    .max(80, "Der Anzeigename darf höchstens 80 Zeichen lang sein."),
   password: z
     .string()
     .min(8, "Das Passwort muss mindestens 8 Zeichen lang sein."),

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -51,15 +51,25 @@ export async function POST(request: Request) {
 
   const passwordHash = await hashPassword(password);
 
-  const user = await prisma.user.create({
-    data: {
-      email: normalizedEmail,
-      displayName,
-      passwordHash,
-    },
-  });
+  try {
+    const user = await prisma.user.create({
+      data: {
+        email: normalizedEmail,
+        displayName,
+        passwordHash,
+      },
+    });
 
-  await createSession(user.id, rememberMe);
+    await createSession(user.id, rememberMe);
 
-  return NextResponse.json({ ok: true }, { status: 201 });
-}
+    return NextResponse.json({ ok: true }, { status: 201 });
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === "P2002") {
+      return NextResponse.json(
+        { error: "Diese E-Mail-Adresse ist bereits registriert." },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,84 @@
+import { RegisterForm } from "@/components/register/RegisterForm";
+import { GraduationCap } from "lucide-react";
+import Image from "next/image";
+
+export default function RegisterPage() {
+  return (
+    <div className="flex min-h-screen">
+      <div
+        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
+        style={{
+          backgroundImage:
+            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
+        }}
+      >
+        <svg
+          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <defs>
+            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
+              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
+              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
+              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
+              <circle cx="0" cy="0" r="1.4" fill="white" />
+              <circle cx="80" cy="0" r="1.4" fill="white" />
+              <circle cx="0" cy="80" r="1.4" fill="white" />
+              <circle cx="80" cy="80" r="1.4" fill="white" />
+              <circle cx="40" cy="40" r="2.2" fill="white" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
+        </svg>
+
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
+          }}
+        />
+
+        <div className="relative flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <GraduationCap className="h-8 w-8" />
+            <span className="text-5xl font-extrabold tracking-tight">
+              <span className="text-white">Learn</span>
+              <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>Hub</span>
+            </span>
+          </div>
+          <Image
+            src="/images/Dhbw_Icon.png"
+            alt="DHBW Logo"
+            width={90}
+            height={90}
+            className="object-contain opacity-90"
+          />
+        </div>
+
+        <div className="relative flex-1 flex items-center">
+          <div className="space-y-6">
+            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
+              Starte deinen <span className="italic">strukturierten</span>
+              <br />
+              Weg zum <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>Lernerfolg</span>.
+            </p>
+            <p className="text-lg text-white/70 max-w-md">
+              Lege dir in wenigen Sekunden ein Konto an und plane deine
+              Klausuren, Lerninhalte und Termine an einem Ort.
+            </p>
+          </div>
+        </div>
+
+        <div className="relative text-sm text-white/60">
+          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
+        <RegisterForm />
+      </div>
+    </div>
+  );
+}

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -86,7 +86,7 @@ export function RegisterForm() {
           <Input
             id="displayName"
             type="text"
-            placeholder="z. B. Finn P."
+            placeholder="z. B. Max Mustermann"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             required

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, displayName, password }),
+      });
+
+      if (res.ok) {
+        router.push("/dashboard");
+        return;
+      }
+
+      const data = (await res.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+      setError(data?.error ?? "Registrierung fehlgeschlagen. Bitte erneut versuchen.");
+    } catch {
+      setError("Verbindung zum Server fehlgeschlagen. Bitte erneut versuchen.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-md">
+      {/* 1. Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          Account erstellen
+        </h1>
+        <p className="text-gray-500 text-sm">
+          Lege dein LearnHub-Konto in wenigen Sekunden an.
+        </p>
+      </div>
+
+      {/* 2. Formular */}
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="email"
+            className="text-xs font-semibold uppercase tracking-wider text-gray-500"
+          >
+            E-Mail
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="name@stud.hs.de"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            autoComplete="email"
+            className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="displayName"
+            className="text-xs font-semibold uppercase tracking-wider text-gray-500"
+          >
+            Anzeigename
+          </Label>
+          <Input
+            id="displayName"
+            type="text"
+            placeholder="z. B. Finn P."
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            required
+            autoComplete="name"
+            maxLength={80}
+            className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="password"
+            className="text-xs font-semibold uppercase tracking-wider text-gray-500"
+          >
+            Passwort
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="Mindestens 8 Zeichen"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="new-password"
+            minLength={8}
+            className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
+          />
+        </div>
+
+        {/* Fehler-Anzeige */}
+        {error ? (
+          <p
+            role="alert"
+            className="text-sm text-brand-red bg-brand-red/5 border border-brand-red/20 rounded-lg px-3 py-2"
+          >
+            {error}
+          </p>
+        ) : null}
+
+        {/* 3. CTA */}
+        <div className="pt-2">
+          <Button
+            type="submit"
+            disabled={submitting}
+            className="w-full h-12 rounded-xl bg-brand-red hover:bg-brand-red-dark text-white font-bold text-base disabled:opacity-60"
+          >
+            {submitting ? "Wird erstellt …" : "Account erstellen"}
+          </Button>
+        </div>
+
+        {/* 4. Login-Link */}
+        <p className="text-center text-sm text-gray-500">
+          Bereits einen Account?{" "}
+          <Link
+            href="/login"
+            className="font-semibold text-brand-red hover:text-brand-red-dark hover:underline"
+          >
+            Jetzt Anmelden
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/lib/auth/cookie.ts
+++ b/src/lib/auth/cookie.ts
@@ -1,0 +1,16 @@
+// Auth-Cookie-Konstanten gemaess docs/auth-concept.md §5.2 und §5.3.
+
+export const SESSION_COOKIE = "lh_session";
+
+export const SESSION_TTL_DEFAULT_SECONDS = 24 * 60 * 60;        // 24 Stunden
+export const SESSION_TTL_REMEMBER_SECONDS = 30 * 24 * 60 * 60;  // 30 Tage
+
+export function sessionCookieOptions(maxAgeSeconds: number) {
+  return {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: maxAgeSeconds,
+  };
+}

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,0 +1,12 @@
+import bcrypt from "bcryptjs";
+
+// Cost 12 gemaess docs/auth-concept.md §4 — gaengiger Default fuer 2026.
+const COST = 12;
+
+export function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, COST);
+}
+
+export function verifyPassword(plain: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(plain, hash);
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,37 @@
+import { randomBytes } from "crypto";
+import { cookies } from "next/headers";
+import { prisma } from "@/lib/prisma";
+import {
+  SESSION_COOKIE,
+  SESSION_TTL_DEFAULT_SECONDS,
+  SESSION_TTL_REMEMBER_SECONDS,
+  sessionCookieOptions,
+} from "./cookie";
+
+// >= 256 Bit Entropie gemaess docs/auth-concept.md §3 und §5.1.
+function generateSessionToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Erstellt eine neue Session fuer den User: Token erzeugen, DB-Eintrag
+ * anlegen, Cookie setzen. Wird von Register und (spaeter, in C3) Login
+ * aufgerufen.
+ */
+export async function createSession(
+  userId: string,
+  rememberMe: boolean,
+): Promise<void> {
+  const token = generateSessionToken();
+  const ttlSeconds = rememberMe
+    ? SESSION_TTL_REMEMBER_SECONDS
+    : SESSION_TTL_DEFAULT_SECONDS;
+  const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+  await prisma.session.create({
+    data: { id: token, userId, expiresAt },
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set(SESSION_COOKIE, token, sessionCookieOptions(ttlSeconds));
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+// Singleton, damit der Dev-Server bei Hot-Reload nicht zig Prisma-Instanzen
+// erzeugt (jede haelt eine eigene Pool-Verbindung zur Datenbank).
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- Registrierungsseite `/register` im Stil der bestehenden Login-Seite (Split-Layout mit Branding links, Form rechts)
- Server-API `POST /api/auth/register` mit zod-Validation, bcrypt-Hashing (cost 12) und Session-Erstellung
- Auth-Helper unter `src/lib/auth/`: `password.ts`, `cookie.ts`, `session.ts` — fertig nutzbar für C3 (Login/Logout)
- Prisma-Client-Singleton unter `src/lib/prisma.ts` (verhindert Pool-Leak bei Hot-Reload)

Setzt um was in [docs/auth-concept.md](./docs/auth-concept.md) §4, §5.1 und §7 für Registrierung spezifiziert ist.

## Akzeptanzkriterien #42
- [x] Registrierungsseite ist erreichbar (`/register`)
- [x] Nutzer kann E-Mail, Anzeigename und Passwort eingeben
- [x] Passwort wird nicht im Klartext gespeichert (bcrypt-Hash mit Cost 12)
- [x] Doppelte E-Mail-Adressen erzeugen verständliche Fehlermeldung („Diese E-Mail-Adresse ist bereits registriert.") mit Status 409
- [x] Nach erfolgreicher Registrierung wird auf `/dashboard` weitergeleitet (Session-Cookie ist gesetzt)

## Sicherheits-Eckdaten (Auth-Konzept §4, §5.2)
- **bcrypt-Cost 12** über `bcryptjs` (kein nativer Build nötig)
- **Mindest-Passwortlänge 8 Zeichen** (NIST SP 800-63B — keine Sonderzeichen-Pflicht)
- **Session-Token** 256 Bit Entropie via `crypto.randomBytes(32).toString("base64url")`
- **Cookie** `lh_session`: HttpOnly, SameSite=Lax, Secure in Production, Path=/, Max-Age 24h
- **E-Mail-Normalisierung** auf Kleinbuchstaben vor Speichern und Vergleich

## Was bewusst NICHT im Scope ist
- **Login-Flow**, **Logout**, **`getCurrentUser()`** → C3 (#43)
- **Middleware-Aktivierung** (`AUTH_ENABLED = true`) → C3
- **Schutz von App-Routen** → C3
- **„Eingeloggt bleiben"-Checkbox bei Register** — bewusst weggelassen, Standard 24h-Session reicht für den initialen Sign-up; die Checkbox kommt im Login-Form

## Test plan
- [ ] `cp .env.example .env`, `docker compose up -d`, `npm run prisma:migrate`, `npm install`, `npm run build` läuft grün
- [ ] `npm run dev` und `/register` aufrufen — Form sieht aus wie die Login-Seite (Split-Layout, gleicher Stil)
- [ ] Happy Path: E-Mail + Anzeigename + Passwort eingeben → Redirect auf `/dashboard`, Cookie `lh_session` in DevTools sichtbar (HttpOnly)
- [ ] DB-Check: `docker exec learnhub-db psql -U learnhub -d learnhub -c 'SELECT email, \"displayName\", LEFT(\"passwordHash\", 25) FROM \"User\";'` zeigt User mit `passwordHash` beginnend mit `$2a$12$…` oder `$2b$12$…`
- [ ] Duplikat: nochmal mit gleicher E-Mail → rote Fehlermeldung, kein Redirect
- [ ] Validation: Passwort < 8 Zeichen → „Das Passwort muss mindestens 8 Zeichen lang sein."

Closes #42