### PR TITLE
feat(settings): avatar cropper with zoom and pan

### DIFF
--- a/src/components/settings/AvatarCropperModal.tsx
+++ b/src/components/settings/AvatarCropperModal.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+const PREVIEW_SIZE = 280;
+const OUTPUT_SIZE = 512;
+
+interface AvatarCropperModalProps {
+  file: File;
+  onConfirm: (blob: Blob) => void;
+  onCancel: () => void;
+}
+
+export function AvatarCropperModal({ file, onConfirm, onCancel }: AvatarCropperModalProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const lastPointer = useRef<{ x: number; y: number } | null>(null);
+  const [zoom, setZoom] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      imgRef.current = img;
+      setLoaded(true);
+    };
+    img.src = url;
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const img = imgRef.current;
+    if (!canvas || !img || !loaded) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const baseScale = PREVIEW_SIZE / Math.min(img.naturalWidth, img.naturalHeight);
+    const drawW = img.naturalWidth * baseScale * zoom;
+    const drawH = img.naturalHeight * baseScale * zoom;
+    const drawX = (PREVIEW_SIZE - drawW) / 2 + offset.x;
+    const drawY = (PREVIEW_SIZE - drawH) / 2 + offset.y;
+
+    ctx.clearRect(0, 0, PREVIEW_SIZE, PREVIEW_SIZE);
+    ctx.drawImage(img, drawX, drawY, drawW, drawH);
+  }, [zoom, offset, loaded]);
+
+  function clampOffset(next: { x: number; y: number }, currentZoom: number) {
+    const img = imgRef.current;
+    if (!img) return next;
+    const baseScale = PREVIEW_SIZE / Math.min(img.naturalWidth, img.naturalHeight);
+    const drawW = img.naturalWidth * baseScale * currentZoom;
+    const drawH = img.naturalHeight * baseScale * currentZoom;
+    const maxX = Math.max(0, (drawW - PREVIEW_SIZE) / 2);
+    const maxY = Math.max(0, (drawH - PREVIEW_SIZE) / 2);
+    return {
+      x: Math.max(-maxX, Math.min(maxX, next.x)),
+      y: Math.max(-maxY, Math.min(maxY, next.y)),
+    };
+  }
+
+  function handlePointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    setDragging(true);
+    lastPointer.current = { x: e.clientX, y: e.clientY };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (!dragging || !lastPointer.current) return;
+    const dx = e.clientX - lastPointer.current.x;
+    const dy = e.clientY - lastPointer.current.y;
+    lastPointer.current = { x: e.clientX, y: e.clientY };
+    setOffset((prev) => clampOffset({ x: prev.x + dx, y: prev.y + dy }, zoom));
+  }
+
+  function handlePointerUp() {
+    setDragging(false);
+    lastPointer.current = null;
+  }
+
+  function handleZoomChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newZoom = parseFloat(e.target.value);
+    setZoom(newZoom);
+    setOffset((prev) => clampOffset(prev, newZoom));
+  }
+
+  function handleConfirm() {
+    const img = imgRef.current;
+    if (!img) return;
+
+    const out = document.createElement("canvas");
+    out.width = OUTPUT_SIZE;
+    out.height = OUTPUT_SIZE;
+    const ctx = out.getContext("2d");
+    if (!ctx) return;
+
+    const ratio = OUTPUT_SIZE / PREVIEW_SIZE;
+    const baseScale = PREVIEW_SIZE / Math.min(img.naturalWidth, img.naturalHeight);
+    const drawW = img.naturalWidth * baseScale * zoom * ratio;
+    const drawH = img.naturalHeight * baseScale * zoom * ratio;
+    const drawX = (OUTPUT_SIZE - drawW) / 2 + offset.x * ratio;
+    const drawY = (OUTPUT_SIZE - drawH) / 2 + offset.y * ratio;
+
+    ctx.drawImage(img, drawX, drawY, drawW, drawH);
+    out.toBlob((blob) => { if (blob) onConfirm(blob); }, "image/jpeg", 0.92);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div className="flex w-full max-w-sm flex-col gap-5 rounded-xl border border-gray-200 bg-white p-6 shadow-xl">
+        <div>
+          <h2 className="text-base font-semibold text-gray-950">Profilbild anpassen</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Bild verschieben und zoomen, dann übernehmen.
+          </p>
+        </div>
+
+        <div className="flex justify-center">
+          <div
+            className="overflow-hidden rounded-full ring-2 ring-gray-200"
+            style={{ width: PREVIEW_SIZE, height: PREVIEW_SIZE }}
+          >
+            <canvas
+              ref={canvasRef}
+              width={PREVIEW_SIZE}
+              height={PREVIEW_SIZE}
+              className={dragging ? "cursor-grabbing" : "cursor-grab"}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerLeave={handlePointerUp}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700">Zoom</label>
+          <input
+            type="range"
+            min="1"
+            max="3"
+            step="0.01"
+            value={zoom}
+            onChange={handleZoomChange}
+            className="w-full accent-gray-900"
+          />
+        </div>
+
+        <div className="flex gap-3 border-t border-gray-100 pt-4">
+          <Button type="button" variant="outline" className="flex-1" onClick={onCancel}>
+            Abbrechen
+          </Button>
+          <Button type="button" className="flex-1" onClick={handleConfirm} disabled={!loaded}>
+            Übernehmen
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/AvatarCropperModal.tsx
+++ b/src/components/settings/AvatarCropperModal.tsx
@@ -112,11 +112,17 @@ export function AvatarCropperModal({ file, onConfirm, onCancel }: AvatarCropperM
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      onMouseDown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+      onClick={onCancel}
     >
-      <div className="flex w-full max-w-sm flex-col gap-5 rounded-xl border border-gray-200 bg-white p-6 shadow-xl">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="avatar-cropper-title"
+        className="flex w-full max-w-sm flex-col gap-5 rounded-xl border border-gray-200 bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div>
-          <h2 className="text-base font-semibold text-gray-950">Profilbild anpassen</h2>
+          <h2 id="avatar-cropper-title" className="text-base font-semibold text-gray-950">Profilbild anpassen</h2>
           <p className="mt-1 text-sm text-gray-500">
             Bild verschieben und zoomen, dann übernehmen.
           </p>

--- a/src/components/settings/AvatarCropperModal.tsx
+++ b/src/components/settings/AvatarCropperModal.tsx
@@ -64,6 +64,7 @@ export function AvatarCropperModal({ file, onConfirm, onCancel }: AvatarCropperM
   }
 
   function handlePointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    e.preventDefault();
     setDragging(true);
     lastPointer.current = { x: e.clientX, y: e.clientY };
     e.currentTarget.setPointerCapture(e.pointerId);
@@ -71,6 +72,7 @@ export function AvatarCropperModal({ file, onConfirm, onCancel }: AvatarCropperM
 
   function handlePointerMove(e: React.PointerEvent<HTMLCanvasElement>) {
     if (!dragging || !lastPointer.current) return;
+    e.preventDefault();
     const dx = e.clientX - lastPointer.current.x;
     const dy = e.clientY - lastPointer.current.y;
     lastPointer.current = { x: e.clientX, y: e.clientY };

--- a/src/components/settings/AvatarCropperModal.tsx
+++ b/src/components/settings/AvatarCropperModal.tsx
@@ -147,8 +147,9 @@ export function AvatarCropperModal({ file, onConfirm, onCancel }: AvatarCropperM
         </div>
 
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-gray-700">Zoom</label>
+          <label htmlFor="avatar-zoom" className="text-sm font-medium text-gray-700">Zoom</label>
           <input
+            id="avatar-zoom"
             type="range"
             min="1"
             max="3"

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import type { CurrentUser } from "@/lib/auth/session";
+import { AvatarCropperModal } from "@/components/settings/AvatarCropperModal";
 
 type SettingsCategoryId = "profile" | "notifications" | "calendar";
 
@@ -53,6 +54,7 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   );
   const [avatarError, setAvatarError] = useState<string | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
+  const [cropFile, setCropFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // displayName → Vorname / Nachname aufsplitten
@@ -88,7 +90,6 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
       return;
     }
 
-    // S-4 Fix: MIME- und Größenvalidierung.
     if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
       setAvatarError("Bitte ein PNG-, JPEG- oder WebP-Bild auswählen.");
       event.target.value = "";
@@ -101,32 +102,39 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
       return;
     }
 
-    // Lokale Vorschau sofort anzeigen
+    setCropFile(file);
+  }
+
+  function handleCropConfirm(blob: Blob) {
+    setCropFile(null);
+
     setAvatarPreview((previous) => {
       if (previous && previous.startsWith("blob:")) {
         URL.revokeObjectURL(previous);
       }
-      return URL.createObjectURL(file);
+      return URL.createObjectURL(blob);
     });
 
-    // Hochladen + in DB speichern
     setAvatarUploading(true);
     const formData = new FormData();
-    formData.append("avatar", file);
+    formData.append("avatar", blob, "avatar.jpg");
     fetch("/api/profile/avatar", { method: "POST", body: formData })
       .then(async (res) => {
         if (!res.ok) {
           const body = await res.json().catch(() => ({})) as { error?: string };
           setAvatarError(body.error ?? "Upload fehlgeschlagen.");
         } else {
-          // File-Input leeren damit dieselbe Datei erneut auswählbar ist
           if (fileInputRef.current) fileInputRef.current.value = "";
-          // Sidebar und Layout neu laden damit der neue Avatar sofort erscheint
           router.refresh();
         }
       })
       .catch(() => setAvatarError("Upload fehlgeschlagen. Bitte erneut versuchen."))
       .finally(() => setAvatarUploading(false));
+  }
+
+  function handleCropCancel() {
+    setCropFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   function handleCategoryChange(categoryId: SettingsCategoryId) {
@@ -185,6 +193,14 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
         {activeCategory === "notifications" && <NotificationSettings />}
         {activeCategory === "calendar" && <CalendarSettings />}
       </div>
+
+      {cropFile && (
+        <AvatarCropperModal
+          file={cropFile}
+          onConfirm={handleCropConfirm}
+          onCancel={handleCropCancel}
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Was wurde geändert?

Beim Hochladen eines Profilbilds öffnet sich jetzt ein interaktiver Cropper-Modal, bevor das Bild gespeichert wird.

**Neue Datei:** `src/components/settings/AvatarCropperModal.tsx`
- Canvas-basierter Cropper (keine neue Dependency)
- Bild per Drag verschieben (Pointer Capture, funktioniert auch auf Touch)
- Zoom-Slider von 1× bis 3×; Bild bleibt immer vollständig im Kreisausschnitt (Clamp-Logik)
- Auf „Übernehmen" wird das sichtbare Ausschnitt als 512×512 JPEG (Qualität 0.92) via Canvas exportiert und hochgeladen
- Klick auf den Backdrop oder „Abbrechen" schließt den Modal ohne Upload

**Geändert:** `src/components/settings/SettingsPage.tsx`
- `handleAvatarChange` öffnet nach Validierung nun den Cropper statt direkt hochzuladen
- Neuer `handleCropConfirm(blob)`-Handler übernimmt Preview-Setzung und Upload
- Neuer `handleCropCancel()`-Handler räumt File-Input auf

Außerdem in diesem Branch enthalten: DB-Persistenz für lokale Kalender-Events (`feat(calendar): persist local events to database`).

## Test-Plan

- [ ] Profilbild hochladen → Cropper-Modal öffnet sich
- [ ] Bild per Drag verschieben
- [ ] Zoom-Slider bedienen; Bild verlässt nie den Kreisausschnitt
- [ ] „Übernehmen" → Bild wird in Sidebar und Einstellungen aktualisiert
- [ ] „Abbrechen" → kein Upload, Modal schließt sich
- [ ] Klick auf Backdrop schließt Modal
- [ ] Ungültige Datei (falsches Format / zu groß) → Fehlermeldung, kein Modal
