### PR TITLE
feat: persistenten Dark Mode vervollständigen

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,30 +77,30 @@
     --chart-4: oklch(0.371 0 0);
     --chart-5: oklch(0.269 0 0);
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
+    --sidebar: oklch(0.49 0.018 230);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.985 0 0);
+    --sidebar-primary-foreground: oklch(0.205 0 0);
+    --sidebar-accent: oklch(1 0 0 / 12%);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 18%);
     --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
+    --background: oklch(0.21 0.006 250);
     --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
+    --card: oklch(0.255 0.008 250);
     --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
+    --popover: oklch(0.255 0.008 250);
     --popover-foreground: oklch(0.985 0 0);
     --primary: oklch(0.922 0 0);
     --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
+    --secondary: oklch(0.315 0.008 250);
     --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
+    --muted: oklch(0.295 0.008 250);
+    --muted-foreground: oklch(0.72 0.01 250);
+    --accent: oklch(0.319 0.008 250);
     --accent-foreground: oklch(0.985 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --border: oklch(1 0 0 / 10%);
@@ -111,14 +111,27 @@
     --chart-3: oklch(0.439 0 0);
     --chart-4: oklch(0.371 0 0);
     --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
+    --sidebar: oklch(0.23 0.008 250);
     --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary: oklch(0.985 0 0);
     --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent: oklch(1 0 0 / 10%);
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+
+    /* Keep legacy gray utility classes readable until feature screens use semantic tokens. */
+    --color-gray-50: oklch(0.24 0.006 250);
+    --color-gray-100: oklch(0.28 0.007 250);
+    --color-gray-200: oklch(0.34 0.008 250);
+    --color-gray-300: oklch(0.43 0.009 250);
+    --color-gray-400: oklch(0.58 0.01 250);
+    --color-gray-500: oklch(0.7 0.01 250);
+    --color-gray-600: oklch(0.78 0.009 250);
+    --color-gray-700: oklch(0.85 0.007 250);
+    --color-gray-800: oklch(0.92 0.004 250);
+    --color-gray-900: oklch(0.96 0.002 250);
+    --color-gray-950: oklch(0.985 0 0);
 }
 
 @layer base {
@@ -131,4 +144,10 @@
   html {
     @apply font-sans;
     }
+}
+
+@layer utilities {
+  .dark .bg-white {
+    background-color: var(--card);
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,22 @@ import './globals.css'
 import { GeistSans } from "geist/font/sans";
 import { cn } from "@/lib/utils";
 
+const themeInitializationScript = `
+  (() => {
+    try {
+      const storedTheme = localStorage.getItem("learnhub-theme");
+      const theme =
+        storedTheme === "light" || storedTheme === "dark"
+          ? storedTheme
+          : matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+      document.documentElement.classList.toggle("dark", theme === "dark");
+      document.documentElement.style.colorScheme = theme;
+    } catch {}
+  })();
+`;
+
 export const metadata: Metadata = {
   title: 'LearnHub',
   description: 'Klausuren planen, Lernplan generieren, Fortschritt tracken',
@@ -14,7 +30,14 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="de" className={cn("font-sans", GeistSans.variable)}>
+    <html
+      lang="de"
+      className={cn("font-sans", GeistSans.variable)}
+      suppressHydrationWarning
+    >
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitializationScript }} />
+      </head>
       <body>{children}</body>
     </html>
   )

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -12,7 +12,7 @@ export default function NotFound() {
       </div>
       <Link
         href="/dashboard"
-        className="inline-flex h-10 items-center justify-center rounded-md bg-gray-900 px-4 text-sm font-semibold text-white transition-colors hover:bg-gray-800"
+        className="inline-flex h-10 items-center justify-center rounded-md bg-foreground px-4 text-sm font-semibold text-background transition-opacity hover:opacity-90"
       >
         Zurück zum Dashboard
       </Link>

--- a/src/components/calendar/CalendarSidebar.tsx
+++ b/src/components/calendar/CalendarSidebar.tsx
@@ -122,10 +122,10 @@ export function CalendarSidebar({
                   />
                   {/* Custom Checkbox */}
                   <span
-                    className={`flex-shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
+                    className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border-2 transition-colors group-hover:border-white/80 ${
                       checked
-                        ? "bg-white border-white"
-                        : "bg-transparent border-white/40"
+                        ? "border-white bg-[#ffffff] shadow-sm"
+                        : "border-white/45 bg-black/10"
                     }`}
                   >
                     {checked && (
@@ -133,8 +133,8 @@ export function CalendarSidebar({
                         viewBox="0 0 10 8"
                         className="w-2.5 h-2"
                         fill="none"
-                        stroke="#5f6a70"
-                        strokeWidth="2"
+                        stroke="#4b565c"
+                        strokeWidth="2.25"
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >

--- a/src/components/calendar/EditableCombobox.tsx
+++ b/src/components/calendar/EditableCombobox.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Check, ChevronDown, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface EditableComboboxProps {
   id: string;
@@ -64,7 +65,10 @@ export function EditableCombobox({
             setOpen(true);
           }}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 pr-9 text-sm focus:border-brand-red focus:bg-white focus:outline-none focus:ring-2 focus:ring-brand-red/30"
+          className={cn(
+            "w-full rounded-lg border border-gray-300 px-3 py-2 pr-9 text-sm focus:border-brand-red focus:outline-none focus:ring-2 focus:ring-brand-red/30",
+            value.trim() ? "bg-white" : "bg-gray-100 text-gray-500",
+          )}
         />
         <button
           type="button"

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -12,36 +12,28 @@ interface DashboardShellProps {
 
 export function DashboardShell({ children, currentUser }: DashboardShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [darkMode, setDarkMode] = useState(false);
   const sidebarWidth = 260;
 
-  const bg = "#e9e9e9";
-  const contentBg = "#efefef";
-
   return (
-    <div className="flex min-h-screen transition-colors duration-300" style={{ backgroundColor: bg }}>
+    <div className="flex min-h-screen bg-background text-foreground transition-colors duration-300">
       {/* Linke Sidebar – fixed */}
       <div
         className="fixed top-0 left-0 h-screen z-40 transition-all duration-300"
         style={{ width: sidebarOpen ? sidebarWidth : 0, overflow: "hidden" }}
       >
-        <Sidebar darkMode={darkMode} currentUser={currentUser} />
+        <Sidebar currentUser={currentUser} />
       </div>
 
       {/* Rechter Hauptbereich */}
       <div
-        className="flex flex-col flex-1 min-h-screen transition-all duration-300"
-        style={{ marginLeft: sidebarOpen ? sidebarWidth : 0, backgroundColor: contentBg }}
+        className="flex min-h-screen flex-1 flex-col bg-muted/40 transition-[margin,background-color] duration-300"
+        style={{ marginLeft: sidebarOpen ? sidebarWidth : 0 }}
       >
         <Topbar
           sidebarOpen={sidebarOpen}
           onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
-          darkMode={darkMode}
-          onToggleDarkMode={() => setDarkMode(!darkMode)}
         />
-        <div className="flex-1">
-          {children}
-        </div>
+        <div className="flex-1">{children}</div>
       </div>
     </div>
   );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,7 +26,6 @@ const navItems = [
 ];
 
 interface SidebarProps {
-  darkMode?: boolean;
   currentUser?: CurrentUser;
 }
 
@@ -49,17 +48,13 @@ function isActiveLink(currentPath: string, href: string) {
   return currentPath === target || currentPath.startsWith(`${target}/`);
 }
 
-export function Sidebar({ darkMode, currentUser }: SidebarProps) {
+export function Sidebar({ currentUser }: SidebarProps) {
   const pathname = usePathname() ?? "";
-  const bg = darkMode ? "#2a2a2a" : "#5f6a70";
   const displayName = currentUser?.displayName ?? "LearnHub";
   const email = currentUser?.email ?? "";
 
   return (
-    <div
-      className="flex h-full w-full flex-col px-5 py-6 transition-colors duration-300"
-      style={{ backgroundColor: bg }}
-    >
+    <div className="flex h-full w-full flex-col border-r border-sidebar-border bg-sidebar px-5 py-6 text-sidebar-foreground transition-colors duration-300">
       {/* Logo – führt zur Home/Dashboard-Seite */}
       <Link
         href="/dashboard"
@@ -78,10 +73,7 @@ export function Sidebar({ darkMode, currentUser }: SidebarProps) {
       <nav className="flex flex-1 flex-col gap-8">
         {navItems.map(({ section, items }) => (
           <div key={section}>
-            <p
-              className="mb-3 text-xs font-medium uppercase tracking-wider"
-              style={{ color: "#aeb4b8" }}
-            >
+            <p className="mb-3 text-xs font-medium uppercase tracking-wider text-sidebar-foreground/60">
               {section}
             </p>
             <ul className="flex flex-col gap-3">
@@ -109,7 +101,7 @@ export function Sidebar({ darkMode, currentUser }: SidebarProps) {
       </nav>
 
       {/* Trennlinie */}
-      <div className="my-4" style={{ borderTop: "1px solid #7a868c" }} />
+      <div className="my-4 border-t border-sidebar-border" />
 
       {/* User Card – führt zum Profil-Tab in den Einstellungen */}
       <Link
@@ -133,9 +125,7 @@ export function Sidebar({ darkMode, currentUser }: SidebarProps) {
         </div>
         <div className="flex flex-col">
           <span className="text-sm font-semibold text-white">{displayName}</span>
-          <span className="text-xs" style={{ color: "#aeb4b8" }}>
-            {email}
-          </span>
+          <span className="text-xs text-sidebar-foreground/60">{email}</span>
         </div>
       </Link>
     </div>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,25 +1,25 @@
 "use client";
 
-import { Search, PanelLeftClose, PanelLeftOpen, Moon, Sun, LogOut } from "lucide-react";
+import { LogOut, Moon, PanelLeftClose, PanelLeftOpen, Search, Sun } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { useTheme } from "@/lib/useTheme";
 
 interface TopbarProps {
   sidebarOpen: boolean;
   onToggleSidebar: () => void;
-  darkMode: boolean;
-  onToggleDarkMode: () => void;
 }
 
-export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMode }: TopbarProps) {
+export function Topbar({ sidebarOpen, onToggleSidebar }: TopbarProps) {
   const router = useRouter();
+  const { isDark, toggleTheme } = useTheme();
   const [logoutError, setLogoutError] = useState<string | null>(null);
 
   async function handleLogout() {
     try {
-      const res = await fetch("/api/auth/logout", { method: "POST" });
-      if (!res.ok) {
+      const response = await fetch("/api/auth/logout", { method: "POST" });
+      if (!response.ok) {
         setLogoutError("Abmelden fehlgeschlagen. Bitte versuche es erneut.");
         return;
       }
@@ -29,49 +29,52 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
       setLogoutError("Abmelden fehlgeschlagen. Bitte versuche es erneut.");
     }
   }
-  return (
-    <div className="flex flex-col">
-      <div className="flex items-center justify-between px-6 py-4">
 
-        {/* Links: Sidebar-Toggle */}
+  return (
+    <div className="flex flex-col border-b border-border bg-background/85 backdrop-blur-sm">
+      <div className="flex items-center justify-between px-6 py-4">
         <button
+          type="button"
           onClick={onToggleSidebar}
-          className="p-1.5 rounded-lg hover:bg-black/5 transition-colors text-gray-600"
+          className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           title={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
+          aria-label={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
         >
-          {sidebarOpen
-            ? <PanelLeftClose className="w-5 h-5" />
-            : <PanelLeftOpen className="w-5 h-5" />
-          }
+          {sidebarOpen ? (
+            <PanelLeftClose className="h-5 w-5" />
+          ) : (
+            <PanelLeftOpen className="h-5 w-5" />
+          )}
         </button>
 
-        {/* Mitte: Suchfeld */}
-        <div
-          className="flex items-center gap-2 px-4 py-2 rounded-2xl"
-          style={{ backgroundColor: darkMode ? "#4a4a4a" : "#dcdcdc", width: 280 }}
-        >
-          <Search className="w-4 h-4" style={{ color: "#9ca3af" }} />
-          <span className="text-sm" style={{ color: "#9ca3af" }}>Suchen</span>
+        <div className="flex w-[280px] items-center gap-2 rounded-2xl bg-muted px-4 py-2 text-muted-foreground">
+          <Search className="h-4 w-4" />
+          <span className="text-sm">Suchen</span>
         </div>
 
-        {/* Rechts: Dark Mode Toggle + DHBW Icon */}
         <div className="flex items-center gap-3">
           <button
-            onClick={onToggleDarkMode}
-            className="p-1.5 rounded-lg hover:bg-black/5 transition-colors"
-            style={{ color: darkMode ? "#facc15" : "#4b5563" }}
-            title={darkMode ? "Light Mode" : "Dark Mode"}
+            type="button"
+            onClick={toggleTheme}
+            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title={isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
+            aria-label={isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
+            aria-pressed={isDark}
           >
-            {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+            {isDark ? (
+              <Sun className="h-5 w-5 text-amber-400" />
+            ) : (
+              <Moon className="h-5 w-5" />
+            )}
           </button>
           <button
+            type="button"
             onClick={handleLogout}
-            className="p-1.5 rounded-lg hover:bg-black/5 transition-colors"
-            style={{ color: darkMode ? "#f3f4f6" : "#4b5563" }}
+            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title="Abmelden"
             aria-label="Abmelden"
           >
-            <LogOut className="w-5 h-5" />
+            <LogOut className="h-5 w-5" />
           </button>
           <Image
             src="/images/Dhbw_Icon.png"
@@ -83,15 +86,11 @@ export function Topbar({ sidebarOpen, onToggleSidebar, darkMode, onToggleDarkMod
         </div>
       </div>
 
-      {/* Fehler beim Logout */}
       {logoutError && (
-        <div className="px-6 py-2 text-sm text-red-600 bg-red-50 border-b border-red-200">
+        <div className="border-t border-red-200 bg-red-50 px-6 py-2 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
           {logoutError}
         </div>
       )}
-
-      {/* Trennlinie */}
-      <div style={{ borderBottom: "1px solid #cfcfcf" }} />
     </div>
   );
 }

--- a/src/components/notifications/NotificationsPage.tsx
+++ b/src/components/notifications/NotificationsPage.tsx
@@ -263,7 +263,7 @@ export function NotificationsPage() {
           </div>
         </aside>
 
-        <section className="flex min-h-0 flex-col bg-[#f8f8f8]">
+        <section className="flex min-h-0 flex-col bg-gray-50">
           {selectedNotification ? (
             <>
               <div className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4">

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -166,7 +166,7 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
                 className={cn(
                   "inline-flex h-10 items-center gap-2 rounded-md px-4 text-sm font-semibold transition-colors",
                   isActive
-                    ? "bg-gray-900 text-white shadow-sm"
+                    ? "bg-foreground text-background shadow-sm"
                     : "text-gray-600 hover:bg-gray-100 hover:text-gray-950",
                 )}
               >

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -11,8 +11,12 @@ function getSystemTheme(): Theme {
 }
 
 function getStoredTheme(): Theme | null {
-  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-  return storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+  try {
+    const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+  } catch {
+    return null;
+  }
 }
 
 function applyTheme(theme: Theme) {

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "learnhub-theme";
+
+function getSystemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme | null {
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+  return storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    function syncTheme(nextTheme?: Theme) {
+      const resolvedTheme = nextTheme ?? getStoredTheme() ?? getSystemTheme();
+      applyTheme(resolvedTheme);
+      setTheme(resolvedTheme);
+    }
+
+    function handleSystemThemeChange() {
+      if (!getStoredTheme()) {
+        syncTheme(getSystemTheme());
+      }
+    }
+
+    function handleStorageChange(event: StorageEvent) {
+      if (event.key === THEME_STORAGE_KEY) {
+        syncTheme();
+      }
+    }
+
+    syncTheme();
+    mediaQuery.addEventListener("change", handleSystemThemeChange);
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleSystemThemeChange);
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const nextTheme: Theme = document.documentElement.classList.contains("dark")
+      ? "light"
+      : "dark";
+
+    window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    applyTheme(nextTheme);
+    setTheme(nextTheme);
+  }, []);
+
+  return {
+    theme,
+    isDark: theme === "dark",
+    toggleTheme,
+  };
+}

--- a/src/lib/useTheme.ts
+++ b/src/lib/useTheme.ts
@@ -63,7 +63,12 @@ export function useTheme() {
       ? "light"
       : "dark";
 
-    window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    } catch {
+      // Ignore persistence errors (e.g. storage disabled) and still apply the theme.
+    }
+
     applyTheme(nextTheme);
     setTheme(nextTheme);
   }, []);


### PR DESCRIPTION
## Zusammenfassung
- aktiviert den Dark Mode global über die vorhandenen Theme-Variablen
- speichert die Theme-Auswahl und berücksichtigt beim ersten Aufruf die Systempräferenz
- verhindert ein Aufblitzen des falschen Themes beim Laden
- vereinheitlicht App-Shell, Sidebar, Topbar und bestehende Feature-Ansichten
- hellt die Dark-Mode-Palette für bessere Lesbarkeit moderat auf
- korrigiert Fachfilter-Checkboxen sowie Typ-/Fach-Eingabefelder im Kalender
- verbessert Beschriftung und Zustand des Theme-Schalters für Screenreader

## Tests
- `npm.cmd run lint`
- `npm.cmd run build`

Closes #102