### PR TITLE
feat(calendar): Termin-Detailansicht und Bearbeitung per Klick

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -6,6 +6,7 @@ import { MonthView } from "./MonthView";
 import { WeekView } from "./WeekView";
 import { DayView } from "./DayView";
 import { ListView } from "./ListView";
+import { EventDetailModal } from "./EventDetailModal";
 import {
   formatMonthYear,
   formatWeekRange,
@@ -38,6 +39,7 @@ export function Calendar({
 }: CalendarProps) {
   const [view, setView] = useState<View>("week");
   const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
 
   // Sichtbarer Zeitraum je nach View
   function getViewRange(): { start: Date; end: Date } {
@@ -80,6 +82,15 @@ export function Calendar({
   function handleEventChange(next: CalEvent) {
     if (next.readOnly) return;
     onLocalEventsChange(localEvents.map((e) => (e.id === next.id ? next : e)));
+  }
+
+  function handleEventSave(updated: CalEvent) {
+    if (updated.readOnly) return;
+    onLocalEventsChange(localEvents.map((e) => (e.id === updated.id ? updated : e)));
+  }
+
+  function handleEventDelete(id: string) {
+    onLocalEventsChange(localEvents.filter((e) => e.id !== id));
   }
 
   function goPrev() {
@@ -179,13 +190,18 @@ export function Calendar({
       {/* Body */}
       <div className="flex-1 overflow-auto">
         {view === "month" ? (
-          <MonthView currentDate={currentDate} events={visibleEvents} />
+          <MonthView
+            currentDate={currentDate}
+            events={visibleEvents}
+            onEventClick={setSelectedEvent}
+          />
         ) : view === "week" ? (
           <WeekView
             currentDate={currentDate}
             events={visibleEvents}
             onEventChange={handleEventChange}
             onRequestCreate={onRequestCreate}
+            onEventClick={setSelectedEvent}
           />
         ) : view === "day" ? (
           <DayView
@@ -193,11 +209,24 @@ export function Calendar({
             events={visibleEvents}
             onEventChange={handleEventChange}
             onRequestCreate={onRequestCreate}
+            onEventClick={setSelectedEvent}
           />
         ) : (
-          <ListView currentDate={currentDate} events={visibleEvents} />
+          <ListView
+            currentDate={currentDate}
+            events={visibleEvents}
+            onEventClick={setSelectedEvent}
+          />
         )}
       </div>
+
+      <EventDetailModal
+        event={selectedEvent}
+        onClose={() => setSelectedEvent(null)}
+        onSave={handleEventSave}
+        onDelete={handleEventDelete}
+        blockedEvents={externalEvents.filter((e) => e.source === "dhbw")}
+      />
     </div>
   );
 }

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -19,6 +19,7 @@ interface DayViewProps {
   events: CalEvent[];
   onEventChange: (next: CalEvent) => void;
   onRequestCreate?: (defaults: { start: Date; end: Date }) => void;
+  onEventClick?: (event: CalEvent) => void;
 }
 
 const HOURS = Array.from(
@@ -26,7 +27,7 @@ const HOURS = Array.from(
   (_, i) => i + DAY_START_HOUR
 );
 
-export function DayView({ currentDate, events, onEventChange, onRequestCreate }: DayViewProps) {
+export function DayView({ currentDate, events, onEventChange, onRequestCreate, onEventClick }: DayViewProps) {
   const today = new Date();
   const isToday = isSameDay(currentDate, today);
   const totalHeight = HOURS.length * HOUR_HEIGHT;
@@ -100,6 +101,7 @@ export function DayView({ currentDate, events, onEventChange, onRequestCreate }:
               column={column}
               columns={columns}
               blockedEvents={dhbwEvents}
+              onEventClick={onEventClick}
             />
           ))}
         </div>

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -145,8 +145,8 @@ export function EventBlock({
       return;
     }
 
-    // Kein echter Drag → Click-Handler aufrufen
-    if (!didDragRef.current) {
+    // Kein echter Drag → Click-Handler nur beim "move"-Bereich (nicht bei Resize-Handles) aufrufen
+    if (drag.mode === "move" && !didDragRef.current) {
       setPreview(null);
       onEventClick?.(event);
       return;

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -25,6 +25,8 @@ interface EventBlockProps {
   columns?: number;
   /** DHBW-Events, in die nicht verschoben/vergrößert werden darf. */
   blockedEvents?: CalEvent[];
+  /** Wird aufgerufen wenn der Nutzer auf das Event klickt (kein Drag). */
+  onEventClick?: (event: CalEvent) => void;
 }
 
 type DragMode = "move" | "resize-top" | "resize-bottom";
@@ -54,9 +56,12 @@ export function EventBlock({
   column = 0,
   columns = 1,
   blockedEvents = [],
+  onEventClick,
 }: EventBlockProps) {
   const dragRef = useRef<DragState | null>(null);
   const [preview, setPreview] = useState<Preview | null>(null);
+  // Tracking ob es ein echter Drag war (> 5px Bewegung)
+  const didDragRef = useRef(false);
 
   const baseTop = dateToTop(event.start);
   const baseHeight = Math.max(
@@ -86,6 +91,7 @@ export function EventBlock({
     e.stopPropagation();
     e.preventDefault();
     (e.target as Element).setPointerCapture?.(e.pointerId);
+    didDragRef.current = false;
     dragRef.current = {
       mode,
       startX: e.clientX,
@@ -101,6 +107,11 @@ export function EventBlock({
     if (!drag) return;
     const deltaY = e.clientY - drag.startY;
     const deltaX = e.clientX - drag.startX;
+
+    // Als Drag markieren sobald Bewegung > 5px
+    if (!didDragRef.current && (Math.abs(deltaY) > 5 || Math.abs(deltaX) > 5)) {
+      didDragRef.current = true;
+    }
 
     if (drag.mode === "move") {
       // Vertikal: pixelgenaue Vorschau (kein Snap → flüssig)
@@ -131,6 +142,13 @@ export function EventBlock({
     dragRef.current = null;
     if (!drag) {
       setPreview(null);
+      return;
+    }
+
+    // Kein echter Drag → Click-Handler aufrufen
+    if (!didDragRef.current) {
+      setPreview(null);
+      onEventClick?.(event);
       return;
     }
 
@@ -240,8 +258,9 @@ export function EventBlock({
     >
       <div
         onPointerDown={(e) => onPointerDown(e, "move")}
+        onClick={isReadOnly ? () => onEventClick?.(event) : undefined}
         className={`absolute inset-0 rounded-md overflow-hidden px-2 py-1 ${
-          isReadOnly ? "cursor-default" : "cursor-grab active:cursor-grabbing"
+          isReadOnly ? "cursor-pointer" : "cursor-grab active:cursor-grabbing"
         }`}
       >
         <div className="font-semibold leading-tight truncate">{event.title}</div>

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MapPin, Pencil, Trash2, X } from "lucide-react";
+import {
+  CalEvent,
+  EVENT_TYPES,
+  EventType,
+  RepeatRule,
+  SUBJECTS,
+  overlapsAnyDhbwEvent,
+} from "./events";
+
+interface EventDetailModalProps {
+  event: CalEvent | null;
+  onClose: () => void;
+  onSave: (updated: CalEvent) => void;
+  onDelete: (id: string) => void;
+  blockedEvents?: CalEvent[];
+}
+
+function toLocalInputValue(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDateTime(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const weekdays = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
+  const months = ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"];
+  return `${weekdays[d.getDay()]}, ${d.getDate()}. ${months[d.getMonth()]} ${d.getFullYear()} · ${pad(d.getHours())}:${pad(d.getMinutes())} Uhr`;
+}
+
+function formatDuration(start: Date, end: Date): string {
+  const minutes = Math.round((end.getTime() - start.getTime()) / 60000);
+  if (minutes < 60) return `${minutes} Min.`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m === 0 ? `${h} Std.` : `${h} Std. ${m} Min.`;
+}
+
+export function EventDetailModal({
+  event,
+  onClose,
+  onSave,
+  onDelete,
+  blockedEvents = [],
+}: EventDetailModalProps) {
+  const [editMode, setEditMode] = useState(false);
+
+  // Edit-Felder
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<EventType>("Lernsession");
+  const [subject, setSubject] = useState<string>(SUBJECTS[0].name);
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [repeat, setRepeat] = useState<RepeatRule>("none");
+  const [notes, setNotes] = useState("");
+  const [conflictError, setConflictError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Felder beim Öffnen befüllen
+  useEffect(() => {
+    if (event) {
+      setTitle(event.title);
+      setType(event.type ?? "Lernsession");
+      setSubject(event.subject ?? SUBJECTS[0].name);
+      setStart(toLocalInputValue(event.start));
+      setEnd(toLocalInputValue(event.end));
+      setRepeat(event.repeat ?? "none");
+      setNotes(event.notes ?? "");
+      setConflictError(null);
+      setEditMode(false);
+      setConfirmDelete(false);
+    }
+  }, [event]);
+
+  // ESC schließt Modal
+  useEffect(() => {
+    if (!event) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        if (editMode) setEditMode(false);
+        else onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [event, editMode, onClose]);
+
+  if (!event) return null;
+
+  const isReadOnly = !!event.readOnly;
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
+    if (endDate.getTime() <= startDate.getTime()) return;
+
+    if (overlapsAnyDhbwEvent(startDate, endDate, blockedEvents)) {
+      setConflictError(
+        "Dieser Zeitraum überschneidet sich mit einer DHBW-Vorlesung. Bitte wähle einen anderen Zeitraum.",
+      );
+      return;
+    }
+
+    const typeColor =
+      EVENT_TYPES.find((t) => t.name === type)?.color ??
+      SUBJECTS.find((s) => s.name === subject)?.color ??
+      "bg-brand-red";
+
+    onSave({
+      ...event,
+      id: event!.id,
+      title: title.trim(),
+      type,
+      subject,
+      start: startDate,
+      end: endDate,
+      repeat,
+      notes: notes.trim() || undefined,
+      color: typeColor,
+    });
+    onClose();
+  }
+
+  function handleDelete() {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      return;
+    }
+    onDelete(event!.id);
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-detail-title"
+        className="w-full max-w-md rounded-2xl bg-white shadow-xl border border-gray-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2 min-w-0">
+            {/* Farbpunkt */}
+            <span className={`inline-block shrink-0 h-3 w-3 rounded-full ${event.color}`} />
+            <h3
+              id="event-detail-title"
+              className="text-lg font-bold text-gray-900 truncate"
+            >
+              {editMode ? "Termin bearbeiten" : event.title}
+            </h3>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            {!isReadOnly && !editMode && (
+              <button
+                type="button"
+                onClick={() => setEditMode(true)}
+                className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+                aria-label="Bearbeiten"
+              >
+                <Pencil className="w-4 h-4 text-gray-500" />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+              aria-label="Schließen"
+            >
+              <X className="w-4 h-4 text-gray-500" />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        {!editMode ? (
+          /* ── Read-Only Detailansicht ── */
+          <div className="px-5 py-4 flex flex-col gap-3">
+            {/* Typ / Quelle */}
+            <div className="flex items-center gap-2 flex-wrap">
+              {event.type && (
+                <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-gray-100 text-gray-700">
+                  {event.type}
+                </span>
+              )}
+              {event.subject && (
+                <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-gray-100 text-gray-700">
+                  {event.subject}
+                </span>
+              )}
+              {event.source === "dhbw" && (
+                <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-blue-50 text-blue-700">
+                  DHBW
+                </span>
+              )}
+              {event.repeat && event.repeat !== "none" && (
+                <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold bg-gray-100 text-gray-700">
+                  {event.repeat === "daily" ? "Täglich" : "Wöchentlich"}
+                </span>
+              )}
+            </div>
+
+            {/* Zeit */}
+            <div className="rounded-xl bg-gray-50 px-4 py-3 flex flex-col gap-1">
+              {event.allDay ? (
+                <p className="text-sm font-medium text-gray-900">Ganztägig</p>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-gray-900">{formatDateTime(event.start)}</p>
+                  <p className="text-xs text-gray-500">
+                    bis {`${event.end.getHours().toString().padStart(2, "0")}:${event.end.getMinutes().toString().padStart(2, "0")} Uhr`}
+                    &nbsp;·&nbsp;{formatDuration(event.start, event.end)}
+                  </p>
+                </>
+              )}
+            </div>
+
+            {/* Ort */}
+            {event.location && (
+              <div className="flex items-start gap-2 text-sm text-gray-700">
+                <MapPin className="w-4 h-4 mt-0.5 shrink-0 text-gray-400" />
+                <span>{event.location}</span>
+              </div>
+            )}
+
+            {/* Notizen */}
+            {event.notes && (
+              <div className="rounded-xl bg-gray-50 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-1">Notiz</p>
+                <p className="text-sm text-gray-700 whitespace-pre-wrap">{event.notes}</p>
+              </div>
+            )}
+
+            {/* Footer: Löschen */}
+            {!isReadOnly && (
+              <div className="pt-2 border-t border-gray-100 flex justify-between items-center">
+                {confirmDelete ? (
+                  <div className="flex items-center gap-2 w-full">
+                    <span className="text-xs text-red-600 font-medium flex-1">Wirklich löschen?</span>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmDelete(false)}
+                      className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors"
+                    >
+                      Abbrechen
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      className="px-3 py-1.5 text-sm font-bold text-white rounded-lg bg-red-600 hover:bg-red-700 transition-colors"
+                    >
+                      Löschen
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Löschen
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditMode(true)}
+                      className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-bold text-white rounded-lg shadow-sm transition-opacity hover:opacity-90"
+                      style={{ backgroundColor: "#ef233c" }}
+                    >
+                      <Pencil className="w-4 h-4" />
+                      Bearbeiten
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          /* ── Edit-Formular ── */
+          <form onSubmit={handleSave} className="px-5 py-4 flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="ed-title" className="text-xs font-semibold text-gray-700">Titel</label>
+              <input
+                id="ed-title"
+                type="text"
+                required
+                autoFocus
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1">
+                <label htmlFor="ed-type" className="text-xs font-semibold text-gray-700">Typ</label>
+                <select
+                  id="ed-type"
+                  value={type}
+                  onChange={(e) => setType(e.target.value as EventType)}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
+                >
+                  {EVENT_TYPES.map((t) => (
+                    <option key={t.name} value={t.name}>{t.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="ed-subject" className="text-xs font-semibold text-gray-700">Fach</label>
+                <select
+                  id="ed-subject"
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
+                >
+                  {SUBJECTS.map((s) => (
+                    <option key={s.name} value={s.name}>{s.name}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1">
+                <label htmlFor="ed-start" className="text-xs font-semibold text-gray-700">Beginn</label>
+                <input
+                  id="ed-start"
+                  type="datetime-local"
+                  required
+                  value={start}
+                  onChange={(e) => { setStart(e.target.value); setConflictError(null); }}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label htmlFor="ed-end" className="text-xs font-semibold text-gray-700">Ende</label>
+                <input
+                  id="ed-end"
+                  type="datetime-local"
+                  required
+                  value={end}
+                  onChange={(e) => { setEnd(e.target.value); setConflictError(null); }}
+                  className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <label htmlFor="ed-notes" className="text-xs font-semibold text-gray-700">Notiz</label>
+              <textarea
+                id="ed-notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={3}
+                placeholder="Optionale Anmerkungen…"
+                className="rounded-lg border border-gray-300 px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold text-gray-700">Wiederholen</span>
+              <div className="flex items-center gap-1 p-1 rounded-xl bg-gray-100">
+                {(
+                  [
+                    { v: "none", label: "Keine" },
+                    { v: "daily", label: "Täglich" },
+                    { v: "weekly", label: "Wöchentlich" },
+                  ] as { v: RepeatRule; label: string }[]
+                ).map((opt) => (
+                  <button
+                    key={opt.v}
+                    type="button"
+                    onClick={() => setRepeat(opt.v)}
+                    className={`flex-1 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
+                      repeat === opt.v
+                        ? "bg-white text-gray-900 shadow-sm"
+                        : "text-gray-500 hover:text-gray-700"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2 pt-2 border-t border-gray-100">
+              {conflictError && (
+                <p className="text-xs font-medium text-red-600 bg-red-50 rounded-lg px-3 py-2">
+                  {conflictError}
+                </p>
+              )}
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                >
+                  <Trash2 className="w-4 h-4" />
+                  {confirmDelete ? "Wirklich?" : "Löschen"}
+                </button>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setEditMode(false)}
+                    className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors"
+                  >
+                    Abbrechen
+                  </button>
+                  <button
+                    type="submit"
+                    className="px-4 py-2 text-sm font-bold text-white rounded-lg shadow-sm transition-opacity hover:opacity-90 active:scale-95"
+                    style={{ backgroundColor: "#ef233c" }}
+                  >
+                    Speichern
+                  </button>
+                </div>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/ListView.tsx
+++ b/src/components/calendar/ListView.tsx
@@ -7,6 +7,7 @@ import { MONTHS, WEEKDAYS, isSameDay } from "./utils";
 interface ListViewProps {
   events: CalEvent[];
   currentDate: Date;
+  onEventClick?: (event: CalEvent) => void;
 }
 
 function formatTimeRange(ev: CalEvent): string {
@@ -41,7 +42,7 @@ function dayKey(d: Date): string {
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
 }
 
-export function ListView({ events, currentDate }: ListViewProps) {
+export function ListView({ events, currentDate, onEventClick }: ListViewProps) {
   const from = new Date(currentDate);
   from.setHours(0, 0, 0, 0);
 
@@ -99,7 +100,8 @@ export function ListView({ events, currentDate }: ListViewProps) {
             {items.map((ev) => (
               <li
                 key={ev.id}
-                className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-colors"
+                onClick={() => onEventClick?.(ev)}
+                className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-colors cursor-pointer"
               >
                 <span
                   className={`mt-1 w-1 self-stretch rounded-full ${ev.color}`}

--- a/src/components/calendar/ListView.tsx
+++ b/src/components/calendar/ListView.tsx
@@ -98,11 +98,13 @@ export function ListView({ events, currentDate, onEventClick }: ListViewProps) {
 
           <ul className="space-y-2 ml-[60px] pl-0">
             {items.map((ev) => (
-              <li
-                key={ev.id}
-                onClick={() => onEventClick?.(ev)}
-                className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-colors cursor-pointer"
-              >
+              <li key={ev.id}>
+                <button
+                  type="button"
+                  onClick={() => onEventClick?.(ev)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onEventClick?.(ev); } }}
+                  className="flex w-full items-start gap-3 p-3 rounded-lg border border-gray-200 hover:border-gray-300 hover:bg-gray-50 transition-colors text-left cursor-pointer"
+                >
                 <span
                   className={`mt-1 w-1 self-stretch rounded-full ${ev.color}`}
                   aria-hidden
@@ -123,6 +125,7 @@ export function ListView({ events, currentDate, onEventClick }: ListViewProps) {
                     </div>
                   ) : null}
                 </div>
+                </button>
               </li>
             ))}
           </ul>

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -6,6 +6,7 @@ import { CalEvent, eventOnDay, eventOverlapsDay } from "./events";
 interface MonthViewProps {
   currentDate: Date;
   events?: CalEvent[];
+  onEventClick?: (event: CalEvent) => void;
 }
 
 function formatTime(d: Date): string {
@@ -13,7 +14,7 @@ function formatTime(d: Date): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-export function MonthView({ currentDate, events = [] }: MonthViewProps) {
+export function MonthView({ currentDate, events = [], onEventClick }: MonthViewProps) {
   const days = getMonthGrid(currentDate);
   const today = new Date();
   const currentMonth = currentDate.getMonth();
@@ -70,7 +71,8 @@ export function MonthView({ currentDate, events = [] }: MonthViewProps) {
                   <div
                     key={ev.id}
                     title={`${ev.title}${ev.allDay ? "" : ` · ${formatTime(ev.start)}`}`}
-                    className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-tight text-white truncate ${ev.color}`}
+                    onClick={(e) => { e.stopPropagation(); onEventClick?.(ev); }}
+                    className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-tight text-white truncate cursor-pointer hover:opacity-80 transition-opacity ${ev.color}`}
                   >
                     {!ev.allDay && (
                       <span className="font-medium opacity-90 shrink-0">

--- a/src/components/calendar/MonthView.tsx
+++ b/src/components/calendar/MonthView.tsx
@@ -68,11 +68,12 @@ export function MonthView({ currentDate, events = [], onEventClick }: MonthViewP
               {/* Events */}
               <div className="flex flex-col gap-0.5">
                 {visible.map((ev) => (
-                  <div
+                  <button
                     key={ev.id}
+                    type="button"
                     title={`${ev.title}${ev.allDay ? "" : ` · ${formatTime(ev.start)}`}`}
                     onClick={(e) => { e.stopPropagation(); onEventClick?.(ev); }}
-                    className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-tight text-white truncate cursor-pointer hover:opacity-80 transition-opacity ${ev.color}`}
+                    className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] leading-tight text-white truncate w-full text-left cursor-pointer hover:opacity-80 transition-opacity ${ev.color}`}
                   >
                     {!ev.allDay && (
                       <span className="font-medium opacity-90 shrink-0">
@@ -80,7 +81,7 @@ export function MonthView({ currentDate, events = [], onEventClick }: MonthViewP
                       </span>
                     )}
                     <span className="truncate">{ev.title}</span>
-                  </div>
+                  </button>
                 ))}
                 {overflow > 0 && (
                   <span className="text-[10px] text-gray-500 px-1">

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -20,6 +20,7 @@ interface WeekViewProps {
   events: CalEvent[];
   onEventChange: (next: CalEvent) => void;
   onRequestCreate?: (defaults: { start: Date; end: Date }) => void;
+  onEventClick?: (event: CalEvent) => void;
 }
 
 const HOURS = Array.from(
@@ -27,7 +28,7 @@ const HOURS = Array.from(
   (_, i) => i + DAY_START_HOUR
 );
 
-export function WeekView({ currentDate, events, onEventChange, onRequestCreate }: WeekViewProps) {
+export function WeekView({ currentDate, events, onEventChange, onRequestCreate, onEventClick }: WeekViewProps) {
   const days = getWeekDays(currentDate);
   const today = new Date();
   const totalHeight = HOURS.length * HOUR_HEIGHT;
@@ -131,6 +132,7 @@ export function WeekView({ currentDate, events, onEventChange, onRequestCreate }
                   column={column}
                   columns={columns}
                   blockedEvents={dhbwEvents}
+                  onEventClick={onEventClick}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Feature: Termin anklicken → Details sehen + bearbeiten

### Was wurde gebaut?

**`EventDetailModal.tsx`** (neu)
- Klick auf beliebigen Termin öffnet ein Modal
- **DHBW-Events**: Read-only Ansicht mit Titel, Zeitraum, Dauer, Ort, Typ-Badge
- **Eigene Events**: Vollständiges Edit-Formular (Titel, Typ, Fach, Start/Ende, Notiz, Wiederholung)
- Löschen-Button mit Bestätigungsschritt
- DHBW-Konfliktprüfung beim Speichern
- ESC schließt Modal

**`EventBlock.tsx`**
- Neuer `onEventClick` Prop
- Click vs. Drag unterschieden: Bewegung < 5px → Click-Handler, sonst Drag
- DHBW-Events haben `cursor-pointer` und reagieren auf Click

**`WeekView` + `DayView`**
- `onEventClick` prop durchgereicht bis `EventBlock`

**`MonthView`**
- Event-Chips sind klickbar (`stopPropagation` damit Tages-Klick nicht feuert)

**`ListView`**
- Listeneinträge sind klickbar

**`Calendar.tsx`**
- `selectedEvent` State
- `EventDetailModal` wird gerendert
- `onSave` → aktualisiert localEvents
- `onDelete` → entfernt Event aus localEvents