### PR TITLE
chore(ci): GitHub Actions Workflow fuer Lint und Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,7 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          # Dummy-URL damit Prisma Client beim Build-Import nicht abstuerzt.
+          # Es wird keine echte DB-Verbindung aufgebaut.
+          DATABASE_URL: postgresql://ci:ci@localhost:5432/ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [main]
 
+# Least Privilege: CI braucht nur Lesezugriff auf den Repo-Inhalt.
+permissions:
+  contents: read
+
 jobs:
   lint-and-build:
     name: Lint & Build
@@ -27,13 +31,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Dummy-DATABASE_URL fuer prisma generate. Es wird nichts mit der DB gemacht;
-      # die URL wird nur fuer die Schema-Validierung benoetigt.
-      - name: Create dummy .env
-        run: echo "DATABASE_URL=postgresql://ci:ci@localhost:5432/ci" > .env
-
+      # Dummy-DATABASE_URL nur fuer diesen Step. Es wird nichts mit der DB
+      # gemacht; die URL wird nur fuer die Schema-Validierung benoetigt.
       - name: Prisma generate
-        run: npx prisma generate
+        run: npm run prisma:generate
+        env:
+          DATABASE_URL: postgresql://ci:ci@localhost:5432/ci
 
       - name: Lint
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   lint-and-build:
     name: Lint & Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# Loescht broken Builds bevor sie auf main landen.
+# Laeuft auf jedem PR gegen main sowie auf jedem Push auf main (als Safety-Net).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Dummy-DATABASE_URL fuer prisma generate. Es wird nichts mit der DB gemacht;
+      # die URL wird nur fuer die Schema-Validierung benoetigt.
+      - name: Create dummy .env
+        run: echo "DATABASE_URL=postgresql://ci:ci@localhost:5432/ci" > .env
+
+      - name: Prisma generate
+        run: npx prisma generate
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-# Loescht broken Builds bevor sie auf main landen.
+# Verhindert kaputte Builds, bevor sie auf main landen.
 # Laeuft auf jedem PR gegen main sowie auf jedem Push auf main (als Safety-Net).
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Fuegt `.github/workflows/ci.yml` hinzu
- Laeuft auf jedem PR gegen `main` sowie auf jedem Push auf `main`
- Steps: `npm ci` → `prisma generate` (mit Dummy-`DATABASE_URL`) → `npm run lint` → `npm run build`
- Node-Version: `20` (uebernimmt npm-Cache automatisch)
- Timeout: 10 Minuten

## Warum
Stellt sicher, dass kein PR mit kaputtem Build oder Lint-Fehlern auf `main` landen kann.
Bisher konnten Syntax- oder Build-Fehler unbemerkt durchrutschen, weil keine
automatische Pruefung vor dem Merge stattfand.

## Hinweis
Der Workflow ist standardmaessig **nicht als Required Check** konfiguriert.
Damit der Check vor dem Merge erzwungen wird, muesste in
`Settings → Branches → Branch protection rules` fuer `main` die Option
"Require status checks to pass before merging" aktiviert und der
Job `Lint & Build` ausgewaehlt werden. Das kann nach dem Mergen dieses PRs
in einem separaten Schritt erfolgen.

## Test plan
- [ ] Action laeuft automatisch auf diesem PR an
- [ ] Pruefen, ob `npm run lint` und `npm run build` durchlaufen
- [ ] Nach Merge: Settings → Branch protection → Required check aktivieren