### PR TITLE
feat(calendar): persist local events to database

### DIFF
--- a/prisma/migrations/20260609203909_add_calendar_event_fields/migration.sql
+++ b/prisma/migrations/20260609203909_add_calendar_event_fields/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "CalendarEvent" DROP CONSTRAINT "CalendarEvent_ownerId_fkey";
+
+-- AlterTable
+ALTER TABLE "CalendarEvent" ADD COLUMN     "notes" TEXT,
+ADD COLUMN     "repeat" TEXT,
+ADD COLUMN     "subject" TEXT,
+ALTER COLUMN "ownerId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,10 @@ model CalendarEvent {
   allDay      Boolean     @default(false)
   type        EventType
   location    String?
-  ownerId     String
+  notes       String?
+  subject     String?
+  repeat      String?     // "none" | "daily" | "weekly"
+  ownerId     String?
   // Quelle des Events. EXTERNAL z.B. aus DHBW-ICS-Feed → read-only im UI.
   source      EventSource @default(LOCAL)
   // UID aus externer Quelle (ICS), für Dedupe bei späterem persistenten Import.
@@ -137,7 +140,7 @@ model CalendarEvent {
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
 
-  owner User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  owner User? @relation(fields: [ownerId], references: [id], onDelete: SetNull)
   // Bei Task-Löschung bleibt der Kalendereintrag erhalten und verliert nur
   // die Verknüpfung (PRD §8.1).
   task      Task?      @relation(fields: [taskId], references: [id], onDelete: SetNull)

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { EventType as DbEventType } from "@prisma/client";
+import type { EventType as CalEventType, RepeatRule } from "@/components/calendar/events";
+
+const TYPE_FROM_DB: Record<DbEventType, CalEventType> = {
+  LERNEINHEIT: "Lernsession",
+  VORLESUNG: "Klausur",
+  ZIELTERMIN: "Deadline",
+  SONSTIGES: "Pause",
+};
+
+const TYPE_COLOR: Record<CalEventType, string> = {
+  Lernsession: "bg-blue-500",
+  Klausur: "bg-brand-red",
+  Deadline: "bg-amber-500",
+  Pause: "bg-emerald-500",
+};
+
+/** PATCH /api/calendar/events/[id] — Start/End eines Events aktualisieren (Drag) */
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = await req.json().catch(() => null);
+  const { start, end } = body ?? {};
+
+  const row = await prisma.calendarEvent.update({
+    where: { id },
+    data: {
+      ...(start ? { startsAt: new Date(start) } : {}),
+      ...(end ? { endsAt: new Date(end) } : {}),
+    },
+  });
+
+  const calType = TYPE_FROM_DB[row.type];
+
+  return NextResponse.json({
+    event: {
+      id: row.id,
+      title: row.title,
+      start: row.startsAt.toISOString(),
+      end: row.endsAt.toISOString(),
+      allDay: row.allDay,
+      type: calType,
+      color: TYPE_COLOR[calType],
+      source: "local" as const,
+      location: row.location ?? undefined,
+      notes: row.notes ?? undefined,
+      subject: row.subject ?? undefined,
+      repeat: (row.repeat as RepeatRule | null) ?? "none",
+    },
+  });
+}
+
+/** DELETE /api/calendar/events/[id] — Event löschen */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  await prisma.calendarEvent.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -58,9 +58,22 @@ export async function PATCH(
 /** DELETE /api/calendar/events/[id] — Event löschen */
 export async function DELETE(
   _req: Request,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: { id: string } },
 ) {
-  const { id } = await params;
-  await prisma.calendarEvent.delete({ where: { id } });
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const { id } = params;
+
+  const deleted = await prisma.calendarEvent.deleteMany({
+    where: { id, ownerId: session.userId, source: "LOCAL" },
+  });
+
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -21,19 +21,94 @@ const TYPE_COLOR: Record<CalEventType, string> = {
 /** PATCH /api/calendar/events/[id] — Start/End eines Events aktualisieren (Drag) */
 export async function PATCH(
   req: Request,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: { id: string } },
 ) {
-  const { id } = await params;
-  const body = await req.json().catch(() => null);
-  const { start, end } = body ?? {};
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
 
-  const row = await prisma.calendarEvent.update({
-    where: { id },
-    data: {
-      ...(start ? { startsAt: new Date(start) } : {}),
-      ...(end ? { endsAt: new Date(end) } : {}),
-    },
+  const { id } = params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const { start, end, title, allDay, type, location, notes, subject, repeat } =
+    (body ?? {}) as Record<string, unknown>;
+
+  const TYPE_TO_DB: Record<CalEventType, DbEventType> = {
+    Lernsession: "LERNEINHEIT",
+    Klausur: "VORLESUNG",
+    Deadline: "ZIELTERMIN",
+    Pause: "SONSTIGES",
+  };
+
+  const data: Record<string, unknown> = {};
+
+  if (typeof title === "string") data.title = title.trim();
+  if (typeof allDay === "boolean") data.allDay = allDay;
+
+  if (typeof type === "string") {
+    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_DB, type)) {
+      return NextResponse.json({ error: "Ungültiger Event-Typ" }, { status: 400 });
+    }
+    data.type = TYPE_TO_DB[type as CalEventType];
+  }
+
+  if (typeof location === "string") data.location = location;
+  if (location === null) data.location = null;
+
+  if (typeof notes === "string") data.notes = notes.trim() || null;
+  if (notes === null) data.notes = null;
+
+  if (typeof subject === "string") data.subject = subject;
+  if (subject === null) data.subject = null;
+
+  if (typeof repeat === "string") {
+    data.repeat =
+      repeat === "daily" || repeat === "weekly" || repeat === "none" ? repeat : "none";
+  }
+
+  let startsAt: Date | undefined;
+  let endsAt: Date | undefined;
+  if (typeof start === "string") {
+    startsAt = new Date(start);
+    if (Number.isNaN(startsAt.getTime())) {
+      return NextResponse.json({ error: "Ungültiges Start-Datum" }, { status: 400 });
+    }
+    data.startsAt = startsAt;
+  }
+  if (typeof end === "string") {
+    endsAt = new Date(end);
+    if (Number.isNaN(endsAt.getTime())) {
+      return NextResponse.json({ error: "Ungültiges End-Datum" }, { status: 400 });
+    }
+    data.endsAt = endsAt;
+  }
+  if (startsAt && endsAt && endsAt.getTime() <= startsAt.getTime()) {
+    return NextResponse.json({ error: "Ungültiger Zeitraum" }, { status: 400 });
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "Keine Änderungen übergeben." }, { status: 400 });
+  }
+
+  const updated = await prisma.calendarEvent.updateMany({
+    where: { id, ownerId: session.userId, source: "LOCAL" },
+    data,
   });
+  if (updated.count === 0) {
+    return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
+  }
+
+  const row = await prisma.calendarEvent.findUnique({ where: { id } });
+  if (!row) {
+    return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
+  }
 
   const calType = TYPE_FROM_DB[row.type];
 

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import { EventType as DbEventType } from "@prisma/client";
 import type { EventType as CalEventType, RepeatRule } from "@/components/calendar/events";

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -27,8 +27,13 @@ const TYPE_COLOR: Record<CalEventType, string> = {
 
 /** GET /api/calendar/events — alle lokalen Events aus der DB */
 export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
   const rows = await prisma.calendarEvent.findMany({
-    where: { source: "LOCAL" },
+    where: { source: "LOCAL", ownerId: session.userId },
     orderBy: { startsAt: "asc" },
   });
 

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { EventType as DbEventType } from "@prisma/client";
+import type { EventType as CalEventType, RepeatRule } from "@/components/calendar/events";
+
+const TYPE_TO_DB: Record<CalEventType, DbEventType> = {
+  Lernsession: "LERNEINHEIT",
+  Klausur: "VORLESUNG",
+  Deadline: "ZIELTERMIN",
+  Pause: "SONSTIGES",
+};
+
+const TYPE_FROM_DB: Record<DbEventType, CalEventType> = {
+  LERNEINHEIT: "Lernsession",
+  VORLESUNG: "Klausur",
+  ZIELTERMIN: "Deadline",
+  SONSTIGES: "Pause",
+};
+
+const TYPE_COLOR: Record<CalEventType, string> = {
+  Lernsession: "bg-blue-500",
+  Klausur: "bg-brand-red",
+  Deadline: "bg-amber-500",
+  Pause: "bg-emerald-500",
+};
+
+/** GET /api/calendar/events — alle lokalen Events aus der DB */
+export async function GET() {
+  const rows = await prisma.calendarEvent.findMany({
+    where: { source: "LOCAL" },
+    orderBy: { startsAt: "asc" },
+  });
+
+  const events = rows.map((e) => {
+    const calType = TYPE_FROM_DB[e.type];
+    return {
+      id: e.id,
+      title: e.title,
+      start: e.startsAt.toISOString(),
+      end: e.endsAt.toISOString(),
+      allDay: e.allDay,
+      type: calType,
+      color: TYPE_COLOR[calType],
+      source: "local" as const,
+      location: e.location ?? undefined,
+      notes: e.notes ?? undefined,
+      subject: e.subject ?? undefined,
+      repeat: (e.repeat as RepeatRule | null) ?? "none",
+    };
+  });
+
+  return NextResponse.json({ events });
+}
+
+/** POST /api/calendar/events — neues lokales Event speichern */
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const { title, start, end, allDay, type, location, notes, subject, repeat } =
+    body ?? {};
+
+  if (!title || !start || !end || !type) {
+    return NextResponse.json({ error: "Pflichtfelder fehlen" }, { status: 400 });
+  }
+
+  const dbType = TYPE_TO_DB[type as CalEventType] ?? "SONSTIGES";
+
+  const row = await prisma.calendarEvent.create({
+    data: {
+      title: String(title),
+      startsAt: new Date(start),
+      endsAt: new Date(end),
+      allDay: allDay ?? false,
+      type: dbType,
+      location: location ?? null,
+      notes: notes ?? null,
+      subject: subject ?? null,
+      repeat: repeat ?? "none",
+      source: "LOCAL",
+    },
+  });
+
+  const calType = TYPE_FROM_DB[row.type];
+
+  return NextResponse.json({
+    event: {
+      id: row.id,
+      title: row.title,
+      start: row.startsAt.toISOString(),
+      end: row.endsAt.toISOString(),
+      allDay: row.allDay,
+      type: calType,
+      color: TYPE_COLOR[calType],
+      source: "local" as const,
+      location: row.location ?? undefined,
+      notes: row.notes ?? undefined,
+      subject: row.subject ?? undefined,
+      repeat: (row.repeat as RepeatRule | null) ?? "none",
+    },
+  });
+}

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -60,28 +60,60 @@ export async function GET() {
 
 /** POST /api/calendar/events — neues lokales Event speichern */
 export async function POST(req: Request) {
-  const body = await req.json().catch(() => null);
-  const { title, start, end, allDay, type, location, notes, subject, repeat } =
-    body ?? {};
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
 
-  if (!title || !start || !end || !type) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const { title, start, end, allDay, type, location, notes, subject, repeat } =
+    (body ?? {}) as Record<string, unknown>;
+
+  if (
+    typeof title !== "string" ||
+    typeof start !== "string" ||
+    typeof end !== "string" ||
+    typeof type !== "string"
+  ) {
     return NextResponse.json({ error: "Pflichtfelder fehlen" }, { status: 400 });
   }
 
-  const dbType = TYPE_TO_DB[type as CalEventType] ?? "SONSTIGES";
+  if (!Object.prototype.hasOwnProperty.call(TYPE_TO_DB, type)) {
+    return NextResponse.json({ error: "Ungültiger Event-Typ" }, { status: 400 });
+  }
+
+  const startsAt = new Date(start);
+  const endsAt = new Date(end);
+  if (
+    Number.isNaN(startsAt.getTime()) ||
+    Number.isNaN(endsAt.getTime()) ||
+    endsAt.getTime() <= startsAt.getTime()
+  ) {
+    return NextResponse.json({ error: "Ungültiger Zeitraum" }, { status: 400 });
+  }
+
+  const repeatRule: RepeatRule =
+    repeat === "daily" || repeat === "weekly" || repeat === "none" ? repeat : "none";
 
   const row = await prisma.calendarEvent.create({
     data: {
-      title: String(title),
-      startsAt: new Date(start),
-      endsAt: new Date(end),
-      allDay: allDay ?? false,
-      type: dbType,
-      location: location ?? null,
-      notes: notes ?? null,
-      subject: subject ?? null,
-      repeat: repeat ?? "none",
+      title: title.trim(),
+      startsAt,
+      endsAt,
+      allDay: allDay === true,
+      type: TYPE_TO_DB[type as CalEventType],
+      location: typeof location === "string" ? location : null,
+      notes: typeof notes === "string" && notes.trim() ? notes : null,
+      subject: typeof subject === "string" ? subject : null,
+      repeat: repeatRule,
       source: "LOCAL",
+      ownerId: session.userId,
     },
   });
 

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import { EventType as DbEventType } from "@prisma/client";
 import type { EventType as CalEventType, RepeatRule } from "@/components/calendar/events";

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -81,7 +81,7 @@ export default function LoginPage() {
       </div>
 
       <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
-        <Suspense>
+        <Suspense fallback={null}>
           <LoginForm />
         </Suspense>
       </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { LoginForm } from "@/components/login/LoginForm";
 import { GraduationCap } from "lucide-react";
 import Image from "next/image";
@@ -80,7 +81,9 @@ export default function LoginPage() {
       </div>
 
       <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
-        <LoginForm />
+        <Suspense>
+          <LoginForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Calendar } from "./Calendar";
 import { CalendarSidebar } from "./CalendarSidebar";
 import { NewEventModal } from "./NewEventModal";
-import { CalEvent } from "./events";
+import { CalEvent, RepeatRule } from "./events";
 import { useExternalEvents } from "@/lib/calendar/useExternalEvents";
 
 type ModalState = {
@@ -13,15 +13,40 @@ type ModalState = {
   defaultEnd?: Date;
 };
 
+function deserializeEvent(raw: Record<string, unknown>): CalEvent {
+  return {
+    ...(raw as Omit<CalEvent, "start" | "end">),
+    start: new Date(raw.start as string),
+    end: new Date(raw.end as string),
+    repeat: (raw.repeat as RepeatRule | undefined) ?? "none",
+  };
+}
+
 export function CalendarPageContent() {
   const [localEvents, setLocalEvents] = useState<CalEvent[]>([]);
   const [modal, setModal] = useState<ModalState>({ open: false });
+  const localEventsRef = useRef(localEvents);
+  localEventsRef.current = localEvents;
+
   const {
     events: externalEvents,
     loading: externalLoading,
     error: externalError,
     refresh: refreshExternal,
   } = useExternalEvents();
+
+  // Lokale Events beim Start aus der DB laden
+  useEffect(() => {
+    fetch("/api/calendar/events")
+      .then((r) => r.json())
+      .then((data) => {
+        const events: CalEvent[] = (data.events as Record<string, unknown>[]).map(
+          deserializeEvent,
+        );
+        setLocalEvents(events);
+      })
+      .catch(() => {/* DB nicht erreichbar → leerer Kalender */});
+  }, []);
 
   function openModal(defaults?: { start?: Date; end?: Date }) {
     setModal({
@@ -35,13 +60,66 @@ export function CalendarPageContent() {
     setModal({ open: false });
   }
 
+  async function handleCreate(ev: CalEvent) {
+    try {
+      const res = await fetch("/api/calendar/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: ev.title,
+          start: ev.start.toISOString(),
+          end: ev.end.toISOString(),
+          allDay: ev.allDay ?? false,
+          type: ev.type,
+          location: ev.location,
+          notes: ev.notes,
+          subject: ev.subject,
+          repeat: ev.repeat ?? "none",
+        }),
+      });
+      const data = await res.json();
+      // Ersetze temporäre local-ID mit echter DB-ID
+      const saved = deserializeEvent(data.event as Record<string, unknown>);
+      setLocalEvents((prev) => [...prev, saved]);
+    } catch {
+      // Fallback: Event nur lokal halten wenn DB nicht erreichbar
+      setLocalEvents((prev) => [...prev, ev]);
+    }
+  }
+
+  async function handleEventsChange(newEvents: CalEvent[]) {
+    // Geändertes Event durch Drag-Move/Resize finden und in DB persistieren
+    const prev = localEventsRef.current;
+    const changed = newEvents.find((ne) => {
+      const old = prev.find((e) => e.id === ne.id);
+      return (
+        old &&
+        (old.start.getTime() !== ne.start.getTime() ||
+          old.end.getTime() !== ne.end.getTime())
+      );
+    });
+
+    setLocalEvents(newEvents);
+
+    if (changed && !changed.id.startsWith("local-")) {
+      fetch(`/api/calendar/events/${changed.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          start: changed.start.toISOString(),
+          end: changed.end.toISOString(),
+        }),
+      }).catch(() => {/* Drag-Update gescheitert, UI-State bleibt */});
+    }
+  }
+
   return (
     <div className="flex h-full overflow-hidden">
       {/* Kalender-Hauptbereich */}
       <div className="flex-1 p-6 overflow-hidden">
         <Calendar
           localEvents={localEvents}
-          onLocalEventsChange={setLocalEvents}
+          onLocalEventsChange={handleEventsChange}
           onRequestCreate={openModal}
           externalEvents={externalEvents}
           externalLoading={externalLoading}
@@ -59,7 +137,7 @@ export function CalendarPageContent() {
         defaultStart={modal.defaultStart}
         defaultEnd={modal.defaultEnd}
         blockedEvents={externalEvents}
-        onCreate={(ev) => setLocalEvents((prev) => [...prev, ev])}
+        onCreate={handleCreate}
       />
     </div>
   );

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -89,28 +89,55 @@ export function CalendarPageContent() {
   }
 
   async function handleEventsChange(newEvents: CalEvent[]) {
-    // Geändertes Event durch Drag-Move/Resize finden und in DB persistieren
     const prev = localEventsRef.current;
+
+    const removed = prev.filter((e) => !newEvents.some((ne) => ne.id === e.id));
     const changed = newEvents.find((ne) => {
       const old = prev.find((e) => e.id === ne.id);
       return (
         old &&
         (old.start.getTime() !== ne.start.getTime() ||
-          old.end.getTime() !== ne.end.getTime())
+          old.end.getTime() !== ne.end.getTime() ||
+          old.title !== ne.title ||
+          (old.allDay ?? false) !== (ne.allDay ?? false) ||
+          (old.type ?? null) !== (ne.type ?? null) ||
+          (old.location ?? null) !== (ne.location ?? null) ||
+          (old.notes ?? null) !== (ne.notes ?? null) ||
+          (old.subject ?? null) !== (ne.subject ?? null) ||
+          (old.repeat ?? "none") !== (ne.repeat ?? "none"))
       );
     });
 
     setLocalEvents(newEvents);
 
+    // Löschungen persistieren
+    removed
+      .filter((e) => !e.id.startsWith("local-"))
+      .forEach((e) => {
+        fetch(`/api/calendar/events/${e.id}`, { method: "DELETE" }).catch(() => {
+          /* Delete gescheitert, UI-State bleibt */
+        });
+      });
+
+    // Änderungen persistieren (Drag + Edit-Modal)
     if (changed && !changed.id.startsWith("local-")) {
       fetch(`/api/calendar/events/${changed.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          title: changed.title,
           start: changed.start.toISOString(),
           end: changed.end.toISOString(),
+          allDay: changed.allDay ?? false,
+          type: changed.type,
+          location: changed.location,
+          notes: changed.notes,
+          subject: changed.subject,
+          repeat: changed.repeat ?? "none",
         }),
-      }).catch(() => {/* Drag-Update gescheitert, UI-State bleibt */});
+      }).catch(() => {
+        /* Update gescheitert, UI-State bleibt */
+      });
     }
   }
 

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -62,6 +62,9 @@ export function CalendarPageContent() {
   }
 
   async function handleCreate(ev: CalEvent) {
+    // Optimistic: sofort im UI anzeigen
+    setLocalEvents((prev) => [...prev, ev]);
+
     try {
       const res = await fetch("/api/calendar/events", {
         method: "POST",
@@ -78,13 +81,22 @@ export function CalendarPageContent() {
           repeat: ev.repeat ?? "none",
         }),
       });
-      const data = await res.json();
-      // Ersetze temporäre local-ID mit echter DB-ID
-      const saved = deserializeEvent(data.event as Record<string, unknown>);
-      setLocalEvents((prev) => [...prev, saved]);
+
+      const data = (await res.json().catch(() => null)) as
+        | { event?: Record<string, unknown>; error?: string }
+        | null;
+
+      if (!res.ok || !data?.event) {
+        throw new Error(data?.error ?? "Event konnte nicht gespeichert werden.");
+      }
+
+      const saved = deserializeEvent(data.event);
+      // Ersetze optimistisch eingefügtes local-Event mit der DB-Version (ohne lokale Änderungen zu überschreiben)
+      setLocalEvents((prev) =>
+        prev.map((e) => (e.id === ev.id ? { ...saved, ...e, id: saved.id } : e)),
+      );
     } catch {
-      // Fallback: Event nur lokal halten wenn DB nicht erreichbar
-      setLocalEvents((prev) => [...prev, ev]);
+      // Fallback: Optimistic-Event bleibt lokal erhalten (DB nicht erreichbar / Fehler)
     }
   }
 

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -38,14 +38,15 @@ export function CalendarPageContent() {
   // Lokale Events beim Start aus der DB laden
   useEffect(() => {
     fetch("/api/calendar/events")
-      .then((r) => r.json())
-      .then((data) => {
-        const events: CalEvent[] = (data.events as Record<string, unknown>[]).map(
-          deserializeEvent,
-        );
+      .then(async (r) => {
+        if (!r.ok) throw new Error("Failed to load events");
+        const data = (await r.json()) as { events?: Record<string, unknown>[] };
+        const events: CalEvent[] = (data.events ?? []).map(deserializeEvent);
         setLocalEvents(events);
       })
-      .catch(() => {/* DB nicht erreichbar → leerer Kalender */});
+      .catch(() => {
+        /* DB nicht erreichbar/keine Berechtigung → leerer Kalender */
+      });
   }, []);
 
   function openModal(defaults?: { start?: Date; end?: Date }) {


### PR DESCRIPTION
## Summary

- Kalender-Events werden beim Anlegen in der DB gespeichert und beim nächsten Seitenaufruf automatisch geladen
- Drag-Move und Drag-Resize werden ebenfalls in der DB persistiert (PATCH)
- Schema um `notes`, `subject`, `repeat` erweitert; `ownerId` optional (Auth folgt in separatem PR)

## Änderungen

**Prisma Schema & Migration**
- `CalendarEvent` um `notes?`, `subject?`, `repeat?` erweitert
- `ownerId` auf optional gesetzt (`String?`), Relation auf `SetNull` geändert

**Neue API Routes**
- `GET /api/calendar/events` — alle lokalen Events aus DB laden
- `POST /api/calendar/events` — neues Event speichern, gibt DB-ID zurück
- `PATCH /api/calendar/events/[id]` — Start/End nach Drag aktualisieren
- `DELETE /api/calendar/events/[id]` — Event löschen

**CalendarPageContent**
- `useEffect` lädt Events beim Mount aus der DB
- `handleCreate` postet zur API, ersetzt temporäre `local-xxx`-ID mit echter DB-ID
- `handleEventsChange` erkennt Drag-Änderungen und patcht automatisch

**Bugfix**
- `LoginForm` in `<Suspense>` gewrappt (`useSearchParams` requirement)

## Test plan

- [ ] Neues Event anlegen → Seite neu laden → Event ist noch da
- [ ] Event per Drag verschieben → neu laden → neue Position bleibt
- [ ] Mehrere Events anlegen, alle bleiben nach Reload erhalten

🤖 Generated with [Claude Code](https://claude.com/claude-code)