### PR TITLE
feat(calendar): Typ und Fach als freie Texteingabe mit Vorschlaegen

### DIFF
--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -53,10 +53,9 @@ export async function PATCH(
   if (typeof allDay === "boolean") data.allDay = allDay;
 
   if (typeof type === "string") {
-    if (!Object.prototype.hasOwnProperty.call(TYPE_TO_DB, type)) {
-      return NextResponse.json({ error: "Ungültiger Event-Typ" }, { status: 400 });
-    }
-    data.type = TYPE_TO_DB[type as CalEventType];
+    // Bekannte Typen werden auf den passenden DB-Enum gemappt;
+    // unbekannte Freitext-Typen landen als SONSTIGES.
+    data.type = (TYPE_TO_DB as Record<string, DbEventType>)[type] ?? "SONSTIGES";
   }
 
   if (typeof location === "string") data.location = location;

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -84,9 +84,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Pflichtfelder fehlen" }, { status: 400 });
   }
 
-  if (!Object.prototype.hasOwnProperty.call(TYPE_TO_DB, type)) {
-    return NextResponse.json({ error: "Ungültiger Event-Typ" }, { status: 400 });
-  }
+  // Bekannte Typen werden auf den passenden DB-Enum gemappt;
+  // unbekannte Freitext-Typen landen als SONSTIGES.
+  const dbType: DbEventType =
+    (TYPE_TO_DB as Record<string, DbEventType>)[type] ?? "SONSTIGES";
 
   const startsAt = new Date(start);
   const endsAt = new Date(end);
@@ -107,7 +108,7 @@ export async function POST(req: Request) {
       startsAt,
       endsAt,
       allDay: allDay === true,
-      type: TYPE_TO_DB[type as CalEventType],
+      type: dbType,
       location: typeof location === "string" ? location : null,
       notes: typeof notes === "string" && notes.trim() ? notes : null,
       subject: typeof subject === "string" ? subject : null,

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -5,7 +5,6 @@ import { MapPin, Pencil, Trash2, X } from "lucide-react";
 import {
   CalEvent,
   EVENT_TYPES,
-  EventType,
   RepeatRule,
   SUBJECTS,
   overlapsAnyDhbwEvent,
@@ -50,7 +49,7 @@ export function EventDetailModal({
 
   // Edit-Felder
   const [title, setTitle] = useState("");
-  const [type, setType] = useState<EventType>("Lernsession");
+  const [type, setType] = useState<string>("Lernsession");
   const [subject, setSubject] = useState<string>(SUBJECTS[0].name);
   const [start, setStart] = useState("");
   const [end, setEnd] = useState("");
@@ -305,29 +304,37 @@ export function EventDetailModal({
             <div className="grid grid-cols-2 gap-3">
               <div className="flex flex-col gap-1">
                 <label htmlFor="ed-type" className="text-xs font-semibold text-gray-700">Typ</label>
-                <select
+                <input
                   id="ed-type"
+                  type="text"
+                  list="ed-type-list"
                   value={type}
-                  onChange={(e) => setType(e.target.value as EventType)}
+                  onChange={(e) => setType(e.target.value)}
+                  placeholder="z. B. Sport, Lernsession …"
                   className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
-                >
+                />
+                <datalist id="ed-type-list">
                   {EVENT_TYPES.map((t) => (
-                    <option key={t.name} value={t.name}>{t.name}</option>
+                    <option key={t.name} value={t.name} />
                   ))}
-                </select>
+                </datalist>
               </div>
               <div className="flex flex-col gap-1">
                 <label htmlFor="ed-subject" className="text-xs font-semibold text-gray-700">Fach</label>
-                <select
+                <input
                   id="ed-subject"
+                  type="text"
+                  list="ed-subject-list"
                   value={subject}
                   onChange={(e) => setSubject(e.target.value)}
+                  placeholder="z. B. Sport, Mathematik …"
                   className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
-                >
+                />
+                <datalist id="ed-subject-list">
                   {SUBJECTS.map((s) => (
-                    <option key={s.name} value={s.name}>{s.name}</option>
+                    <option key={s.name} value={s.name} />
                   ))}
-                </select>
+                </datalist>
               </div>
             </div>
 

--- a/src/components/calendar/NewEventModal.tsx
+++ b/src/components/calendar/NewEventModal.tsx
@@ -5,7 +5,6 @@ import { X } from "lucide-react";
 import {
   CalEvent,
   EVENT_TYPES,
-  EventType,
   RepeatRule,
   SUBJECTS,
   overlapsAnyDhbwEvent,
@@ -53,7 +52,7 @@ export function NewEventModal({
     })();
 
   const [title, setTitle] = useState("");
-  const [type, setType] = useState<EventType>("Lernsession");
+  const [type, setType] = useState<string>("Lernsession");
   const [subject, setSubject] = useState<string>(SUBJECTS[0].name);
   const [start, setStart] = useState<string>(toLocalInputValue(initialStart));
   const [end, setEnd] = useState<string>(toLocalInputValue(initialEnd));
@@ -179,36 +178,40 @@ export function NewEventModal({
               <label htmlFor="ev-type" className="text-xs font-semibold text-gray-700">
                 Typ
               </label>
-              <select
+              <input
                 id="ev-type"
+                type="text"
+                list="ev-type-list"
                 value={type}
-                onChange={(e) => setType(e.target.value as EventType)}
+                onChange={(e) => setType(e.target.value)}
+                placeholder="z. B. Sport, Lernsession …"
                 className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
-              >
+              />
+              <datalist id="ev-type-list">
                 {EVENT_TYPES.map((t) => (
-                  <option key={t.name} value={t.name}>
-                    {t.name}
-                  </option>
+                  <option key={t.name} value={t.name} />
                 ))}
-              </select>
+              </datalist>
             </div>
 
             <div className="flex flex-col gap-1">
               <label htmlFor="ev-subject" className="text-xs font-semibold text-gray-700">
                 Fach
               </label>
-              <select
+              <input
                 id="ev-subject"
+                type="text"
+                list="ev-subject-list"
                 value={subject}
                 onChange={(e) => setSubject(e.target.value)}
+                placeholder="z. B. Sport, Mathematik …"
                 className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red bg-white"
-              >
+              />
+              <datalist id="ev-subject-list">
                 {SUBJECTS.map((s) => (
-                  <option key={s.name} value={s.name}>
-                    {s.name}
-                  </option>
+                  <option key={s.name} value={s.name} />
                 ))}
-              </select>
+              </datalist>
             </div>
           </div>
 

--- a/src/components/calendar/events.ts
+++ b/src/components/calendar/events.ts
@@ -41,7 +41,7 @@ export const EVENT_TYPES: { name: EventType; color: string }[] = [
 
 // Layout-Konstanten (müssen mit den Views übereinstimmen)
 export const DAY_START_HOUR = 7;
-export const DAY_END_HOUR = 21; // exclusive Ende → 14 Stunden sichtbar
+export const DAY_END_HOUR = 24; // exclusive Ende → 17 Stunden sichtbar (7–24 Uhr)
 export const HOUR_HEIGHT = 64; // px (= h-16)
 export const SNAP_MIN = 15; // Snap-Raster in Minuten
 export const MIN_EVENT_MIN = 30; // Mindestdauer eines Termins in Minuten

--- a/src/components/calendar/events.ts
+++ b/src/components/calendar/events.ts
@@ -15,7 +15,8 @@ export type CalEvent = {
   readOnly?: boolean;
   location?: string;
   allDay?: boolean;
-  type?: EventType;
+  /** Bekannte Werte: EventType-Konstanten; freie Eingabe ebenfalls erlaubt. */
+  type?: string;
   subject?: string;
   notes?: string;
   repeat?: RepeatRule;


### PR DESCRIPTION
## Was wurde geaendert?

Bei der Erstellung eines neuen Kalender-Termins koennen Typ und Fach jetzt **frei eingetippt** werden. Die bekannten Werte (Lernsession, Klausur, Sport etc.) werden als Vorschlaege per `<datalist>` angeboten, sind aber nicht mehr verpflichtend.

### Aenderungen
- `events.ts`: `CalEvent.type` von `EventType` (strikte Union) auf `string` erweitert
- `NewEventModal.tsx`: `<select>` fuer Typ und Fach jeweils durch `<input list=...>` + `<datalist>` ersetzt
- Import von `EventType` entfernt (nicht mehr benoetigt)

## Beispiel
Ein Termin "Sport" laesst sich jetzt anlegen, ohne dass Sport als fester Typ existiert.