### PR TITLE
docs(study-plan): add scheduling constraints for weekly learning sessions

### DIFF
--- a/docs/study-plan-redesign.md
+++ b/docs/study-plan-redesign.md
@@ -163,7 +163,7 @@ Ein **Modal oder Slide-Over** öffnet sich bei „+ Neuer Lernplan" / „Bearbei
 | **Maximale Häufigkeit** | max. 5 Lerneinheiten pro Woche je Thema |
 | **Einheitsdauer** | 2 h pro Timeslot |
 
-> Der Algorithmus verteilt die berechnete Gesamtstundenzahl so, dass pro Thema **bevorzugt 3–4 Sitzungen à 2 h pro Woche** eingeplant werden. Mehr als **5 Sitzungen pro Woche** sind nicht zulässig, um Überlastung zu vermeiden.
+> Der Algorithmus verteilt die berechnete Gesamtstundenzahl so, dass pro Thema **bevorzugt 3–4 Lerneinheiten à 2 h pro Woche** eingeplant werden. Mehr als **5 Lerneinheiten pro Woche** sind nicht zulässig, um Überlastung zu vermeiden.
 
 ---
 

--- a/docs/study-plan-redesign.md
+++ b/docs/study-plan-redesign.md
@@ -155,6 +155,16 @@ Ein **Modal oder Slide-Over** öffnet sich bei „+ Neuer Lernplan" / „Bearbei
 
 > Wenn Seiten und ECTS angegeben → Algorithmus wird direkt beim Speichern berechnet und das Ergebnis gespeichert.
 
+### Scheduling-Constraints (Lerneinheiten pro Woche)
+
+| Constraint | Wert |
+|------------|------|
+| **Ziel-Häufigkeit** | 3–4 Lerneinheiten pro Woche je Thema |
+| **Maximale Häufigkeit** | max. 5 Lerneinheiten pro Woche je Thema |
+| **Einheitsdauer** | 2 h pro Timeslot |
+
+> Der Algorithmus verteilt die berechnete Gesamtstundenzahl so, dass pro Thema **bevorzugt 3–4 Sitzungen à 2 h pro Woche** eingeplant werden. Mehr als **5 Sitzungen pro Woche** sind nicht zulässig, um Überlastung zu vermeiden.
+
 ---
 
 ## 6. API-Routen (zu implementieren)


### PR DESCRIPTION
## Änderung

Ergänzt in `docs/study-plan-redesign.md` (Abschnitt 5) eine neue Untersektion **„Scheduling-Constraints"**, die die Anforderungen an die Verteilung von Lerneinheiten pro Woche festlegt.

### Neue Constraints

| Constraint | Wert |
|------------|------|
| Ziel-Häufigkeit | 3–4 Lerneinheiten pro Woche je Thema |
| Maximale Häufigkeit | max. 5 Lerneinheiten pro Woche je Thema |
| Einheitsdauer | 2 h pro Timeslot |

Diese Vorgaben dienen als Grundlage für die Algorithmus-Implementierung beim Planen von Lernplänen.