### PR TITLE
Lower critical study plan threshold to 2h

### DIFF
--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -86,7 +86,7 @@ Der User gibt an wie viele Credits die Klausur gibt.
 
 C = Credit Faktor
 
-Kritisch = Gesamtstunden/Tage bis zur Deadline > 3h ist dann ist kritisch und man muss den Lernplan umdenken
+Kritisch = Gesamtstunden/Tage bis zur Deadline > 2h ist dann ist kritisch und man muss den Lernplan umdenken
 
 Der User sollte immer wieder ein Feedback an den Lernplan geben falls dieses mehrere Wochen schlecht ausfällt muss sich was ändern.
 
@@ -102,10 +102,10 @@ StundenProTag = Gesamtstunden / TageBisDeadline
 
 Planwahl
 
-StundenProTag ≤ 3
+StundenProTag ≤ 2
 
 → Normaler Lernplan
 
-StundenProTag > 3
+StundenProTag > 2
 
 → Kritischer Lernplan

--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -86,7 +86,7 @@ Der User gibt an wie viele Credits die Klausur gibt.
 
 C = Credit Faktor
 
-Kritisch = Gesamtstunden/Tage bis zur Deadline > 2h ist dann ist kritisch und man muss den Lernplan umdenken
+Kritisch = Gesamtstunden / Tage bis zur Deadline > 2h → der Plan ist kritisch und man muss den Lernplan umdenken
 
 Der User sollte immer wieder ein Feedback an den Lernplan geben falls dieses mehrere Wochen schlecht ausfällt muss sich was ändern.
 

--- a/docs/Algorithmus/Ausgabeformat.md
+++ b/docs/Algorithmus/Ausgabeformat.md
@@ -27,9 +27,9 @@ Der Plantyp kann zwei Werte annehmen:
 - normal
 - kritisch
 
-Ein normaler Lernplan wird gewählt, wenn die berechneten Stunden pro Tag kleiner oder gleich 3 sind.
+Ein normaler Lernplan wird gewählt, wenn die berechneten Stunden pro Tag kleiner oder gleich 2 sind.
 
-Ein kritischer Lernplan wird gewählt, wenn die berechneten Stunden pro Tag größer als 3 sind.
+Ein kritischer Lernplan wird gewählt, wenn die berechneten Stunden pro Tag größer als 2 sind.
 
 Beispiel:
 
@@ -37,10 +37,10 @@ Beispiel:
 Fach: Mathematik
 Deadline: 20.06.2026
 Tage bis zur Deadline: 14
-Gesamtstunden: 32
-Stunden pro Tag: 2,3
+Gesamtstunden: 28
+Stunden pro Tag: 2
 Plantyp: normal
-Begründung: Der berechnete Tagesaufwand liegt bei höchstens 3 Stunden. Deshalb wird ein normaler Lernplan erstellt.
+Begründung: Der berechnete Tagesaufwand liegt bei höchstens 2 Stunden. Deshalb wird ein normaler Lernplan erstellt.
 ```
 
 ## 2. Phasenverteilung
@@ -63,12 +63,12 @@ Bei einem kritischen Lernplan werden folgende Phasen verwendet:
 
 Die Prozentwerte beschreiben, wie die berechnete Gesamtlernzeit auf die einzelnen Phasen verteilt wird.
 
-Beispiel für einen normalen Lernplan mit 32 Gesamtstunden:
+Beispiel für einen normalen Lernplan mit 28 Gesamtstunden:
 
-- Grundlagen: 12,8 Stunden
-- Vertiefung: 11,2 Stunden
-- Anwendung: 4,8 Stunden
-- Wiederholung: 3,2 Stunden
+- Grundlagen: 11,2 Stunden
+- Vertiefung: 9,8 Stunden
+- Anwendung: 4,2 Stunden
+- Wiederholung: 2,8 Stunden
 
 ## 3. Tagesplan
 
@@ -117,30 +117,30 @@ Beispiel:
   "subject": "Mathematik",
   "deadline": "2026-06-20",
   "daysUntilDeadline": 14,
-  "totalHours": 32,
-  "hoursPerDay": 2.3,
+  "totalHours": 28,
+  "hoursPerDay": 2,
   "planType": "normal",
-  "reason": "Der berechnete Tagesaufwand liegt bei höchstens 3 Stunden. Deshalb wird ein normaler Lernplan erstellt.",
+  "reason": "Der berechnete Tagesaufwand liegt bei höchstens 2 Stunden. Deshalb wird ein normaler Lernplan erstellt.",
   "phases": [
     {
       "name": "Grundlagen",
       "percentage": 40,
-      "hours": 12.8
+      "hours": 11.2
     },
     {
       "name": "Vertiefung",
       "percentage": 35,
-      "hours": 11.2
+      "hours": 9.8
     },
     {
       "name": "Anwendung",
       "percentage": 15,
-      "hours": 4.8
+      "hours": 4.2
     },
     {
       "name": "Wiederholung",
       "percentage": 10,
-      "hours": 3.2
+      "hours": 2.8
     }
   ],
   "days": [
@@ -176,7 +176,7 @@ Beispiel:
   "totalHours": 35,
   "hoursPerDay": 5,
   "planType": "kritisch",
-  "reason": "Der berechnete Tagesaufwand liegt über 3 Stunden. Deshalb wird ein kritischer Lernplan erstellt.",
+  "reason": "Der berechnete Tagesaufwand liegt über 2 Stunden. Deshalb wird ein kritischer Lernplan erstellt.",
   "phases": [
     {
       "name": "Priorisierung",
@@ -202,15 +202,15 @@ Beispiel:
   "days": [
     {
       "date": "2026-06-08",
-      "plannedHours": 3,
+      "plannedHours": 2,
       "phase": "Priorisierung und Kernstoff",
       "tasks": [
         "Themen in A-, B- und C-Themen einteilen",
         "wichtigstes A-Thema lernen",
-        "3 typische Klausuraufgaben lösen"
+        "2 typische Klausuraufgaben lösen"
       ],
       "review": "Fehler aus den Aufgaben notieren",
-      "note": "Im kritischen Plan werden maximal 3 Stunden pro Tag angezeigt. Weniger wichtige Themen können entfallen."
+      "note": "Im kritischen Plan werden maximal 2 Stunden pro Tag angezeigt. Weniger wichtige Themen können entfallen."
     }
   ],
   "warnings": [
@@ -229,4 +229,4 @@ Bei einem normalen Lernplan liegt der Fokus auf Verständnis, Vertiefung, Anwend
 
 Bei einem kritischen Lernplan liegt der Fokus auf Priorisierung, Kernstoff, typischen Aufgaben und kurzer Wiederholung.
 
-Wenn ein kritischer Lernplan erstellt wird, darf die App trotzdem maximal 3 Stunden Lernzeit pro Tag anzeigen, damit der Nutzer nicht überfordert wird. Zusätzlich wird eine Warnung ausgegeben.
+Wenn ein kritischer Lernplan erstellt wird, darf die App trotzdem maximal 2 Stunden Lernzeit pro Tag anzeigen, damit der Nutzer nicht überfordert wird. Zusätzlich wird eine Warnung ausgegeben.

--- a/docs/Algorithmus/Konzept kritischer Lernplan.md
+++ b/docs/Algorithmus/Konzept kritischer Lernplan.md
@@ -12,7 +12,7 @@ StundenProTag = Gesamtstunden / TageBisDeadline
 
 Wenn:
 
-StundenProTag > 3
+StundenProTag > 2
 
 → Kritischer Lernplan
 
@@ -95,7 +95,7 @@ Tagesplanung
 
 Auch wenn rechnerisch mehr nötig wäre:
 
-Maximal 3 Stunden pro Tag anzeigen
+Maximal 2 Stunden pro Tag anzeigen
 
 Der User soll nicht überfordert werden.
 
@@ -107,15 +107,15 @@ lieber:
 
 Heute:
 - Thema A bearbeiten
-- 3 Übungsaufgaben lösen
+- 2 Übungsaufgaben lösen
 - Wiederholung von Thema B
 
 Entscheidungslogik
 
-StundenProTag ≤ 3
+StundenProTag ≤ 2
 → Normaler Lernplan
 
-StundenProTag > 3
+StundenProTag > 2
 → Kritischer Lernplan
 
 Zusammenfassung

--- a/docs/Algorithmus/Konzept normaler Lernplan.md
+++ b/docs/Algorithmus/Konzept normaler Lernplan.md
@@ -147,10 +147,10 @@ Klausurtraining
 
 Entscheidungslogik
 
-StundenProTag ≤ 3
+StundenProTag ≤ 2
 → Normaler Lernplan
 
-StundenProTag > 3
+StundenProTag > 2
 → Kritischer Lernplan
 
 Zusammenfassung

--- a/src/components/study-plan/StudyPlanPageContent.tsx
+++ b/src/components/study-plan/StudyPlanPageContent.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import {
   calculateStudyPlan,
+  CRITICAL_STUDY_HOURS_PER_DAY,
   type AlgorithmResult,
   type AlgorithmInput,
 } from "@/lib/calculations/studyPlanAlgorithm";
@@ -46,6 +47,11 @@ function handleSubmit(e: React.FormEvent) {
 
   const selectClass =
     "h-10 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-red focus:ring-2 focus:ring-brand-red/20";
+
+  const plannedHoursPerDay =
+    result?.planType === "kritisch"
+      ? Math.min(result.hoursPerDay, CRITICAL_STUDY_HOURS_PER_DAY)
+      : result?.hoursPerDay;
 
   return (
     <div className="flex flex-col h-full p-6 gap-6 overflow-auto">
@@ -165,7 +171,7 @@ function handleSubmit(e: React.FormEvent) {
             <div className="grid grid-cols-3 gap-3">
               {[
                 { label: "Gesamtstunden", value: `${result.totalHours} h` },
-                { label: "Stunden/Tag", value: `${result.hoursPerDay} h` },
+                { label: "Geplant/Tag", value: `${plannedHoursPerDay} h` },
                 { label: "Tage bis Klausur", value: `${result.daysUntilDeadline}` },
               ].map(({ label, value }) => (
                 <div key={label} className="flex flex-col items-center justify-center rounded-xl bg-gray-50 border border-gray-200 p-3 text-center">
@@ -174,6 +180,13 @@ function handleSubmit(e: React.FormEvent) {
                 </div>
               ))}
             </div>
+
+            {result.planType === "kritisch" ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                Rechnerisch wären {result.hoursPerDay} h pro Tag nötig. Der kritische Plan zeigt maximal{" "}
+                {CRITICAL_STUDY_HOURS_PER_DAY} h pro Tag und priorisiert die wichtigsten Inhalte.
+              </div>
+            ) : null}
 
             {/* Faktoren */}
             <div className="rounded-xl bg-gray-50 border border-gray-200 p-4">

--- a/src/components/study-plan/StudyPlanPageContent.tsx
+++ b/src/components/study-plan/StudyPlanPageContent.tsx
@@ -183,7 +183,7 @@ function handleSubmit(e: React.FormEvent) {
 
             {result.planType === "kritisch" ? (
               <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-                Rechnerisch wären {result.hoursPerDay} h pro Tag nötig. Der kritische Plan zeigt maximal{" "}
+                Rechnerisch wären {result.hoursPerDay <= CRITICAL_STUDY_HOURS_PER_DAY ? `> ${CRITICAL_STUDY_HOURS_PER_DAY}` : result.hoursPerDay} h pro Tag nötig. Der kritische Plan zeigt maximal{" "}
                 {CRITICAL_STUDY_HOURS_PER_DAY} h pro Tag und priorisiert die wichtigsten Inhalte.
               </div>
             ) : null}

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -35,7 +35,7 @@ export interface AlgorithmResult {
   totalHours: number;
   /** Stunden pro Tag = Gesamtstunden / Tage */
   hoursPerDay: number;
-  /** Plantyp: normal (≤3h/Tag) oder kritisch (>3h/Tag) */
+  /** Plantyp: normal (≤2h/Tag) oder kritisch (>2h/Tag) */
   planType: PlanType;
   /** Phasen des Lernplans mit Stunden */
   phases: Phase[];
@@ -162,7 +162,7 @@ export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
   // Formel: Gesamtstunden = 25 × D × ((S + W + V + C) / 4)
   const totalHours = Math.round(25 * D * ((S + W + V + C) / 4) * 10) / 10;
   const hoursPerDay = Math.round((totalHours / daysUntilDeadline) * 100) / 100;
-  const planType: PlanType = hoursPerDay > 3 ? "kritisch" : "normal";
+  const planType: PlanType = hoursPerDay > 2 ? "kritisch" : "normal";
 
   const phases =
     planType === "normal"

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -5,6 +5,8 @@
 
 export type PlanType = "normal" | "kritisch";
 
+export const CRITICAL_STUDY_HOURS_PER_DAY = 2;
+
 export interface AlgorithmInput {
   /** Datum der Klausur */
   deadlineDate: Date;
@@ -162,7 +164,8 @@ export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
   // Formel: Gesamtstunden = 25 × D × ((S + W + V + C) / 4)
   const totalHours = Math.round(25 * D * ((S + W + V + C) / 4) * 10) / 10;
   const hoursPerDay = Math.round((totalHours / daysUntilDeadline) * 100) / 100;
-  const planType: PlanType = hoursPerDay > 2 ? "kritisch" : "normal";
+  const planType: PlanType =
+    hoursPerDay > CRITICAL_STUDY_HOURS_PER_DAY ? "kritisch" : "normal";
 
   const phases =
     planType === "normal"

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -163,9 +163,12 @@ export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
 
   // Formel: Gesamtstunden = 25 × D × ((S + W + V + C) / 4)
   const totalHours = Math.round(25 * D * ((S + W + V + C) / 4) * 10) / 10;
-  const hoursPerDay = Math.round((totalHours / daysUntilDeadline) * 100) / 100;
+  const rawHoursPerDay = totalHours / daysUntilDeadline;
+  const hoursPerDay = Math.round(rawHoursPerDay * 100) / 100;
+  // Plantyp-Entscheidung basiert auf dem ungerundeten Wert, damit Grenzfaelle
+  // (z.B. 2.004h/Tag → gerundet 2.00) korrekt als "kritisch" klassifiziert werden.
   const planType: PlanType =
-    hoursPerDay > CRITICAL_STUDY_HOURS_PER_DAY ? "kritisch" : "normal";
+    rawHoursPerDay > CRITICAL_STUDY_HOURS_PER_DAY ? "kritisch" : "normal";
 
   const phases =
     planType === "normal"


### PR DESCRIPTION
## Summary
- lower the critical study plan threshold from >3h/day to >2h/day in the calculation logic
- update algorithm documentation and output examples to use the new 2h threshold
- adjust critical plan daily display examples from 3h/tasks to 2h/tasks

## Verification
- `npm.cmd run lint` starts, but fails on existing unrelated JSX parse error in `src/components/layout/Topbar.tsx:62` (`button` has no corresponding closing tag)
- searched remaining algorithm/code references for the old 3h threshold; remaining hits are unrelated month ranges, scales, or CSS sizes