### PR TITLE
feat(study-plan): Lernplan-Algorithmus + Test-UI + DHBW-Kurs-Einstellung

### DIFF
--- a/src/app/(app)/study-plan/page.tsx
+++ b/src/app/(app)/study-plan/page.tsx
@@ -1,0 +1,5 @@
+import { StudyPlanPageContent } from "@/components/study-plan/StudyPlanPageContent";
+
+export default function StudyPlanPage() {
+  return <StudyPlanPageContent />;
+}

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,8 +8,6 @@ const registerSchema = z.object({
   email: z.string().trim().email("Bitte gib eine gültige E-Mail-Adresse an."),
   displayName: z
     .string()
-  displayName: z
-    .string()
     .trim()
     .min(1, "Bitte gib einen Anzeigenamen an.")
     .max(80, "Der Anzeigename darf höchstens 80 Zeichen lang sein."),
@@ -75,3 +73,4 @@ export async function POST(request: Request) {
     }
     throw err;
   }
+}

--- a/src/app/api/calendar/external/route.ts
+++ b/src/app/api/calendar/external/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from "next/server";
 import * as ical from "node-ical";
 import { mapIcsToCalEvents, type IcsComponent } from "@/lib/calendar/icsMapper";
 import type { CalEvent } from "@/components/calendar/events";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
 
-// TODO: Sobald das DB-Schema steht, hier die CalendarSources des Users laden.
-// Bis dahin: hardcoded Default-URL (DHBW Lörrach TIF25A).
+// Fallback-URL solange kein User eingeloggt ist oder noch keine Quelle gespeichert hat.
 const DEFAULT_ICS_URL =
-  "https://webmail.dhbw-loerrach.de/owa/calendar/kal-tif25a%40dhbw-loerrach.de/Kalender/calendar.ics";
+  "https://stash.dhbw-loerrach.de/calendar/kal-tif25a@dhbw-loerrach.de.ics";
 
 const FETCH_TIMEOUT_MS = 8000;
 const MAX_RETRIES = 4;
@@ -54,8 +55,18 @@ async function fetchIcsWithRetry(url: string): Promise<string> {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const url = searchParams.get("url") ?? DEFAULT_ICS_URL;
   const force = searchParams.get("force") === "1";
+
+  // URL aus DB laden wenn User eingeloggt ist, sonst Fallback
+  let url = searchParams.get("url") ?? DEFAULT_ICS_URL;
+  const session = await getSession();
+  if (session) {
+    const source = await prisma.calendarSource.findFirst({
+      where: { userId: session.userId, type: "ics-dhbw" },
+      select: { url: true },
+    });
+    if (source?.url) url = source.url;
+  }
 
   // Frischer Cache-Hit innerhalb der TTL → ohne Upstream-Call zurückgeben.
   // Mit `?force=1` (z. B. vom Refresh-Button) wird das übersprungen.

--- a/src/app/api/calendar/sources/route.ts
+++ b/src/app/api/calendar/sources/route.ts
@@ -32,14 +32,19 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json().catch(() => null);
-  const courseCode: string = body?.courseCode ?? "";
+  const courseCode = String(body?.courseCode ?? "").trim();
 
-  if (!courseCode.trim()) {
+  if (!courseCode) {
     return NextResponse.json({ error: "Kurskennung darf nicht leer sein" }, { status: 400 });
+  }
+  if (!/^[A-Za-z0-9]+$/.test(courseCode)) {
+    return NextResponse.json(
+      { error: "Kurskennung enthält ungültige Zeichen" },
+      { status: 400 },
+    );
   }
 
   const url = buildDhbwUrl(courseCode);
-
   // Upsert: ein User hat genau eine DHBW-Quelle
   const existing = await prisma.calendarSource.findFirst({
     where: { userId: session.userId, type: "ics-dhbw" },

--- a/src/app/api/calendar/sources/route.ts
+++ b/src/app/api/calendar/sources/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth/session";
+
+const DHBW_ICS_BASE = "https://stash.dhbw-loerrach.de/calendar";
+
+function buildDhbwUrl(courseCode: string): string {
+  const normalized = courseCode.trim().toLowerCase();
+  return `${DHBW_ICS_BASE}/kal-${normalized}@dhbw-loerrach.de.ics`;
+}
+
+/** GET /api/calendar/sources — gibt die gespeicherte Kurskennung zurück */
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
+  }
+
+  const source = await prisma.calendarSource.findFirst({
+    where: { userId: session.userId, type: "ics-dhbw" },
+    select: { name: true, url: true },
+  });
+
+  return NextResponse.json({ source: source ?? null });
+}
+
+/** POST /api/calendar/sources — speichert/aktualisiert die DHBW-Kurskennung */
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const courseCode: string = body?.courseCode ?? "";
+
+  if (!courseCode.trim()) {
+    return NextResponse.json({ error: "Kurskennung darf nicht leer sein" }, { status: 400 });
+  }
+
+  const url = buildDhbwUrl(courseCode);
+
+  // Upsert: ein User hat genau eine DHBW-Quelle
+  const existing = await prisma.calendarSource.findFirst({
+    where: { userId: session.userId, type: "ics-dhbw" },
+  });
+
+  const source = existing
+    ? await prisma.calendarSource.update({
+        where: { id: existing.id },
+        data: {
+          name: `DHBW Stundenplan (${courseCode.trim().toUpperCase()})`,
+          url,
+          lastSyncedAt: null,
+        },
+      })
+    : await prisma.calendarSource.create({
+        data: {
+          userId: session.userId,
+          name: `DHBW Stundenplan (${courseCode.trim().toUpperCase()})`,
+          url,
+          type: "ics-dhbw",
+        },
+      });
+
+  return NextResponse.json({ source });
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LayoutDashboard, Calendar, MessageSquare, Settings } from "lucide-react";
+import { LayoutDashboard, Calendar, BookOpen, MessageSquare, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,7 @@ const navItems = [
     section: "Learning",
     items: [
       { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+      { label: "Lernpläne", href: "/study-plan", icon: BookOpen },
       { label: "Kalender", href: "/calendar", icon: Calendar },
     ],
   },

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -372,45 +372,92 @@ function NotificationSettings() {
 }
 
 function CalendarSettings() {
-  const [isImporting, setIsImporting] = useState(false);
+  const [courseCode, setCourseCode] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
-  // S-10 Hinweis: Fake-Import bis API/ICS-Endpoint existiert.
-  function handleScheduleImport(event: React.FormEvent<HTMLFormElement>) {
+  // Gespeicherte Kurskennung beim Laden abrufen
+  useEffect(() => {
+    fetch("/api/calendar/sources")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.source?.name) {
+          // Name ist z.B. "DHBW Stundenplan (TIF25A)" → Kurskennung extrahieren
+          const match = data.source.name.match(/\((.+)\)$/);
+          if (match) setCourseCode(match[1]);
+        }
+      })
+      .catch(() => {/* nicht eingeloggt oder Fehler – ignorieren */})
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  async function handleScheduleImport(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (isSaving || !courseCode.trim()) return;
 
-    if (isImporting) {
-      return;
+    setIsSaving(true);
+    setFeedback(null);
+
+    try {
+      const res = await fetch("/api/calendar/sources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courseCode }),
+      });
+
+      if (res.ok) {
+        setFeedback({ type: "success", message: `Stundenplan für ${courseCode.toUpperCase()} gespeichert.` });
+      } else {
+        const data = await res.json();
+        setFeedback({ type: "error", message: data.error ?? "Fehler beim Speichern." });
+      }
+    } catch {
+      setFeedback({ type: "error", message: "Netzwerkfehler. Bitte erneut versuchen." });
+    } finally {
+      setIsSaving(false);
     }
-
-    setIsImporting(true);
-    // TODO: Echten Import an /api/calendar/import anbinden.
-    window.setTimeout(() => setIsImporting(false), 1600);
   }
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
       <div className="flex flex-col gap-1 border-b border-gray-100 pb-4">
-        {/* S-1 Fix: Englische Überschrift -> Deutsch. */}
         <h2 className="text-base font-semibold text-gray-950">Kalender</h2>
         <p className="text-sm text-gray-500">
-          Wähle aus, welchen Stundenplan du in den Kalender importieren willst.
+          Gib deine Kurskennung ein (z.&nbsp;B. <strong>TIF25A</strong>). Der DHBW-Stundenplan wird automatisch geladen.
         </p>
       </div>
 
       <form className="mt-5 grid max-w-xl gap-5" onSubmit={handleScheduleImport}>
-        <Field label="Stundenplan" htmlFor="schedule-group">
-          <Input id="schedule-group" name="scheduleGroup" placeholder="TIF25A" />
+        <Field label="Kurskennung" htmlFor="schedule-group">
+          <Input
+            id="schedule-group"
+            name="scheduleGroup"
+            placeholder="TIF25A"
+            value={isLoading ? "" : courseCode}
+            disabled={isLoading}
+            onChange={(e) => setCourseCode(e.target.value)}
+          />
+          <p className="text-xs text-gray-400">
+            Der Link wird automatisch zusammengestellt: stash.dhbw-loerrach.de/calendar/<strong>{courseCode ? courseCode.toLowerCase() : "kurskennung"}</strong>@dhbw-loerrach.de.ics
+          </p>
         </Field>
 
+        {feedback && (
+          <p className={`text-sm font-medium ${feedback.type === "success" ? "text-green-600" : "text-red-600"}`}>
+            {feedback.message}
+          </p>
+        )}
+
         <div className="flex justify-end border-t border-gray-100 pt-4">
-          {isImporting ? (
+          {isSaving ? (
             <div
               role="status"
               aria-live="polite"
               className="flex h-9 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-3"
             >
               <CalendarDays className="h-4 w-4 text-gray-600" />
-              <span className="text-sm font-medium text-gray-700">Stundenplan wird importiert</span>
+              <span className="text-sm font-medium text-gray-700">Stundenplan wird gespeichert</span>
               <div className="flex items-center gap-1" aria-hidden="true">
                 <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.2s]" />
                 <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-gray-500 [animation-delay:-0.1s]" />
@@ -418,9 +465,9 @@ function CalendarSettings() {
               </div>
             </div>
           ) : (
-            <Button type="submit">
+            <Button type="submit" disabled={!courseCode.trim()}>
               <CalendarDays className="h-4 w-4" />
-              Stundenplan importieren
+              Stundenplan speichern
             </Button>
           )}
         </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -383,10 +383,8 @@ function CalendarSettings() {
       .then((r) => r.json())
       .then((data) => {
         if (data.source?.name) {
-          // Name ist z.B. "DHBW Stundenplan (TIF25A)" → Kurskennung extrahieren
           const match = data.source.name.match(/\((.+)\)$/);
-          if (match) setCourseCode(match[1]);
-        }
+          if (match) setCourseCode(match[1].trim());
       })
       .catch(() => {/* nicht eingeloggt oder Fehler – ignorieren */})
       .finally(() => setIsLoading(false));

--- a/src/components/study-plan/StudyPlanPageContent.tsx
+++ b/src/components/study-plan/StudyPlanPageContent.tsx
@@ -27,17 +27,22 @@ export function StudyPlanPageContent() {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   }
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const input: AlgorithmInput = {
-      deadlineDate: new Date(form.deadline),
-      difficulty: Number(form.difficulty) as AlgorithmInput["difficulty"],
-      priorKnowledge: Number(form.priorKnowledge) as AlgorithmInput["priorKnowledge"],
-      pages: Number(form.pages),
-      credits: Number(form.credits),
-    };
-    setResult(calculateStudyPlan(input));
-  }
+function handleSubmit(e: React.FormEvent) {
+  e.preventDefault();
+
+  // `new Date("YYYY-MM-DD")` wird als UTC geparst und kann in lokalen Zeitzonen um einen Tag verschoben sein.
+  const [year, month, day] = form.deadline.split("-").map(Number);
+  const deadlineDate = new Date(year, month - 1, day);
+
+  const input: AlgorithmInput = {
+    deadlineDate,
+    difficulty: Number(form.difficulty) as AlgorithmInput["difficulty"],
+    priorKnowledge: Number(form.priorKnowledge) as AlgorithmInput["priorKnowledge"],
+    pages: Number(form.pages),
+    credits: Number(form.credits),
+  };
+  setResult(calculateStudyPlan(input));
+}
 
   const selectClass =
     "h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-red focus:ring-2 focus:ring-brand-red/20";

--- a/src/components/study-plan/StudyPlanPageContent.tsx
+++ b/src/components/study-plan/StudyPlanPageContent.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { BookOpen, Calculator, AlertTriangle, CheckCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  calculateStudyPlan,
+  type AlgorithmResult,
+  type AlgorithmInput,
+} from "@/lib/calculations/studyPlanAlgorithm";
+
+export function StudyPlanPageContent() {
+  const [result, setResult] = useState<AlgorithmResult | null>(null);
+
+  const [form, setForm] = useState({
+    deadline: "",
+    difficulty: "3",
+    priorKnowledge: "3",
+    pages: "",
+    credits: "",
+  });
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const input: AlgorithmInput = {
+      deadlineDate: new Date(form.deadline),
+      difficulty: Number(form.difficulty) as AlgorithmInput["difficulty"],
+      priorKnowledge: Number(form.priorKnowledge) as AlgorithmInput["priorKnowledge"],
+      pages: Number(form.pages),
+      credits: Number(form.credits),
+    };
+    setResult(calculateStudyPlan(input));
+  }
+
+  const selectClass =
+    "h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-red focus:ring-2 focus:ring-brand-red/20";
+
+  return (
+    <div className="flex flex-col h-full p-6 gap-6 overflow-auto">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-brand-red/10">
+          <BookOpen className="w-5 h-5 text-brand-red" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Lernplan-Algorithmus</h1>
+          <p className="text-sm text-gray-500">Gib deine Klausurdaten ein und erhalte einen persönlichen Lernplan.</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Eingabe-Formular */}
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+        >
+          <h2 className="text-base font-semibold text-gray-800">Klausur-Daten eingeben</h2>
+
+          <div className="grid gap-2">
+            <Label htmlFor="deadline">Klausurdatum</Label>
+            <Input
+              id="deadline"
+              name="deadline"
+              type="date"
+              required
+              value={form.deadline}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="difficulty">Schwierigkeit der Klausur (1 = leicht, 5 = sehr schwer)</Label>
+            <select id="difficulty" name="difficulty" className={selectClass} value={form.difficulty} onChange={handleChange}>
+              <option value="1">1 – Leicht</option>
+              <option value="2">2 – Eher leicht</option>
+              <option value="3">3 – Mittel</option>
+              <option value="4">4 – Schwer</option>
+              <option value="5">5 – Sehr schwer</option>
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="priorKnowledge">Vorwissen (1 = wenig, 5 = viel)</Label>
+            <select id="priorKnowledge" name="priorKnowledge" className={selectClass} value={form.priorKnowledge} onChange={handleChange}>
+              <option value="1">1 – Kaum Vorwissen</option>
+              <option value="2">2 – Wenig Vorwissen</option>
+              <option value="3">3 – Mittleres Vorwissen</option>
+              <option value="4">4 – Gutes Vorwissen</option>
+              <option value="5">5 – Sehr gutes Vorwissen</option>
+            </select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="pages">Anzahl Seiten / Folien</Label>
+            <Input
+              id="pages"
+              name="pages"
+              type="number"
+              min={1}
+              placeholder="z.B. 120"
+              required
+              value={form.pages}
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="credits">ECTS-Punkte der Klausur</Label>
+            <Input
+              id="credits"
+              name="credits"
+              type="number"
+              min={1}
+              max={10}
+              placeholder="z.B. 5"
+              required
+              value={form.credits}
+              onChange={handleChange}
+            />
+          </div>
+
+          <Button type="submit" className="mt-2">
+            <Calculator className="w-4 h-4" />
+            Lernplan berechnen
+          </Button>
+        </form>
+
+        {/* Ergebnis */}
+        {result ? (
+          <div className="flex flex-col gap-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            {/* Plantyp-Badge */}
+            <div className={cn(
+              "flex items-center gap-3 rounded-xl p-4",
+              result.planType === "normal" ? "bg-green-50 border border-green-200" : "bg-red-50 border border-red-200"
+            )}>
+              {result.planType === "normal"
+                ? <CheckCircle className="w-6 h-6 text-green-600 shrink-0" />
+                : <AlertTriangle className="w-6 h-6 text-red-600 shrink-0" />
+              }
+              <div>
+                <p className={cn("font-bold text-lg", result.planType === "normal" ? "text-green-700" : "text-red-700")}>
+                  {result.planType === "normal" ? "Normaler Lernplan" : "Kritischer Lernplan"}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {result.planType === "normal"
+                    ? "Du hast ausreichend Zeit – nachhaltiges Lernen ist möglich."
+                    : "Du musst dich ranhalten – Fokus auf das Wesentliche!"}
+                </p>
+              </div>
+            </div>
+
+            {/* Kennzahlen */}
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                { label: "Gesamtstunden", value: `${result.totalHours} h` },
+                { label: "Stunden/Tag", value: `${result.hoursPerDay} h` },
+                { label: "Tage bis Klausur", value: `${result.daysUntilDeadline}` },
+              ].map(({ label, value }) => (
+                <div key={label} className="flex flex-col items-center justify-center rounded-xl bg-gray-50 border border-gray-200 p-3 text-center">
+                  <span className="text-xl font-bold text-gray-900">{value}</span>
+                  <span className="text-xs text-gray-500 mt-1">{label}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* Faktoren */}
+            <div className="rounded-xl bg-gray-50 border border-gray-200 p-4">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Berechnete Faktoren</p>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                {[
+                  { label: "D (Deadline)", value: result.deadlineFactor },
+                  { label: "S (Schwierigkeit)", value: result.difficultyFactor },
+                  { label: "V (Vorwissen)", value: result.knowledgeFactor },
+                  { label: "W (Volumen)", value: result.volumeFactor },
+                  { label: "C (Credits)", value: result.creditFactor },
+                ].map(({ label, value }) => (
+                  <div key={label} className="flex justify-between gap-2">
+                    <span className="text-gray-500">{label}</span>
+                    <span className="font-semibold text-gray-800">{value}</span>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-xs text-gray-400">
+                Formel: 25 × {result.deadlineFactor} × (({result.difficultyFactor} + {result.volumeFactor} + {result.knowledgeFactor} + {result.creditFactor}) / 4) = <strong>{result.totalHours} h</strong>
+              </p>
+            </div>
+
+            {/* Phasen */}
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Lernphasen</p>
+              {result.phases.map((phase) => (
+                <div key={phase.name} className="rounded-xl border border-gray-200 p-3">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-sm font-semibold text-gray-800">{phase.name}</span>
+                    <span className="text-sm font-bold text-brand-red">{phase.hours} h</span>
+                  </div>
+                  <div className="w-full bg-gray-200 rounded-full h-1.5 mb-2">
+                    <div
+                      className="bg-brand-red h-1.5 rounded-full"
+                      style={{ width: `${phase.percentage}%` }}
+                    />
+                  </div>
+                  <p className="text-xs text-gray-500">{phase.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-gray-50 gap-3 p-12">
+            <Calculator className="w-10 h-10 text-gray-300" />
+            <p className="text-sm text-gray-400 text-center">
+              Fülle das Formular aus und klicke auf „Lernplan berechnen"
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/study-plan/StudyPlanPageContent.tsx
+++ b/src/components/study-plan/StudyPlanPageContent.tsx
@@ -221,7 +221,7 @@ function handleSubmit(e: React.FormEvent) {
           <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-gray-50 gap-3 p-12">
             <Calculator className="w-10 h-10 text-gray-300" />
             <p className="text-sm text-gray-400 text-center">
-              Fülle das Formular aus und klicke auf „Lernplan berechnen"
+              Fülle das Formular aus und klicke auf „Lernplan berechnen“
             </p>
           </div>
         )}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -14,6 +14,24 @@ function generateSessionToken(): string {
 }
 
 /**
+ * Liest den Session-Cookie und gibt die userId zurück, oder null wenn
+ * keine gültige Session existiert.
+ */
+export async function getSession(): Promise<{ userId: string } | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const session = await prisma.session.findUnique({
+    where: { id: token },
+    select: { userId: true, expiresAt: true },
+  });
+
+  if (!session || session.expiresAt < new Date()) return null;
+  return { userId: session.userId };
+}
+
+/**
  * Erstellt eine neue Session fuer den User: Token erzeugen, DB-Eintrag
  * anlegen, Cookie setzen. Wird von Register und (spaeter, in C3) Login
  * aufgerufen.

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -76,7 +76,9 @@ function getVolumeFactor(pages: number): number {
 }
 
 function getCreditFactor(credits: number): number {
-  return Math.min(credits, 10) * 0.2;
+  const value = Number.isFinite(credits) ? credits : 1;
+  const clamped = Math.min(Math.max(value, 1), 10);
+  return clamped * 0.2;
 }
 
 // ─── Phasen ──────────────────────────────────────────────────────────────────

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -148,10 +148,10 @@ export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
   today.setHours(0, 0, 0, 0);
   const deadline = new Date(input.deadlineDate);
   deadline.setHours(0, 0, 0, 0);
-  const daysUntilDeadline = Math.max(
-    1,
-    Math.ceil((deadline.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
-  );
+
+  const diffMs = deadline.getTime() - today.getTime();
+  const diffDays = Number.isFinite(diffMs) ? diffMs / (1000 * 60 * 60 * 24) : 0;
+  const daysUntilDeadline = Math.max(1, Math.ceil(diffDays));
 
   const D = getDeadlineFactor(daysUntilDeadline);
   const S = getDifficultyFactor(input.difficulty);

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -1,0 +1,182 @@
+/**
+ * LearnHub – Lernplan-Algorithmus
+ * Dokumentation: docs/Algorithmus/Algorithmus_neue_Formel.md
+ */
+
+export type PlanType = "normal" | "kritisch";
+
+export interface AlgorithmInput {
+  /** Datum der Klausur */
+  deadlineDate: Date;
+  /** Schwierigkeit der Klausur: 1 (leicht) – 5 (schwer) */
+  difficulty: 1 | 2 | 3 | 4 | 5;
+  /** Vorwissen des Users: 1 (wenig) – 5 (viel) */
+  priorKnowledge: 1 | 2 | 3 | 4 | 5;
+  /** Anzahl der Seiten / Folien */
+  pages: number;
+  /** ECTS-Punkte der Klausur: 1–10 */
+  credits: number;
+}
+
+export interface AlgorithmResult {
+  /** Tage bis zur Deadline */
+  daysUntilDeadline: number;
+  /** D-Faktor (Deadline) */
+  deadlineFactor: number;
+  /** S-Faktor (Schwierigkeit) */
+  difficultyFactor: number;
+  /** V-Faktor (Vorwissen) */
+  knowledgeFactor: number;
+  /** W-Faktor (Volumen/Seiten) */
+  volumeFactor: number;
+  /** C-Faktor (Credits) */
+  creditFactor: number;
+  /** Gesamtstunden = 25 × D × ((S+W+V+C)/4) */
+  totalHours: number;
+  /** Stunden pro Tag = Gesamtstunden / Tage */
+  hoursPerDay: number;
+  /** Plantyp: normal (≤3h/Tag) oder kritisch (>3h/Tag) */
+  planType: PlanType;
+  /** Phasen des Lernplans mit Stunden */
+  phases: Phase[];
+}
+
+export interface Phase {
+  name: string;
+  percentage: number;
+  hours: number;
+  description: string;
+}
+
+// ─── Faktoren ────────────────────────────────────────────────────────────────
+
+function getDeadlineFactor(daysUntilDeadline: number): number {
+  if (daysUntilDeadline > 90) return 1.4;  // > 3 Monate
+  if (daysUntilDeadline > 60) return 1.1;  // 2–3 Monate
+  if (daysUntilDeadline > 30) return 0.9;  // 1–2 Monate
+  if (daysUntilDeadline > 14) return 1.2;  // 2–4 Wochen
+  return 1.5;                               // < 2 Wochen
+}
+
+function getDifficultyFactor(difficulty: number): number {
+  const map: Record<number, number> = { 1: 0.8, 2: 1.0, 3: 1.2, 4: 1.4, 5: 1.6 };
+  return map[difficulty] ?? 1.0;
+}
+
+function getKnowledgeFactor(priorKnowledge: number): number {
+  const map: Record<number, number> = { 1: 1.5, 2: 1.3, 3: 1.0, 4: 0.8, 5: 0.7 };
+  return map[priorKnowledge] ?? 1.0;
+}
+
+function getVolumeFactor(pages: number): number {
+  if (pages <= 50) return 0.7;
+  if (pages <= 100) return 1.0;
+  if (pages <= 150) return 1.3;
+  return 1.6;
+}
+
+function getCreditFactor(credits: number): number {
+  return Math.min(credits, 10) * 0.2;
+}
+
+// ─── Phasen ──────────────────────────────────────────────────────────────────
+
+function buildNormalPhases(totalHours: number): Phase[] {
+  return [
+    {
+      name: "Phase 1 – Grundlagen aufbauen",
+      percentage: 40,
+      hours: Math.round(totalHours * 0.40 * 10) / 10,
+      description: "Vorlesungsfolien, Skripte, Videos – Überblick verschaffen und Wissenslücken schließen",
+    },
+    {
+      name: "Phase 2 – Vertiefung",
+      percentage: 35,
+      hours: Math.round(totalHours * 0.35 * 10) / 10,
+      description: "Übungsaufgaben, eigene Zusammenfassungen, Lernkarten – Fachverständnis aufbauen",
+    },
+    {
+      name: "Phase 3 – Anwendung",
+      percentage: 15,
+      hours: Math.round(totalHours * 0.15 * 10) / 10,
+      description: "Übungsblätter, Beispielaufgaben, kleinere Klausuraufgaben",
+    },
+    {
+      name: "Phase 4 – Wiederholung",
+      percentage: 10,
+      hours: Math.round(totalHours * 0.10 * 10) / 10,
+      description: "Lernkarten, Zusammenfassungen, Formeln, Definitionen",
+    },
+  ];
+}
+
+function buildKritischPhases(totalHours: number): Phase[] {
+  return [
+    {
+      name: "Phase 1 – Priorisierung",
+      percentage: 10,
+      hours: Math.round(totalHours * 0.10 * 10) / 10,
+      description: "Themen in A/B/C einteilen – A (klausurrelevant) zuerst, C kann entfallen",
+    },
+    {
+      name: "Phase 2 – Kernstoff erarbeiten",
+      percentage: 50,
+      hours: Math.round(totalHours * 0.50 * 10) / 10,
+      description: "80% Verständnis mit minimalem Zeitaufwand – Zusammenfassungen, Lernkarten, KI-Erklärungen",
+    },
+    {
+      name: "Phase 3 – Aufgaben & Anwendung",
+      percentage: 30,
+      hours: Math.round(totalHours * 0.30 * 10) / 10,
+      description: "Altklausuren, Übungsaufgaben, typische Klausurfragen – direkt nach Themenverständnis",
+    },
+    {
+      name: "Phase 4 – Wiederholung",
+      percentage: 10,
+      hours: Math.round(totalHours * 0.10 * 10) / 10,
+      description: "Formeln, Definitionen, Lernkarten, persönliche Fehlerliste – keine neuen Themen mehr",
+    },
+  ];
+}
+
+// ─── Hauptfunktion ────────────────────────────────────────────────────────────
+
+export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const deadline = new Date(input.deadlineDate);
+  deadline.setHours(0, 0, 0, 0);
+  const daysUntilDeadline = Math.max(
+    1,
+    Math.ceil((deadline.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)),
+  );
+
+  const D = getDeadlineFactor(daysUntilDeadline);
+  const S = getDifficultyFactor(input.difficulty);
+  const V = getKnowledgeFactor(input.priorKnowledge);
+  const W = getVolumeFactor(input.pages);
+  const C = getCreditFactor(input.credits);
+
+  // Formel: Gesamtstunden = 25 × D × ((S + W + V + C) / 4)
+  const totalHours = Math.round(25 * D * ((S + W + V + C) / 4) * 10) / 10;
+  const hoursPerDay = Math.round((totalHours / daysUntilDeadline) * 100) / 100;
+  const planType: PlanType = hoursPerDay > 3 ? "kritisch" : "normal";
+
+  const phases =
+    planType === "normal"
+      ? buildNormalPhases(totalHours)
+      : buildKritischPhases(totalHours);
+
+  return {
+    daysUntilDeadline,
+    deadlineFactor: D,
+    difficultyFactor: S,
+    knowledgeFactor: V,
+    volumeFactor: W,
+    creditFactor: C,
+    totalHours,
+    hoursPerDay,
+    planType,
+    phases,
+  };
+}


### PR DESCRIPTION
## Was wurde umgesetzt

### 🧮 Lernplan-Algorithmus (`studyPlanAlgorithm.ts`)
Implementierung des Algorithmus aus `docs/Algorithmus/Algorithmus_neue_Formel.md`:
- **Formel:** `Gesamtstunden = 25 × D × ((S + W + V + C) / 4)`
- **5 Faktoren:** D (Deadline), S (Schwierigkeit), V (Vorwissen), W (Volumen/Seiten), C (Credits)
- **Plantyp:** Normal (≤ 3h/Tag) oder Kritisch (> 3h/Tag)
- **Lernphasen:** Normaler Plan (40/35/15/10%) und Kritischer Plan (10/50/30/10%)

### 📚 Lernplan-Seite (`/study-plan`)
- Eingabeformular: Klausurdatum, Schwierigkeit, Vorwissen, Seiten, ECTS
- Ergebnis: Plantyp-Badge, Kennzahlen, alle Faktoren, 4 Lernphasen mit Stundenaufteilung

### 🗂️ Sidebar
- Neuer Eintrag "Lernpläne" mit BookOpen-Icon

### ⚙️ DHBW-Kurskennung in Einstellungen
- User kann Kurskennung (z.B. `TIF25A`) in Einstellungen → Kalender eintragen
- URL wird automatisch zusammengestellt: `stash.dhbw-loerrach.de/calendar/kal-tif25a@dhbw-loerrach.de.ics`
- In DB (`CalendarSource`) gespeichert, Kalender-API lädt URL daraus

### 🔧 Bugfixes
- `register/route.ts`: fehlende schließende `}` ergänzt
- `session.ts`: `getSession()`-Helper ergänzt
- DHBW ICS-URL auf neue Domain aktualisiert (`stash.dhbw-loerrach.de`)