### PR TITLE
feat: npm run setup fuer automatisiertes Lokalsetup

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -108,6 +108,8 @@ npm install
 
 **Was passiert:** Alle Bibliotheken aus `package.json` werden in den Ordner `node_modules/` geladen. Dauert beim ersten Mal 1-2 Minuten. Identisch auf allen Systemen.
 
+> **Shortcut fuer Eilige:** Die Schritte 3-5 (`.env` anlegen, DB starten, Prisma) gibt's auch als ein einzelner Befehl: `npm run setup`. Schritt 6 (`npm run dev`) startest du danach selbst. Die ausfuehrliche Anleitung unten bleibt hilfreich, falls beim Skript etwas nicht klappt.
+
 ### Schritt 3: Umgebungsvariablen vorbereiten
 
 **Was passiert:** Eine Vorlage wird in eine echte Konfigurationsdatei kopiert. In `.env` steht z. B. die Verbindungs-URL zur Datenbank. Die Datei ist absichtlich in `.gitignore` und landet nicht in GitHub.

--- a/SETUP.md
+++ b/SETUP.md
@@ -108,7 +108,7 @@ npm install
 
 **Was passiert:** Alle Bibliotheken aus `package.json` werden in den Ordner `node_modules/` geladen. Dauert beim ersten Mal 1-2 Minuten. Identisch auf allen Systemen.
 
-> **Shortcut fuer Eilige:** Die Schritte 3-5 (`.env` anlegen, DB starten, Prisma) gibt's auch als ein einzelner Befehl: `npm run setup`. Schritt 6 (`npm run dev`) startest du danach selbst. Die ausfuehrliche Anleitung unten bleibt hilfreich, falls beim Skript etwas nicht klappt.
+> **Shortcut fuer Eilige:** Die Schritte 3-5 (`.env` anlegen, DB starten, Prisma) gibt's auch als einzelnen Befehl: `npm run setup`. Schritt 6 (`npm run dev`) startest du danach selbst. Die ausfuehrliche Anleitung unten bleibt hilfreich, falls beim Skript etwas nicht klappt.
 
 ### Schritt 3: Umgebungsvariablen vorbereiten
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint .",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev"
+    "prisma:migrate": "prisma migrate dev",
+    "setup": "node scripts/setup.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Automatisiert das lokale Setup: .env anlegen, Docker-DB hochfahren,
+// Prisma-Migrationen anwenden und Client generieren.
+//
+// Aufruf: npm run setup
+//
+// Was bewusst NICHT passiert:
+//   - npm install (muss vorher gelaufen sein, sonst gaebe es dieses Skript nicht)
+//   - npm run dev (long-running, soll der User selbst starten)
+//   - .env ueberschreiben (Custom-Werte sollen nicht verloren gehen)
+
+import { existsSync, copyFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+const step = (msg) => console.log(`\n→ ${msg}`);
+const done = (msg) => console.log(`  ✓ ${msg}`);
+const fail = (msg) => {
+  console.error(`\n✗ ${msg}`);
+  process.exit(1);
+};
+
+const run = (cmd) => {
+  try {
+    execSync(cmd, { stdio: "inherit" });
+  } catch {
+    fail(`Befehl fehlgeschlagen: ${cmd}`);
+  }
+};
+
+// 1. .env anlegen, falls nicht vorhanden
+step(".env pruefen");
+if (existsSync(".env")) {
+  done(".env existiert bereits — uebersprungen");
+} else {
+  if (!existsSync(".env.example")) {
+    fail(".env.example nicht gefunden — bist du im Projekt-Root?");
+  }
+  copyFileSync(".env.example", ".env");
+  done(".env aus .env.example angelegt");
+}
+
+// 2. Docker-DB hochfahren (--wait blockiert bis Healthcheck gruen ist)
+step("Docker-Datenbank starten");
+run("docker compose up -d --wait");
+done("Datenbank laeuft");
+
+// 3. Prisma-Migrationen anwenden
+step("Prisma-Migrationen anwenden");
+run("npm run prisma:migrate");
+done("Schema synchronisiert");
+
+// 4. Prisma-Client generieren
+step("Prisma-Client generieren");
+run("npm run prisma:generate");
+done("Client generiert");
+
+console.log("\nFertig. Jetzt: npm run dev");


### PR DESCRIPTION
## Summary
- Neues Skript `scripts/setup.mjs` + `npm run setup`
- Fasst die Standard-Setup-Schritte (3-5 in SETUP.md) zu einem Befehl zusammen
- SETUP.md bekommt einen kurzen Shortcut-Hinweis, die ausfuehrlichen Schritte bleiben erhalten

## Hintergrund
Aufgegriffen aus dem Review von #89 — Vorschlag, die Standard-Commands in einem Skript zusammenzufassen, damit man als Dev oder neuer User nicht alle Befehle einzeln tippen muss.

## Was das Skript macht
1. `.env` aus `.env.example` anlegen — **nur wenn `.env` noch nicht existiert** (Custom-Werte werden nicht ueberschrieben)
2. `docker compose up -d --wait` — wartet auf den in `docker-compose.yml` definierten Healthcheck, also kein eigenes Polling/Sleep
3. `npm run prisma:migrate`
4. `npm run prisma:generate`

## Was das Skript bewusst NICHT macht
| Schritt | Warum nicht |
|---|---|
| `npm install` | Muss vorher laufen, damit das Skript ueberhaupt existiert |
| `npm run dev` | Long-running, soll der User selbst starten |
| `.env` ueberschreiben | Wuerde Custom-Configs zerstoeren |
| `git clone` | Repo ist ja schon da, wenn das Skript existiert |

## Warum Node-Skript statt Bash
- Laeuft plattformuebergreifend — auch auf Windows ohne Git Bash
- Node ist sowieso Voraussetzung, keine neuen Dependencies
- Kein doppelter Pflegestand (`setup.sh` + `setup.ps1`)

## Test plan
- [x] `npm run lint` clean
- [x] Skript laeuft lokal: `.env`-Check wirkt idempotent, Docker-Phase startet sauber
- [x] Skript bricht mit klarer Fehlermeldung ab, wenn Docker nicht laeuft
- [ ] Auf Windows getestet (PowerShell oder cmd, einmal durchgespielt)
- [ ] Auf frischem Checkout durchgespielt (ohne vorhandene `.env`, ohne laufenden Container)