### PR TITLE
Kalenderfilter und Live-Zeitanzeige verbessern

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  ChevronLeft,
-  ChevronRight,
-  RefreshCw,
-  Search,
-  X,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { MonthView } from "./MonthView";
 import { WeekView } from "./WeekView";
 import { DayView } from "./DayView";
@@ -33,6 +27,8 @@ interface CalendarProps {
   externalError: string | null;
   refreshExternal: (force?: boolean) => void;
   hiddenSubjects: Set<string>;
+  showImportantOnly: boolean;
+  searchQuery: string;
   typeOptions: string[];
   typeColors: Record<string, string>;
   subjectOptions: string[];
@@ -47,6 +43,8 @@ export function Calendar({
   externalError,
   refreshExternal,
   hiddenSubjects,
+  showImportantOnly,
+  searchQuery,
   typeOptions,
   typeColors,
   subjectOptions,
@@ -54,7 +52,6 @@ export function Calendar({
   const [view, setView] = useState<View>("week");
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedEvent, setSelectedEvent] = useState<CalEvent | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
 
   // Sichtbarer Zeitraum je nach View
   function getViewRange(): { start: Date; end: Date } {
@@ -108,6 +105,7 @@ export function Calendar({
         ev.end.getTime() >= range.start.getTime() &&
         ev.start.getTime() <= range.end.getTime() &&
         (ev.source !== "local" || !ev.subject || !hiddenSubjects.has(ev.subject)) &&
+        (!showImportantOnly || ev.important) &&
         (!normalizedQuery || searchableText.includes(normalizedQuery))
       );
     },
@@ -202,27 +200,6 @@ export function Calendar({
 
         {/* View Toggle */}
         <div className="flex items-center gap-2">
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-            <input
-              type="search"
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Events suchen"
-              aria-label="Kalender durchsuchen"
-              className="w-52 rounded-xl border border-gray-200 bg-gray-50 py-2 pl-9 pr-8 text-sm text-gray-800 outline-none transition-colors placeholder:text-gray-400 focus:border-brand-red focus:bg-white focus:ring-2 focus:ring-brand-red/20"
-            />
-            {searchQuery && (
-              <button
-                type="button"
-                onClick={() => setSearchQuery("")}
-                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-700"
-                aria-label="Suche löschen"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </div>
           <button
             onClick={() => refreshExternal(true)}
             disabled={externalLoading}

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -27,6 +27,8 @@ export function CalendarPageContent() {
   const [hiddenSubjects, setHiddenSubjects] = useState<Set<string>>(
     () => new Set(),
   );
+  const [showImportantOnly, setShowImportantOnly] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [modal, setModal] = useState<ModalState>({ open: false });
   const localEventsRef = useRef(localEvents);
   localEventsRef.current = localEvents;
@@ -227,6 +229,8 @@ export function CalendarPageContent() {
           externalError={externalError}
           refreshExternal={refreshExternal}
           hiddenSubjects={hiddenSubjects}
+          showImportantOnly={showImportantOnly}
+          searchQuery={searchQuery}
           typeOptions={typeOptions}
           typeColors={typeColors}
           subjectOptions={subjectOptions}
@@ -236,11 +240,17 @@ export function CalendarPageContent() {
       {/* Kalender-Seitenleiste (rechts) */}
       <CalendarSidebar
         onNewEvent={() => openModal()}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
         subjects={subjectOptions}
         eventTypes={typeOptions}
         typeColors={typeColors}
         hiddenSubjects={hiddenSubjects}
         onToggleSubject={toggleSubject}
+        showImportantOnly={showImportantOnly}
+        onToggleImportantOnly={() =>
+          setShowImportantOnly((current) => !current)
+        }
       />
 
       <NewEventModal

--- a/src/components/calendar/CalendarSidebar.tsx
+++ b/src/components/calendar/CalendarSidebar.tsx
@@ -1,22 +1,30 @@
-import { Plus, Filter, Lightbulb } from "lucide-react";
+import { Plus, Filter, Lightbulb, Search, Star, X } from "lucide-react";
 import { getEventColor } from "./events";
 
 interface CalendarSidebarProps {
   onNewEvent?: () => void;
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
   subjects: string[];
   eventTypes: string[];
   typeColors: Record<string, string>;
   hiddenSubjects: Set<string>;
   onToggleSubject: (subject: string) => void;
+  showImportantOnly: boolean;
+  onToggleImportantOnly: () => void;
 }
 
 export function CalendarSidebar({
   onNewEvent,
+  searchQuery,
+  onSearchQueryChange,
   subjects,
   eventTypes,
   typeColors,
   hiddenSubjects,
   onToggleSubject,
+  showImportantOnly,
+  onToggleImportantOnly,
 }: CalendarSidebarProps) {
   return (
     <aside
@@ -33,6 +41,28 @@ export function CalendarSidebar({
         Neues Event
       </button>
 
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => onSearchQueryChange(event.target.value)}
+          placeholder="Events suchen"
+          aria-label="Kalender durchsuchen"
+          className="w-full rounded-xl border border-gray-200 bg-white py-2.5 pl-9 pr-9 text-sm text-gray-800 shadow-sm outline-none transition-colors placeholder:text-gray-400 focus:border-brand-red focus:ring-2 focus:ring-brand-red/20"
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => onSearchQueryChange("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            aria-label="Suche löschen"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
       {/* Fächer-Filter */}
       <section
         className="rounded-2xl px-4 py-4 shadow-sm"
@@ -47,6 +77,38 @@ export function CalendarSidebar({
             Fächer-Filter
           </span>
         </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showImportantOnly}
+          onClick={onToggleImportantOnly}
+          className={`mb-3 flex w-full items-center justify-between gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors ${
+            showImportantOnly
+              ? "border-amber-300/80 bg-amber-300/20"
+              : "border-amber-200/25 bg-black/10 hover:bg-amber-300/10"
+          }`}
+        >
+          <span className="flex items-center gap-2 text-sm font-medium text-white">
+            <Star
+              className={`h-4 w-4 text-amber-300 ${
+                showImportantOnly ? "fill-current" : ""
+              }`}
+            />
+            Nur markierte Termine
+          </span>
+          <span
+            className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
+              showImportantOnly ? "bg-amber-400" : "bg-white/25"
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                showImportantOnly ? "translate-x-[18px]" : "translate-x-0.5"
+              }`}
+            />
+          </span>
+        </button>
+        <div className="mb-3 h-px bg-white/15" />
         <ul className="flex flex-col gap-2.5">
           {subjects.map((subject) => {
             const checked = !hiddenSubjects.has(subject);

--- a/src/components/calendar/CalendarSidebar.tsx
+++ b/src/components/calendar/CalendarSidebar.tsx
@@ -90,9 +90,8 @@ export function CalendarSidebar({
         >
           <span className="flex items-center gap-2 text-sm font-medium text-white">
             <Star
-              className={`h-4 w-4 text-amber-300 ${
-                showImportantOnly ? "fill-current" : ""
-              }`}
+              className="h-4 w-4 text-amber-300"
+              fill={showImportantOnly ? "currentColor" : "none"}
             />
             Nur markierte Termine
           </span>

--- a/src/components/calendar/CurrentTimeIndicator.tsx
+++ b/src/components/calendar/CurrentTimeIndicator.tsx
@@ -52,20 +52,31 @@ export function CurrentTimeIndicator({
     >
       {index > 0 && (
         <span
-          className="absolute left-0 top-0 border-t border-dashed border-brand-red/45"
-          style={{ width: `${startPercent}%` }}
+          className="absolute left-0 top-0 border-t border-dashed border-violet-800/45"
+          style={{
+            width: `${startPercent}%`,
+          }}
         />
       )}
       <span
-        className="absolute top-0 h-px bg-brand-red"
+        className="absolute top-0 h-1 -translate-y-1/2 rounded-full bg-white/90"
         style={{
           left: `${startPercent}%`,
           width: `${widthPercent}%`,
         }}
       />
       <span
-        className="absolute top-0 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-brand-red shadow-sm"
-        style={{ left: `${startPercent}%` }}
+        className="absolute top-0 h-0.5 -translate-y-1/2 rounded-full bg-violet-800"
+        style={{
+          left: `${startPercent}%`,
+          width: `${widthPercent}%`,
+        }}
+      />
+      <span
+        className="absolute top-0 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-violet-800 shadow-sm"
+        style={{
+          left: `${startPercent}%`,
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## Zusammenfassung
- verschiebt die Event-Suche aus dem Kalenderkopf in die rechte Seitenleiste
- ergänzt im Fächer-Filter einen hervorgehobenen Filter für markierte Termine
- verbessert die Sichtbarkeit der aktuellen Uhrzeit mit einer dezenten violetten Linie und weißer Kontrastkante

## Tests
- `npm.cmd run lint`
- `npm.cmd run build`