### PR TITLE
feat(auth): password visibility toggle in login & register

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Eye, EyeOff } from "lucide-react";
 
 export function LoginForm() {
   const router = useRouter();
@@ -16,6 +17,7 @@ export function LoginForm() {
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -93,16 +95,27 @@ export function LoginForm() {
           >
             Passwort
           </Label>
-          <Input
-            id="password"
-            type="password"
-            placeholder="Mindestens 8 Zeichen"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="current-password"
-            className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
-          />
+          <div className="relative">
+            <Input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              placeholder="Mindestens 8 Zeichen"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+              className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              tabIndex={-1}
+              aria-label={showPassword ? "Passwort verbergen" : "Passwort anzeigen"}
+            >
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
         </div>
 
         {/* 3. Zusatzoptionen */}

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -110,7 +110,7 @@ export function LoginForm() {
               type="button"
               onClick={() => setShowPassword((v) => !v)}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-              tabIndex={-1}
+              aria-pressed={showPassword}
               aria-label={showPassword ? "Passwort verbergen" : "Passwort anzeigen"}
             >
               {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Eye, EyeOff } from "lucide-react";
 
 export function RegisterForm() {
   const router = useRouter();
@@ -14,6 +15,7 @@ export function RegisterForm() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -103,17 +105,28 @@ export function RegisterForm() {
           >
             Passwort
           </Label>
-          <Input
-            id="password"
-            type="password"
-            placeholder="Mindestens 8 Zeichen"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="new-password"
-            minLength={8}
-            className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red"
-          />
+          <div className="relative">
+            <Input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              placeholder="Mindestens 8 Zeichen"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="new-password"
+              minLength={8}
+              className="h-11 w-full border-gray-200 bg-white placeholder:text-gray-400 focus-visible:ring-brand-red pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              tabIndex={-1}
+              aria-label={showPassword ? "Passwort verbergen" : "Passwort anzeigen"}
+            >
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
         </div>
 
         {/* Fehler-Anzeige */}

--- a/src/components/register/RegisterForm.tsx
+++ b/src/components/register/RegisterForm.tsx
@@ -121,7 +121,7 @@ export function RegisterForm() {
               type="button"
               onClick={() => setShowPassword((v) => !v)}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
-              tabIndex={-1}
+              aria-pressed={showPassword}
               aria-label={showPassword ? "Passwort verbergen" : "Passwort anzeigen"}
             >
               {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}


### PR DESCRIPTION
## Summary

- Passwortfeld im Login-Formular erhaelt einen Toggle-Button (Eye/EyeOff) am rechten Rand
- Passwortfeld im Registrierungs-Formular erhaelt denselben Toggle-Button
- Einmal klicken: Passwort sichtbar; nochmal klicken: wieder verborgen (Punkte)

## Test plan

- Login-Seite oeffnen, Passwort eintippen, Toggle anklicken, Text sichtbar
- Nochmals anklicken, wieder Punkte
- Registrierungs-Seite: identisches Verhalten pruefen
- Sicherstellen, dass Enter/Submit nicht durch den Button ausgeloest wird (type=button)

Generated with Claude Code