### PR TITLE
feat(auth+profile): Session-Helpers, echte Userdaten, Logout, Avatar-Upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,7 +1909,7 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
       "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1922,14 +1922,14 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
       "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
       "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1943,14 +1943,14 @@
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
       "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
       "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3",
@@ -1962,7 +1962,7 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
       "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3"
@@ -2004,7 +2004,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2384,14 +2384,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3532,7 +3532,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -3561,7 +3561,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3668,7 +3668,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3684,7 +3684,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -3843,14 +3843,14 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -3984,7 +3984,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4108,7 +4108,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -4194,7 +4194,7 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4219,7 +4219,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -4306,7 +4306,7 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
       "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4330,7 +4330,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5132,14 +5132,14 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5699,7 +5699,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -7635,7 +7635,7 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-ical": {
@@ -7688,7 +7688,7 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
       "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.2",
@@ -7706,7 +7706,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -7843,7 +7843,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -8141,14 +8141,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8182,7 +8182,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.4",
@@ -8282,7 +8282,7 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8374,7 +8374,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8450,7 +8450,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -8493,7 +8493,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9601,7 +9601,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9879,7 +9879,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -711,7 +710,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1784,7 +1782,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2379,7 +2376,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2397,7 +2393,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2479,7 +2474,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3012,7 +3006,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3497,7 +3490,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4583,7 +4575,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4753,7 +4744,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5082,7 +5072,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5932,7 +5921,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8297,7 +8285,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -8475,7 +8462,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8488,7 +8474,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9663,7 +9648,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9897,7 +9881,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10381,7 +10364,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/prisma/migrations/20260609195146_add_avatar_url_to_user/migration.sql
+++ b/prisma/migrations/20260609195146_add_avatar_url_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "avatarUrl" TEXT;

--- a/prisma/migrations/20260609203121_add_avatar_binary_to_user/migration.sql
+++ b/prisma/migrations/20260609203121_add_avatar_binary_to_user/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "avatarData" BYTEA,
+ADD COLUMN     "avatarMime" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   email        String   @unique
   displayName  String
   passwordHash String
+  avatarUrl    String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model User {
   displayName  String
   passwordHash String
   avatarUrl    String?
+  avatarData   Bytes?
+  avatarMime   String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,5 +1,13 @@
+import { redirect } from "next/navigation";
 import { DashboardShell } from "@/components/layout/DashboardShell";
+import { getCurrentUser } from "@/lib/auth/session";
 
-export default function AppLayout({ children }: { children: React.ReactNode }) {
-  return <DashboardShell>{children}</DashboardShell>;
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser) {
+    redirect("/login");
+  }
+
+  return <DashboardShell currentUser={currentUser}>{children}</DashboardShell>;
 }

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-
+import { getCurrentUser } from "@/lib/auth/session";
 import { SettingsPage } from "@/components/settings/SettingsPage";
 
 function SettingsSkeleton() {
@@ -17,10 +17,11 @@ function SettingsSkeleton() {
   );
 }
 
-export default function SettingsRoute() {
+export default async function SettingsRoute() {
+  const currentUser = await getCurrentUser();
   return (
     <Suspense fallback={<SettingsSkeleton />}>
-      <SettingsPage />
+      <SettingsPage currentUser={currentUser ?? undefined} />
     </Suspense>
   );
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,23 +1,7 @@
 import { NextResponse } from "next/server";
-import { cookies } from "next/headers";
-import { prisma } from "@/lib/prisma";
-import { SESSION_COOKIE, sessionCookieOptions } from "@/lib/auth/cookie";
+import { destroyCurrentSession } from "@/lib/auth/session";
 
 export async function POST() {
-  const cookieStore = await cookies();
-  const token = cookieStore.get(SESSION_COOKIE)?.value;
-
-  if (token) {
-    // Session aus DB löschen – try/catch falls bereits abgelaufen oder nicht vorhanden.
-    try {
-      await prisma.session.delete({ where: { id: token } });
-    } catch {
-      // Ignorieren – Session war bereits ungültig
-    }
-  }
-
-  // Cookie entwerten: Max-Age=0 lässt den Browser das Cookie sofort löschen.
-  cookieStore.set(SESSION_COOKIE, "", sessionCookieOptions(0));
-
+  await destroyCurrentSession();
   return NextResponse.json({ ok: true }, { status: 200 });
 }

--- a/src/app/api/profile/avatar/route.ts
+++ b/src/app/api/profile/avatar/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Request-Body." }, { status: 400 });
+  }
+
+  const file = formData.get("avatar");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Kein Bild angegeben." }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Nur PNG, JPEG oder WebP erlaubt." },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Datei ist zu groß (max. 5 MB)." },
+      { status: 400 },
+    );
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const avatarUrl = `data:${file.type};base64,${buffer.toString("base64")}`;
+
+  await prisma.user.update({
+    where: { id: session.userId },
+    data: { avatarUrl },
+  });
+
+  return NextResponse.json({ avatarUrl }, { status: 200 });
+}

--- a/src/app/api/profile/avatar/route.ts
+++ b/src/app/api/profile/avatar/route.ts
@@ -5,6 +5,32 @@ import { prisma } from "@/lib/prisma";
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
+const AVATAR_SERVE_URL = "/api/profile/avatar";
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return new NextResponse(null, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.userId },
+    select: { avatarData: true, avatarMime: true },
+  });
+
+  if (!user?.avatarData || !user.avatarMime) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  return new NextResponse(user.avatarData, {
+    status: 200,
+    headers: {
+      "Content-Type": user.avatarMime,
+      "Cache-Control": "private, max-age=3600",
+    },
+  });
+}
+
 export async function POST(request: Request) {
   const session = await getSession();
   if (!session) {
@@ -38,12 +64,15 @@ export async function POST(request: Request) {
   }
 
   const buffer = Buffer.from(await file.arrayBuffer());
-  const avatarUrl = `data:${file.type};base64,${buffer.toString("base64")}`;
 
   await prisma.user.update({
     where: { id: session.userId },
-    data: { avatarUrl },
+    data: {
+      avatarData: buffer,
+      avatarMime: file.type,
+      avatarUrl: AVATAR_SERVE_URL,
+    },
   });
 
-  return NextResponse.json({ avatarUrl }, { status: 200 });
+  return NextResponse.json({ avatarUrl: AVATAR_SERVE_URL }, { status: 200 });
 }

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import type { CurrentUser } from "@/lib/auth/session";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 
 interface DashboardShellProps {
   children?: React.ReactNode;
+  currentUser?: CurrentUser;
 }
 
-export function DashboardShell({ children }: DashboardShellProps) {
+export function DashboardShell({ children, currentUser }: DashboardShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [darkMode, setDarkMode] = useState(false);
   const sidebarWidth = 260;
@@ -23,7 +25,7 @@ export function DashboardShell({ children }: DashboardShellProps) {
         className="fixed top-0 left-0 h-screen z-40 transition-all duration-300"
         style={{ width: sidebarOpen ? sidebarWidth : 0, overflow: "hidden" }}
       >
-        <Sidebar darkMode={darkMode} />
+        <Sidebar darkMode={darkMode} currentUser={currentUser} />
       </div>
 
       {/* Rechter Hauptbereich */}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { LayoutDashboard, Calendar, BookOpen, MessageSquare, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { CurrentUser } from "@/lib/auth/session";
 import { cn } from "@/lib/utils";
 
 const navItems = [
@@ -25,6 +26,18 @@ const navItems = [
 
 interface SidebarProps {
   darkMode?: boolean;
+  currentUser?: CurrentUser;
+}
+
+function getInitials(displayName?: string): string {
+  if (!displayName) return "LH";
+  const initials = displayName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join("");
+  return initials || "LH";
 }
 
 function isActiveLink(currentPath: string, href: string) {
@@ -35,9 +48,11 @@ function isActiveLink(currentPath: string, href: string) {
   return currentPath === target || currentPath.startsWith(`${target}/`);
 }
 
-export function Sidebar({ darkMode }: SidebarProps) {
+export function Sidebar({ darkMode, currentUser }: SidebarProps) {
   const pathname = usePathname() ?? "";
   const bg = darkMode ? "#2a2a2a" : "#5f6a70";
+  const displayName = currentUser?.displayName ?? "LearnHub";
+  const email = currentUser?.email ?? "";
 
   return (
     <div
@@ -122,12 +137,12 @@ export function Sidebar({ darkMode }: SidebarProps) {
           className="flex shrink-0 items-center justify-center rounded-full text-sm font-bold text-white"
           style={{ backgroundColor: "#ef233c", width: 38, height: 38 }}
         >
-          MM
+          {getInitials(displayName)}
         </div>
         <div className="flex flex-col">
-          <span className="text-sm font-semibold text-white">Max Mustermann</span>
+          <span className="text-sm font-semibold text-white">{displayName}</span>
           <span className="text-xs" style={{ color: "#aeb4b8" }}>
-            demo@learnhub.de
+            {email}
           </span>
         </div>
       </Link>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -134,10 +134,19 @@ export function Sidebar({ darkMode, currentUser }: SidebarProps) {
         className="flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-white/10"
       >
         <div
-          className="flex shrink-0 items-center justify-center rounded-full text-sm font-bold text-white"
+          className="flex shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-bold text-white"
           style={{ backgroundColor: "#ef233c", width: 38, height: 38 }}
         >
-          {getInitials(displayName)}
+          {currentUser?.avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={currentUser.avatarUrl}
+              alt={displayName}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            getInitials(displayName)
+          )}
         </div>
         <div className="flex flex-col">
           <span className="text-sm font-semibold text-white">{displayName}</span>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -3,6 +3,7 @@
 import { Search, PanelLeftClose, PanelLeftOpen, Moon, Sun, LogOut } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 interface TopbarProps {
   sidebarOpen: boolean;
@@ -13,12 +14,19 @@ interface TopbarProps {
 
 export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMode }: TopbarProps) {
   const router = useRouter();
+  const [logoutError, setLogoutError] = useState<string | null>(null);
 
   async function handleLogout() {
-    const res = await fetch("/api/auth/logout", { method: "POST" }).catch(() => null);
-    if (res && res.ok) {
+    try {
+      const res = await fetch("/api/auth/logout", { method: "POST" });
+      if (!res.ok) {
+        setLogoutError("Abmelden fehlgeschlagen. Bitte versuche es erneut.");
+        return;
+      }
       router.push("/login");
       router.refresh();
+    } catch {
+      setLogoutError("Abmelden fehlgeschlagen. Bitte versuche es erneut.");
     }
   }
   return (
@@ -73,6 +81,13 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
           />
         </div>
       </div>
+
+      {/* Fehler beim Logout */}
+      {logoutError && (
+        <div className="px-6 py-2 text-sm text-red-600 bg-red-50 border-b border-red-200">
+          {logoutError}
+        </div>
+      )}
 
       {/* Trennlinie */}
       <div style={{ borderBottom: "1px solid #cfcfcf" }} />

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -69,6 +69,7 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
             className="p-1.5 rounded-lg hover:bg-black/5 transition-colors"
             style={{ color: darkMode ? "#f3f4f6" : "#4b5563" }}
             title="Abmelden"
+            aria-label="Abmelden"
           >
             <LogOut className="w-5 h-5" />
           </button>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,8 @@
-import { Search, PanelLeftClose, PanelLeftOpen, Moon, Sun } from "lucide-react";
+"use client";
+
+import { Search, PanelLeftClose, PanelLeftOpen, Moon, Sun, LogOut } from "lucide-react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 interface TopbarProps {
   sidebarOpen: boolean;
@@ -9,6 +12,13 @@ interface TopbarProps {
 }
 
 export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMode }: TopbarProps) {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch("/api/auth/logout", { method: "POST" }).catch(() => undefined);
+    router.push("/login");
+    router.refresh();
+  }
   return (
     <div className="flex flex-col">
       <div className="flex items-center justify-between px-6 py-4">
@@ -43,6 +53,14 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
             title={darkMode ? "Light Mode" : "Dark Mode"}
           >
             {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+          </button>
+          <button
+            onClick={handleLogout}
+            className="p-1.5 rounded-lg hover:bg-black/5 transition-colors"
+            style={{ color: darkMode ? "#f3f4f6" : "#4b5563" }}
+            title="Abmelden"
+          >
+            <LogOut className="w-5 h-5" />
           </button>
           <Image
             src="/images/Dhbw_Icon.png"

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -15,9 +15,11 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
   const router = useRouter();
 
   async function handleLogout() {
-    await fetch("/api/auth/logout", { method: "POST" }).catch(() => undefined);
-    router.push("/login");
-    router.refresh();
+    const res = await fetch("/api/auth/logout", { method: "POST" }).catch(() => null);
+    if (res && res.ok) {
+      router.push("/login");
+      router.refresh();
+    }
   }
   return (
     <div className="flex flex-col">

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -35,7 +35,6 @@ export function LoginForm() {
         return;
       }
 
-      // ?redirect= nur akzeptieren wenn es ein lokaler Pfad ist (Open-Redirect-Schutz)
       const redirect = searchParams.get("redirect");
       const target =
         redirect && redirect.startsWith("/") && !redirect.startsWith("//")
@@ -43,6 +42,7 @@ export function LoginForm() {
           : "/dashboard";
 
       router.push(target);
+      router.refresh();
     } catch {
       setError("Verbindungsfehler. Bitte versuche es erneut.");
     } finally {
@@ -96,7 +96,7 @@ export function LoginForm() {
           <Input
             id="password"
             type="password"
-            placeholder="••••••••"
+            placeholder="Mindestens 8 Zeichen"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
@@ -131,7 +131,7 @@ export function LoginForm() {
 
         {/* Fehlermeldung */}
         {error && (
-          <p role="alert" className="rounded-lg bg-red-50 px-3 py-2 text-sm font-medium text-red-600">
+          <p role="alert" className="rounded-lg border border-brand-red/20 bg-brand-red/5 px-3 py-2 text-sm text-brand-red">
             {error}
           </p>
         )}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -68,19 +68,19 @@ export function LoginForm() {
         {/* Feld 1: Benutzerkennung */}
         <div className="space-y-1.5">
           <Label
-            htmlFor="username"
+            htmlFor="email"
             className="text-xs font-semibold uppercase tracking-wider text-gray-500"
           >
             E-Mail
           </Label>
           <Input
-            id="username"
-            type="text"
+            id="email"
+            type="email"
             placeholder="name@stud.hs.de"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
-            autoComplete="username"
+            autoComplete="email"
             className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
           />
         </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -48,8 +48,11 @@ const ALLOWED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp"];
 export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(
+    currentUser?.avatarUrl ?? null,
+  );
   const [avatarError, setAvatarError] = useState<string | null>(null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // displayName → Vorname / Nachname aufsplitten
@@ -98,12 +101,30 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
       return;
     }
 
+    // Lokale Vorschau sofort anzeigen
     setAvatarPreview((previous) => {
-      if (previous) {
+      if (previous && previous.startsWith("blob:")) {
         URL.revokeObjectURL(previous);
       }
       return URL.createObjectURL(file);
     });
+
+    // Hochladen + in DB speichern
+    setAvatarUploading(true);
+    const formData = new FormData();
+    formData.append("avatar", file);
+    fetch("/api/profile/avatar", { method: "POST", body: formData })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string };
+          setAvatarError(body.error ?? "Upload fehlgeschlagen.");
+        } else {
+          // Sidebar und Layout neu laden damit der neue Avatar sofort erscheint
+          router.refresh();
+        }
+      })
+      .catch(() => setAvatarError("Upload fehlgeschlagen. Bitte erneut versuchen."))
+      .finally(() => setAvatarUploading(false));
   }
 
   function handleCategoryChange(categoryId: SettingsCategoryId) {
@@ -150,6 +171,7 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
           <ProfileSettings
             avatarPreview={avatarPreview}
             avatarError={avatarError}
+            avatarUploading={avatarUploading}
             fileInputRef={fileInputRef}
             onAvatarChange={handleAvatarChange}
             firstName={firstName}
@@ -168,6 +190,7 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
 interface ProfileSettingsProps {
   avatarPreview: string | null;
   avatarError: string | null;
+  avatarUploading: boolean;
   fileInputRef: React.RefObject<HTMLInputElement>;
   onAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   firstName: string;
@@ -179,6 +202,7 @@ interface ProfileSettingsProps {
 function ProfileSettings({
   avatarPreview,
   avatarError,
+  avatarUploading,
   fileInputRef,
   onAvatarChange,
   firstName: initialFirstName,
@@ -221,10 +245,11 @@ function ProfileSettings({
             type="button"
             variant="outline"
             className="w-full"
+            disabled={avatarUploading}
             onClick={() => fileInputRef.current?.click()}
           >
             <ImagePlus className="h-4 w-4" />
-            Bild hochladen
+            {avatarUploading ? "Wird hochgeladen…" : "Bild hochladen"}
           </Button>
           {avatarError && (
             <p role="alert" className="text-center text-xs text-red-600">

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -119,6 +119,8 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
           const body = await res.json().catch(() => ({})) as { error?: string };
           setAvatarError(body.error ?? "Upload fehlgeschlagen.");
         } else {
+          // File-Input leeren damit dieselbe Datei erneut auswählbar ist
+          if (fileInputRef.current) fileInputRef.current.value = "";
           // Sidebar und Layout neu laden damit der neue Avatar sofort erscheint
           router.refresh();
         }

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import type { CurrentUser } from "@/lib/auth/session";
 
 type SettingsCategoryId = "profile" | "notifications" | "calendar";
 
@@ -44,12 +45,19 @@ const SELECT_CLASSES =
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024; // 5 MB
 const ALLOWED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
-export function SettingsPage() {
+export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [avatarError, setAvatarError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // displayName → Vorname / Nachname aufsplitten
+  const nameParts = currentUser?.displayName?.split(" ") ?? [];
+  const firstName = nameParts[0] ?? "";
+  const lastName = nameParts.slice(1).join(" ");
+  // Username-Fallback: Teil vor dem @
+  const username = currentUser?.email?.split("@")[0] ?? "";
 
   const tabParam = searchParams.get("tab");
   // S-2 Fix: Default-Tab ist 'profile'.
@@ -144,6 +152,10 @@ export function SettingsPage() {
             avatarError={avatarError}
             fileInputRef={fileInputRef}
             onAvatarChange={handleAvatarChange}
+            firstName={firstName}
+            lastName={lastName}
+            username={username}
+            email={currentUser?.email ?? ""}
           />
         )}
         {activeCategory === "notifications" && <NotificationSettings />}
@@ -158,6 +170,10 @@ interface ProfileSettingsProps {
   avatarError: string | null;
   fileInputRef: React.RefObject<HTMLInputElement>;
   onAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  firstName: string;
+  lastName: string;
+  username: string;
+  email: string;
 }
 
 function ProfileSettings({
@@ -165,6 +181,10 @@ function ProfileSettings({
   avatarError,
   fileInputRef,
   onAvatarChange,
+  firstName,
+  lastName,
+  username,
+  email,
 }: ProfileSettingsProps) {
   // S-5 Fix: Submit-Handler verhindert Page-Reload (echte Persistenz folgt mit API).
   function handleProfileSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -220,15 +240,15 @@ function ProfileSettings({
           <div className="grid gap-4 md:grid-cols-2">
             <Field label="Name" htmlFor="first-name">
               {/* S-11 Fix: Generische Demo-Daten statt echter Personendaten. S-14 Fix: name-Attribut. */}
-              <Input id="first-name" name="firstName" defaultValue="Max" />
+              <Input id="first-name" name="firstName" defaultValue={firstName} />
             </Field>
             <Field label="Nachname" htmlFor="last-name">
-              <Input id="last-name" name="lastName" defaultValue="Mustermann" />
+              <Input id="last-name" name="lastName" defaultValue={lastName} />
             </Field>
           </div>
 
           <Field label="Username" htmlFor="username">
-            <Input id="username" name="username" defaultValue="max.mustermann" />
+            <Input id="username" name="username" defaultValue={username} />
           </Field>
 
           <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
@@ -237,7 +257,7 @@ function ProfileSettings({
                 id="email"
                 name="email"
                 type="email"
-                defaultValue="demo@learnhub.de"
+                defaultValue={email}
               />
             </Field>
             <Button type="button" variant="outline" className="md:mb-0">

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -181,11 +181,16 @@ function ProfileSettings({
   avatarError,
   fileInputRef,
   onAvatarChange,
-  firstName,
-  lastName,
-  username,
-  email,
+  firstName: initialFirstName,
+  lastName: initialLastName,
+  username: initialUsername,
+  email: initialEmail,
 }: ProfileSettingsProps) {
+  const [firstName, setFirstName] = useState(initialFirstName);
+  const [lastName, setLastName] = useState(initialLastName);
+  const [username, setUsername] = useState(initialUsername);
+  const [email, setEmail] = useState(initialEmail);
+
   // S-5 Fix: Submit-Handler verhindert Page-Reload (echte Persistenz folgt mit API).
   function handleProfileSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -239,16 +244,16 @@ function ProfileSettings({
         <form className="mt-5 grid gap-5" onSubmit={handleProfileSubmit}>
           <div className="grid gap-4 md:grid-cols-2">
             <Field label="Name" htmlFor="first-name">
-              {/* S-11 Fix: Generische Demo-Daten statt echter Personendaten. S-14 Fix: name-Attribut. */}
-              <Input id="first-name" name="firstName" defaultValue={firstName} />
+              {/* S-14 Fix: name-Attribut. Controlled input — kein uncontrolled-Warning. */}
+              <Input id="first-name" name="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
             </Field>
             <Field label="Nachname" htmlFor="last-name">
-              <Input id="last-name" name="lastName" defaultValue={lastName} />
+              <Input id="last-name" name="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} />
             </Field>
           </div>
 
           <Field label="Username" htmlFor="username">
-            <Input id="username" name="username" defaultValue={username} />
+            <Input id="username" name="username" value={username} onChange={(e) => setUsername(e.target.value)} />
           </Field>
 
           <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
@@ -257,7 +262,8 @@ function ProfileSettings({
                 id="email"
                 name="email"
                 type="email"
-                defaultValue={email}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
               />
             </Field>
             <Button type="button" variant="outline" className="md:mb-0">

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -8,14 +8,19 @@ import {
   sessionCookieOptions,
 } from "./cookie";
 
-// >= 256 Bit Entropie gemaess docs/auth-concept.md §3 und §5.1.
+export interface CurrentUser {
+  id: string;
+  email: string;
+  displayName: string;
+}
+
 function generateSessionToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
 /**
  * Liest den Session-Cookie und gibt die userId zurück, oder null wenn
- * keine gültige Session existiert.
+ * keine gültige Session existiert. Löscht abgelaufene Sessions aus der DB.
  */
 export async function getSession(): Promise<{ userId: string } | null> {
   const cookieStore = await cookies();
@@ -27,14 +32,61 @@ export async function getSession(): Promise<{ userId: string } | null> {
     select: { userId: true, expiresAt: true },
   });
 
-  if (!session || session.expiresAt < new Date()) return null;
+  if (!session) return null;
+
+  if (session.expiresAt < new Date()) {
+    // Abgelaufene Session aus DB entfernen
+    await prisma.session.delete({ where: { id: token } }).catch(() => undefined);
+    return null;
+  }
+
   return { userId: session.userId };
 }
 
 /**
- * Erstellt eine neue Session fuer den User: Token erzeugen, DB-Eintrag
- * anlegen, Cookie setzen. Wird von Register und (spaeter, in C3) Login
- * aufgerufen.
+ * Gibt den eingeloggten User als CurrentUser zurück oder null.
+ * Wird in Server Components und Layout genutzt um Userdaten anzuzeigen.
+ */
+export async function getCurrentUser(): Promise<CurrentUser | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+
+  const session = await prisma.session.findUnique({
+    where: { id: token },
+    include: {
+      user: {
+        select: { id: true, email: true, displayName: true },
+      },
+    },
+  });
+
+  if (!session) return null;
+
+  if (session.expiresAt < new Date()) {
+    await prisma.session.delete({ where: { id: token } }).catch(() => undefined);
+    return null;
+  }
+
+  return session.user;
+}
+
+/**
+ * Löscht die aktuelle Session aus der DB und entwertet den Cookie.
+ */
+export async function destroyCurrentSession(): Promise<void> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE)?.value;
+
+  if (token) {
+    await prisma.session.delete({ where: { id: token } }).catch(() => undefined);
+  }
+
+  cookieStore.set(SESSION_COOKIE, "", sessionCookieOptions(0));
+}
+
+/**
+ * Erstellt eine neue Session: Token erzeugen, DB-Eintrag anlegen, Cookie setzen.
  */
 export async function createSession(
   userId: string,

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -12,6 +12,7 @@ export interface CurrentUser {
   id: string;
   email: string;
   displayName: string;
+  avatarUrl?: string | null;
 }
 
 function generateSessionToken(): string {
@@ -56,7 +57,7 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
     where: { id: token },
     include: {
       user: {
-        select: { id: true, email: true, displayName: true },
+        select: { id: true, email: true, displayName: true, avatarUrl: true },
       },
     },
   });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,10 +43,10 @@ export function middleware(request: NextRequest) {
       return NextResponse.redirect(loginUrl);
     }
 
-    // Eingeloggte User auf Login/Register → Dashboard
-    if (hasSessionCookie && (pathname === "/login" || pathname === "/register")) {
-      return NextResponse.redirect(new URL("/dashboard", request.url));
-    }
+    // Kein Redirect von /login oder /register basierend nur auf Cookie-Existenz:
+    // Cookie kann vorhanden sein obwohl die Session in der DB bereits ungültig ist (z. B. Logout in anderem Tab).
+    // Ein Redirect würde dann zu einem Loop zwischen /login ↔ /dashboard führen.
+
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,44 +1,49 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { SESSION_COOKIE } from "@/lib/auth/cookie";
 
 /**
  * Middleware für LearnHub — Auth-Schutz (C3).
  *
  * Schutzlogik:
  *   - Nicht eingeloggte User auf geschützten Pfaden → /login?redirect=<pfad>
+ *   - Nicht eingeloggte User auf geschützten API-Routen → 401 JSON
  *   - Eingeloggte User auf /login oder /register → /dashboard
  *
  * Die Middleware prüft nur die Cookie-Existenz, nicht die DB-Gültigkeit
  * (Edge-Runtime hat keinen Prisma-Zugang). Echte Session-Validierung
  * erfolgt in Server Components und Route Handlern via getSession().
  * Siehe docs/auth-concept.md §6.3.
- *
- * Static Assets werden über config.matcher ausgenommen.
  */
 const AUTH_ENABLED = true;
 
-// Cookie-Name als Konstante – muss mit createSession() / deleteSession() übereinstimmen.
-const SESSION_COOKIE_NAME = "lh_session";
+const PUBLIC_PATHS = ["/login", "/register", "/forgot-password", "/api/auth"];
 
-// Pfade die ohne Login erreichbar sein müssen.
-// /api/auth/* ist bereits durch den matcher ("!api") vom Middleware-Matching ausgenommen.
-const PUBLIC_PATHS = ["/login", "/register", "/forgot-password"];
+function isPublicPath(pathname: string) {
+  return PUBLIC_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+}
 
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   // Nur Cookie-Existenz prüfen – keine DB-Validierung (Edge-Runtime hat kein Prisma).
   // Echte Session-Gültigkeit wird in Server Components / Route Handlern via getSession() geprüft.
-  const hasSessionCookie = request.cookies.has(SESSION_COOKIE_NAME);
-  const isPublic = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+  const hasSessionCookie = request.cookies.has(SESSION_COOKIE);
+  const isPublic = isPublicPath(pathname);
 
   if (AUTH_ENABLED) {
-    // Vollständiger Schutz: nicht eingeloggte User → /login
     if (!hasSessionCookie && !isPublic) {
+      // API-Routen: 401 JSON statt Redirect
+      if (pathname.startsWith("/api/")) {
+        return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+      }
+      // Seiten: Redirect auf Login mit Rücksprung-Pfad
       const loginUrl = new URL("/login", request.url);
-      const redirectTo = pathname + search;
-      loginUrl.searchParams.set("redirect", redirectTo);
+      loginUrl.searchParams.set("redirect", `${pathname}${search}`);
       return NextResponse.redirect(loginUrl);
     }
-    // Eingeloggte User auf /login oder /register → /dashboard
+
+    // Eingeloggte User auf Login/Register → Dashboard
     if (hasSessionCookie && (pathname === "/login" || pathname === "/register")) {
       return NextResponse.redirect(new URL("/dashboard", request.url));
     }
@@ -49,7 +54,8 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Alles außer API-Routen, Next.js-Interna und statische Assets.
-    "/((?!api|_next/static|_next/image|favicon.ico|icons|images).*)",
+    // API-Routen einschließen damit die 401-Logik greift.
+    // _next-Interna und statische Assets ausschließen.
+    "/((?!_next/static|_next/image|favicon.ico|icons|images).*)",
   ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -57,4 +57,5 @@ export const config = {
     // API-Routen einschließen damit die 401-Logik greift.
     // _next-Interna und statische Assets ausschließen.
     "/((?!_next|favicon.ico|icons|images).*)",
+  ],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -56,6 +56,5 @@ export const config = {
   matcher: [
     // API-Routen einschließen damit die 401-Logik greift.
     // _next-Interna und statische Assets ausschließen.
-    "/((?!_next/static|_next/image|favicon.ico|icons|images).*)",
-  ],
+    "/((?!_next|favicon.ico|icons|images).*)",
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,22 +16,25 @@ import { NextResponse, type NextRequest } from "next/server";
  */
 const AUTH_ENABLED = true;
 
+// Cookie-Name als Konstante – muss mit createSession() / deleteSession() übereinstimmen.
+const SESSION_COOKIE_NAME = "lh_session";
+
 // Pfade die ohne Login erreichbar sein müssen.
 // /api/auth/* ist bereits durch den matcher ("!api") vom Middleware-Matching ausgenommen.
 const PUBLIC_PATHS = ["/login", "/register", "/forgot-password"];
 
 export function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
   // Nur Cookie-Existenz prüfen – keine DB-Validierung (Edge-Runtime hat kein Prisma).
   // Echte Session-Gültigkeit wird in Server Components / Route Handlern via getSession() geprüft.
-  const hasSessionCookie = request.cookies.has("lh_session");
+  const hasSessionCookie = request.cookies.has(SESSION_COOKIE_NAME);
   const isPublic = PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
   if (AUTH_ENABLED) {
     // Vollständiger Schutz: nicht eingeloggte User → /login
     if (!hasSessionCookie && !isPublic) {
       const loginUrl = new URL("/login", request.url);
-      const redirectTo = request.nextUrl.pathname + request.nextUrl.search;
+      const redirectTo = pathname + search;
       loginUrl.searchParams.set("redirect", redirectTo);
       return NextResponse.redirect(loginUrl);
     }


### PR DESCRIPTION
## Änderungen

### Auth / Session
- `session.ts`: `CurrentUser` Interface, `getCurrentUser()`, `destroyCurrentSession()`, abgelaufene Sessions werden automatisch gelöscht
- `middleware.ts`: `SESSION_COOKIE` Import, `/api/auth` in `PUBLIC_PATHS`, 401 JSON für unauthentifizierte API-Calls, Matcher inkl. API-Routen
- `(app)/layout.tsx`: async, lädt echten User, Redirect zu `/login` wenn null

### Echte Userdaten
- `DashboardShell` + `Sidebar`: zeigen echten `displayName` und `email` aus DB
- Initialen-Funktion (`getInitials`) aus `displayName`
- `Topbar`: Logout-Button mit `handleLogout()` + `router.refresh()`
- `LoginForm`: `router.refresh()` nach Login, brand-red Fehler-Styling

### Settings – echte Daten
- `settings/page.tsx`: async, lädt `getCurrentUser()`, reicht `currentUser` weiter
- `SettingsPage`: Formularfelder mit echtem Vor-/Nachname, Username (E-Mail-Prefix), E-Mail
- Controlled inputs statt `defaultValue` (kein Base UI Warning)

### Avatar-Upload
- Prisma: `avatarUrl String?` zu `User` hinzugefügt + Migration
- `POST /api/profile/avatar`: Validierung, Base64-Konvertierung, DB-Speicherung
- Settings: Upload on select, Loading-State, `router.refresh()` nach Erfolg
- Sidebar: zeigt Avatar-Bild wenn vorhanden, sonst Initialen-Fallback