### PR TITLE
feat: user profile display + login routing

### DIFF
--- a/docs/feat-user-profile-display.md
+++ b/docs/feat-user-profile-display.md
@@ -1,0 +1,120 @@
+# Feature: User Profile Display (`feat/user-profile-display`)
+
+## Ziel
+
+Wenn sich ein Nutzer registriert oder anmeldet, sollen seine echten Daten (Name, E-Mail) überall in der App angezeigt werden, wo aktuell noch Dummy-Daten (`Max Mustermann`, `demo@learnhub.de`, `MM`) stehen.
+
+---
+
+## Betroffene Stellen
+
+### 1. Sidebar — User Card (unten links)
+
+**Datei:** `src/components/layout/Sidebar.tsx`
+
+**Aktuell (Dummy):**
+```tsx
+<div ...>MM</div>
+<span>Max Mustermann</span>
+<span>demo@learnhub.de</span>
+```
+
+**Soll:**
+- Initialen aus `displayName` berechnen (z.B. `Yannik Roeder` → `YR`, `Yannik` → `Y`)
+- Vollständiger Anzeigename aus der Session
+- E-Mail aus der Session
+
+**Ansatz:** `Sidebar` bekommt `user: { displayName: string; email: string }` als Prop. Die Daten kommen vom Server-Layout (`src/app/(app)/layout.tsx`) via `getSession()` + Prisma-User-Lookup.
+
+---
+
+### 2. Settings — Profil-Tab
+
+**Datei:** `src/components/settings/SettingsPage.tsx` → `ProfileSettings`
+
+**Aktuell (Dummy):**
+```tsx
+<Input defaultValue="Max" />          // Vorname
+<Input defaultValue="Mustermann" />   // Nachname
+<Input defaultValue="demo@learnhub.de" />  // E-Mail
+```
+
+**Soll:**
+- `displayName` aus der Session als `defaultValue` im Namensfeld vorbelegen
+- E-Mail aus der Session vorbelegen
+- Nachname-Feld: Da das Schema nur `displayName` (kein getrenntes `firstName`/`lastName`) kennt, wird `displayName` ins Vorname-Feld geladen; Nachname bleibt leer oder wird aus dem zweiten Wort des `displayName` abgeleitet
+
+**Ansatz:** `ProfileSettings` bekommt `user: { displayName: string; email: string }` als Prop. `SettingsPage` bekommt dieselbe Prop vom Server-Parent.
+
+---
+
+## Datenfluss
+
+```
+src/app/(app)/layout.tsx  (Server Component)
+  └─ getSession()  →  prisma.user.findUnique()
+  └─ user = { displayName, email }
+  └─ <DashboardShell user={user} ...>
+
+src/components/layout/DashboardShell.tsx  (Client Component)
+  └─ <Sidebar user={user} ...>
+
+src/components/layout/Sidebar.tsx
+  └─ user.displayName, user.email, initials(user.displayName)
+
+src/app/(app)/settings/page.tsx  (Server Component)
+  └─ getSession()  →  prisma.user.findUnique()
+  └─ <SettingsPage user={user} />
+
+src/components/settings/SettingsPage.tsx
+  └─ user als Prop an ProfileSettings weitergeben
+```
+
+---
+
+## API-Route (optional, für späteres Speichern)
+
+`PATCH /api/profile` — aktualisiert `displayName` des eingeloggten Users.  
+Wird in diesem Feature **noch nicht** implementiert (Speichern-Button bleibt vorerst Stub).  
+Das ist ein separates Follow-up-Ticket.
+
+---
+
+## Prisma-Schema (kein Änderungsbedarf)
+
+Das `User`-Modell hat bereits alle benötigten Felder:
+```prisma
+model User {
+  id          String  @id @default(cuid())
+  email       String  @unique
+  displayName String   // wird als "Vorname (+ Nachname)" genutzt
+  ...
+}
+```
+
+---
+
+## Implementierungsschritte
+
+1. **`src/app/(app)/layout.tsx`** — User aus DB laden und als Prop weitergeben
+2. **`src/components/layout/DashboardShell.tsx`** — `user`-Prop annehmen und an Sidebar weiterreichen
+3. **`src/components/layout/Sidebar.tsx`** — `user`-Prop einbauen, Dummy-Daten ersetzen, Initialen berechnen
+4. **`src/app/(app)/settings/page.tsx`** — User aus DB laden, an SettingsPage übergeben
+5. **`src/components/settings/SettingsPage.tsx`** — `user`-Prop annehmen, Dummy-`defaultValue`s ersetzen
+
+---
+
+## Fallback (nicht eingeloggt / AUTH_ENABLED = false)
+
+Solange `AUTH_ENABLED = false` in der Middleware:
+- `getSession()` gibt `null` zurück
+- Fallback-Objekt verwenden: `{ displayName: "Gast", email: "" }`
+- So funktioniert die App weiterhin ohne Login
+
+---
+
+## Abgrenzung
+
+- **Nicht** Teil dieses Features: Profilbild speichern, Passwort ändern, E-Mail ändern
+- **Nicht** Teil dieses Features: Echtes Speichern von Namensänderungen (Follow-up)
+- **Abhängigkeit zu C3:** Wenn C3 (Login) fertig ist, funktioniert der echte Session-Flow automatisch. Bis dahin greift der Fallback.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 
 export default function RootPage() {
-  // Die Startseite leitet auf das Dashboard. Sobald echtes Auth aktiv ist,
-  // entscheidet die middleware.ts, ob stattdessen /login angezeigt wird.
-  redirect("/dashboard");
+  // Startseite leitet auf Login. Die Middleware leitet eingeloggte User
+  // von /login direkt auf /dashboard weiter (sobald AUTH_ENABLED = true).
+  redirect("/login");
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,7 +26,8 @@ export function middleware(request: NextRequest) {
     // Vollständiger Schutz: nicht eingeloggte User → /login
     if (!isLoggedIn && !isPublic) {
       const loginUrl = new URL("/login", request.url);
-      loginUrl.searchParams.set("redirect", pathname);
+      const redirectTo = request.nextUrl.pathname + request.nextUrl.search;
+      loginUrl.searchParams.set("redirect", redirectTo);
       return NextResponse.redirect(loginUrl);
     }
     // Eingeloggte User auf /login → /dashboard

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,24 +18,25 @@ const AUTH_ENABLED = false;
 const PUBLIC_PATHS = ["/login", "/register", "/forgot-password"];
 
 export function middleware(request: NextRequest) {
-  if (!AUTH_ENABLED) {
-    return NextResponse.next();
-  }
-
   const { pathname } = request.nextUrl;
   const isLoggedIn = request.cookies.has("lh_session");
   const isPublic = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
-  if (!isLoggedIn && !isPublic) {
-    const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(loginUrl);
+  if (AUTH_ENABLED) {
+    // Vollständiger Schutz: nicht eingeloggte User → /login
+    if (!isLoggedIn && !isPublic) {
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("redirect", pathname);
+      return NextResponse.redirect(loginUrl);
+    }
+    // Eingeloggte User auf /login → /dashboard
+    if (isLoggedIn && pathname === "/login") {
+      return NextResponse.redirect(new URL("/dashboard", request.url));
+    }
   }
 
-  if (isLoggedIn && pathname === "/login") {
-    return NextResponse.redirect(new URL("/dashboard", request.url));
-  }
-
+  // AUTH_ENABLED = false: App ist offen, aber /login ist trotzdem der Einstiegspunkt.
+  // Der Redirect von / → /login passiert bereits in src/app/page.tsx.
   return NextResponse.next();
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,19 +19,19 @@ const PUBLIC_PATHS = ["/login", "/register", "/forgot-password"];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const isLoggedIn = request.cookies.has("lh_session");
+  const hasSessionCookie = request.cookies.has("lh_session");
   const isPublic = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
   if (AUTH_ENABLED) {
     // Vollständiger Schutz: nicht eingeloggte User → /login
-    if (!isLoggedIn && !isPublic) {
+    if (!hasSessionCookie && !isPublic) {
       const loginUrl = new URL("/login", request.url);
       const redirectTo = request.nextUrl.pathname + request.nextUrl.search;
       loginUrl.searchParams.set("redirect", redirectTo);
       return NextResponse.redirect(loginUrl);
     }
     // Eingeloggte User auf /login oder /register → /dashboard
-    if (isLoggedIn && (pathname === "/login" || pathname === "/register")) {
+    if (hasSessionCookie && (pathname === "/login" || pathname === "/register")) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,8 +30,8 @@ export function middleware(request: NextRequest) {
       loginUrl.searchParams.set("redirect", redirectTo);
       return NextResponse.redirect(loginUrl);
     }
-    // Eingeloggte User auf /login → /dashboard
-    if (isLoggedIn && pathname === "/login") {
+    // Eingeloggte User auf /login oder /register → /dashboard
+    if (isLoggedIn && (pathname === "/login" || pathname === "/register")) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
   }


### PR DESCRIPTION
## Summary

Zwei Änderungen auf diesem Branch:

### 1. fix(routing): App startet auf `/login`

- `src/app/page.tsx` leitet jetzt auf `/login` statt `/dashboard`
- `src/middleware.ts` umgebaut: Auth-Logik ist sauber in `if (AUTH_ENABLED)` gekapselt, funktioniert auch wenn Auth noch aus ist
- Wenn `AUTH_ENABLED = true` (C3): nicht eingeloggte User → `/login`; eingeloggte User auf `/login` → `/dashboard`

### 2. docs: Feature-Spec `feat/user-profile-display`

Dokumentiert in `docs/feat-user-profile-display.md`:
- Dummy-Daten (`Max Mustermann`, `MM`, `demo@learnhub.de`) in Sidebar und Settings durch echte Session-Daten ersetzen
- Datenfluss: `(app)/layout.tsx` → `DashboardShell` → `Sidebar`
- Fallback `{ displayName: "Gast", email: "" }` solange kein Login aktiv
- Abgrenzung: Speichern von Namensänderungen ist Follow-up

## Testing
1. `localhost:3000` öffnen → landet auf `/login`
2. Login-Button klicken → landet auf `/dashboard`
3. Direkt `/dashboard` aufrufen → funktioniert weiterhin (AUTH_ENABLED = false)