### PR TITLE
Benachrichtigungen in der Datenbank speichern

### DIFF
--- a/prisma/migrations/20260611120000_add_notifications/migration.sql
+++ b/prisma/migrations/20260611120000_add_notifications/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('ASSIGNMENT', 'EXAM');
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "subject" TEXT NOT NULL,
+    "course" TEXT NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "description" TEXT NOT NULL,
+    "isUrgent" BOOLEAN NOT NULL DEFAULT false,
+    "isDone" BOOLEAN NOT NULL DEFAULT false,
+    "isArchived" BOOLEAN NOT NULL DEFAULT false,
+    "ownerId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Notification_ownerId_idx" ON "Notification"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "Notification_expiresAt_idx" ON "Notification"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   studyPlans      StudyPlan[]
   calendarEvents  CalendarEvent[]
   calendarSources CalendarSource[]
+  notifications   Notification[]
 }
 
 model Session {
@@ -184,4 +185,34 @@ model CalendarSource {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+// =====================================================================
+// Benachrichtigungen
+// =====================================================================
+
+enum NotificationType {
+  ASSIGNMENT
+  EXAM
+}
+
+model Notification {
+  id          String           @id @default(cuid())
+  type        NotificationType
+  subject     String
+  course      String
+  dueDate     DateTime
+  description String
+  isUrgent    Boolean          @default(false)
+  isDone      Boolean          @default(false)
+  isArchived  Boolean          @default(false)
+  ownerId     String
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  expiresAt   DateTime
+
+  owner User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+
+  @@index([ownerId])
+  @@index([expiresAt])
 }

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { serializeNotification } from "@/lib/notifications/types";
+import { prisma } from "@/lib/prisma";
+
+/** PATCH /api/notifications/[id] - Status einer Benachrichtigung speichern. */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const input = (body ?? {}) as Record<string, unknown>;
+  const data: { isDone?: boolean; isArchived?: boolean } = {};
+  if (typeof input.isDone === "boolean") data.isDone = input.isDone;
+  if (typeof input.isArchived === "boolean") data.isArchived = input.isArchived;
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "Keine Änderungen übergeben." }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const updated = await prisma.notification.updateMany({
+    where: {
+      id,
+      ownerId: session.userId,
+      expiresAt: { gt: new Date() },
+    },
+    data,
+  });
+
+  if (updated.count === 0) {
+    return NextResponse.json(
+      { error: "Benachrichtigung nicht gefunden." },
+      { status: 404 },
+    );
+  }
+
+  const notification = await prisma.notification.findUnique({ where: { id } });
+  if (!notification) {
+    return NextResponse.json(
+      { error: "Benachrichtigung nicht gefunden." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    notification: serializeNotification(notification),
+  });
+}
+
+/** DELETE /api/notifications/[id] - eine Benachrichtigung sofort löschen. */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const deleted = await prisma.notification.deleteMany({
+    where: { id, ownerId: session.userId },
+  });
+
+  if (deleted.count === 0) {
+    return NextResponse.json(
+      { error: "Benachrichtigung nicht gefunden." },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import {
+  isNotificationType,
+  serializeNotification,
+  toDbNotificationType,
+} from "@/lib/notifications/types";
+import { prisma } from "@/lib/prisma";
+
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** GET /api/notifications - aktive Benachrichtigungen des angemeldeten Users. */
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const now = new Date();
+  const [, notifications] = await prisma.$transaction([
+    prisma.notification.deleteMany({
+      where: { expiresAt: { lte: now } },
+    }),
+    prisma.notification.findMany({
+      where: {
+        ownerId: session.userId,
+        expiresAt: { gt: now },
+      },
+      orderBy: [{ isArchived: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
+    }),
+  ]);
+
+  return NextResponse.json({
+    notifications: notifications.map(serializeNotification),
+  });
+}
+
+/** POST /api/notifications - eine Benachrichtigung sieben Tage lang speichern. */
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const data = (body ?? {}) as Record<string, unknown>;
+  const subject = typeof data.subject === "string" ? data.subject.trim() : "";
+  const course = typeof data.course === "string" ? data.course.trim() : "";
+  const description =
+    typeof data.description === "string" ? data.description.trim() : "";
+
+  if (
+    !isNotificationType(data.type) ||
+    !subject ||
+    !course ||
+    !description ||
+    typeof data.dueDate !== "string"
+  ) {
+    return NextResponse.json({ error: "Pflichtfelder fehlen." }, { status: 400 });
+  }
+
+  const dueDate = new Date(data.dueDate);
+  if (Number.isNaN(dueDate.getTime())) {
+    return NextResponse.json({ error: "Ungültiges Fälligkeitsdatum." }, { status: 400 });
+  }
+
+  const createdAt = new Date();
+  const notification = await prisma.notification.create({
+    data: {
+      type: toDbNotificationType(data.type),
+      subject,
+      course,
+      dueDate,
+      description,
+      isUrgent: data.isUrgent === true,
+      ownerId: session.userId,
+      createdAt,
+      expiresAt: new Date(createdAt.getTime() + RETENTION_MS),
+    },
+  });
+
+  return NextResponse.json(
+    { notification: serializeNotification(notification) },
+    { status: 201 },
+  );
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
   const now = new Date();
   const [, notifications] = await prisma.$transaction([
     prisma.notification.deleteMany({
-      where: { expiresAt: { lte: now } },
+      where: { ownerId: session.userId, expiresAt: { lte: now } },
     }),
     prisma.notification.findMany({
       where: {

--- a/src/components/notifications/NotificationsPage.tsx
+++ b/src/components/notifications/NotificationsPage.tsx
@@ -2,154 +2,182 @@
 
 import { useEffect, useMemo, useState } from "react";
 import {
+  AlertCircle,
   Archive,
   ArchiveRestore,
   BookOpen,
   CheckCircle,
-  MoreHorizontal,
   Search,
-  AlertCircle,
+  Trash2,
 } from "lucide-react";
+import type {
+  NotificationDTO,
+  NotificationType,
+} from "@/lib/notifications/types";
 import { cn } from "@/lib/utils";
-
-type NotificationType = "assignment" | "exam";
-
-type Notification = {
-  id: number;
-  type: NotificationType;
-  subject: string;
-  course: string;
-  dueDate: string;
-  description: string;
-  isUrgent: boolean;
-  isDone: boolean;
-  isArchived: boolean;
-};
-
-// NOTE: Mock-Daten – werden später durch /api/notifications ersetzt.
-const initialNotifications: Notification[] = [
-  {
-    id: 1,
-    type: "assignment",
-    subject: "Hausarbeit Mathematik",
-    course: "Mathematik",
-    dueDate: "09. Mai 2026",
-    description: "Abgabe der Hausarbeit zum Thema Differentialrechnung bis 23:59 Uhr",
-    isUrgent: true,
-    isDone: false,
-    isArchived: false,
-  },
-  {
-    id: 2,
-    type: "exam",
-    subject: "Klausur Web Engineering",
-    course: "Web Engineering",
-    dueDate: "15. Mai 2026",
-    description: "Prüfung in Hörsaal 201, 10:00 - 12:00 Uhr",
-    isUrgent: true,
-    isDone: false,
-    isArchived: false,
-  },
-  {
-    id: 3,
-    type: "assignment",
-    subject: "Projekt-Abgabe",
-    course: "Softwareentwicklung",
-    dueDate: "12. Mai 2026",
-    description: "Abgabe des Gruppenprojekts über das Portal",
-    isUrgent: false,
-    isDone: false,
-    isArchived: false,
-  },
-  {
-    id: 4,
-    type: "exam",
-    subject: "Klausur BWL",
-    course: "Betriebswirtschaftslehre",
-    dueDate: "18. Mai 2026",
-    description: "Prüfung in Hörsaal 105, 14:00 - 16:00 Uhr",
-    isUrgent: false,
-    isDone: false,
-    isArchived: false,
-  },
-  {
-    id: 5,
-    type: "assignment",
-    subject: "Übungsaufgaben Blatt 5",
-    course: "Mathematik",
-    dueDate: "07. Mai 2026",
-    description: "Abgabe der Lösungen bis zum Beginn der nächsten Vorlesung",
-    isUrgent: false,
-    isDone: true,
-    isArchived: false,
-  },
-];
 
 const filters = ["Alle", "Offen", "Abgaben", "Klausuren", "Archiviert"] as const;
 type Filter = (typeof filters)[number];
 
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("de-DE", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
 export function NotificationsPage() {
-  const [items, setItems] = useState<Notification[]>(initialNotifications);
+  const [items, setItems] = useState<NotificationDTO[]>([]);
   const [activeFilter, setActiveFilter] = useState<Filter>("Alle");
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedId, setSelectedId] = useState<number | null>(
-    initialNotifications[0]?.id ?? null,
-  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadNotifications() {
+      try {
+        const response = await fetch("/api/notifications", { cache: "no-store" });
+        const data = (await response.json().catch(() => ({}))) as {
+          notifications?: NotificationDTO[];
+          error?: string;
+        };
+
+        if (!response.ok) {
+          throw new Error(data.error ?? "Benachrichtigungen konnten nicht geladen werden.");
+        }
+
+        if (!cancelled) {
+          setItems(data.notifications ?? []);
+          setError(null);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Benachrichtigungen konnten nicht geladen werden.",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    loadNotifications();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const filteredNotifications = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
     return items
-      .filter((n) => {
+      .filter((notification) => {
         switch (activeFilter) {
           case "Abgaben":
-            return n.type === "assignment" && !n.isArchived;
+            return notification.type === "assignment" && !notification.isArchived;
           case "Klausuren":
-            return n.type === "exam" && !n.isArchived;
+            return notification.type === "exam" && !notification.isArchived;
           case "Offen":
-            return !n.isDone && !n.isArchived;
+            return !notification.isDone && !notification.isArchived;
           case "Archiviert":
-            return n.isArchived;
+            return notification.isArchived;
           default:
-            return !n.isArchived;
+            return !notification.isArchived;
         }
       })
-      .filter((n) => {
+      .filter((notification) => {
         if (!term) return true;
         return (
-          n.subject.toLowerCase().includes(term) ||
-          n.course.toLowerCase().includes(term) ||
-          n.description.toLowerCase().includes(term)
+          notification.subject.toLowerCase().includes(term) ||
+          notification.course.toLowerCase().includes(term) ||
+          notification.description.toLowerCase().includes(term)
         );
       });
   }, [items, activeFilter, searchTerm]);
 
-  // N-5 Fix: Wenn die aktuelle Auswahl im neuen Filter nicht mehr enthalten ist,
-  // automatisch den ersten Eintrag selektieren.
   useEffect(() => {
     if (filteredNotifications.length === 0) {
       setSelectedId(null);
       return;
     }
-    if (!filteredNotifications.some((n) => n.id === selectedId)) {
+    if (!filteredNotifications.some((notification) => notification.id === selectedId)) {
       setSelectedId(filteredNotifications[0].id);
     }
   }, [filteredNotifications, selectedId]);
 
   const selectedNotification = useMemo(
-    () => filteredNotifications.find((n) => n.id === selectedId) ?? null,
+    () =>
+      filteredNotifications.find((notification) => notification.id === selectedId) ??
+      null,
     [selectedId, filteredNotifications],
   );
 
-  const toggleDone = (id: number) => {
-    setItems((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, isDone: !n.isDone } : n)),
-    );
+  const updateNotification = async (
+    id: string,
+    changes: Pick<NotificationDTO, "isDone"> | Pick<NotificationDTO, "isArchived">,
+  ) => {
+    setPendingId(id);
+    try {
+      const response = await fetch(`/api/notifications/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(changes),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        notification?: NotificationDTO;
+        error?: string;
+      };
+
+      if (!response.ok || !data.notification) {
+        throw new Error(data.error ?? "Benachrichtigung konnte nicht gespeichert werden.");
+      }
+
+      const savedNotification = data.notification;
+      setItems((previous) =>
+        previous.map((notification) =>
+          notification.id === id ? savedNotification : notification,
+        ),
+      );
+      setError(null);
+    } catch (updateError) {
+      setError(
+        updateError instanceof Error
+          ? updateError.message
+          : "Benachrichtigung konnte nicht gespeichert werden.",
+      );
+    } finally {
+      setPendingId(null);
+    }
   };
 
-  const toggleArchived = (id: number) => {
-    setItems((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, isArchived: !n.isArchived } : n)),
-    );
+  const deleteNotification = async (id: string) => {
+    setPendingId(id);
+    try {
+      const response = await fetch(`/api/notifications/${id}`, { method: "DELETE" });
+      const data = (await response.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) {
+        throw new Error(data.error ?? "Benachrichtigung konnte nicht gelöscht werden.");
+      }
+
+      setItems((previous) =>
+        previous.filter((notification) => notification.id !== id),
+      );
+      setError(null);
+    } catch (deleteError) {
+      setError(
+        deleteError instanceof Error
+          ? deleteError.message
+          : "Benachrichtigung konnte nicht gelöscht werden.",
+      );
+    } finally {
+      setPendingId(null);
+    }
   };
 
   const getTypeIcon = (type: NotificationType) =>
@@ -176,7 +204,7 @@ export function NotificationsPage() {
           <input
             type="search"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(event) => setSearchTerm(event.target.value)}
             placeholder="Benachrichtigungen suchen"
             className="w-full bg-transparent text-sm text-gray-700 placeholder:text-gray-500 focus:outline-none"
           />
@@ -186,7 +214,11 @@ export function NotificationsPage() {
       <div className="grid flex-1 overflow-hidden lg:grid-cols-[360px_minmax(0,1fr)]">
         <aside className="flex min-h-0 flex-col border-b border-gray-200 lg:border-r lg:border-b-0">
           <div className="border-b border-gray-200 px-4 py-3">
-            <div role="tablist" aria-label="Filter" className="flex gap-1 rounded-xl bg-gray-100 p-1">
+            <div
+              role="tablist"
+              aria-label="Filter"
+              className="flex gap-1 rounded-xl bg-gray-100 p-1"
+            >
               {filters.map((filter) => {
                 const isActive = activeFilter === filter;
                 return (
@@ -211,7 +243,13 @@ export function NotificationsPage() {
           </div>
 
           <div className="min-h-0 flex-1 overflow-auto">
-            {filteredNotifications.length === 0 ? (
+            {loading ? (
+              <p className="px-4 py-8 text-center text-sm text-gray-500">
+                Benachrichtigungen werden geladen...
+              </p>
+            ) : error && items.length === 0 ? (
+              <p className="px-4 py-8 text-center text-sm text-red-600">{error}</p>
+            ) : filteredNotifications.length === 0 ? (
               <p className="px-4 py-8 text-center text-sm text-gray-500">
                 Keine Benachrichtigungen gefunden.
               </p>
@@ -253,7 +291,7 @@ export function NotificationsPage() {
                         )}
                       </div>
                       <p className="mt-2 truncate text-sm font-semibold text-gray-800">
-                        Fällig: {notification.dueDate}
+                        Fällig: {formatDate(notification.dueDate)}
                       </p>
                     </div>
                   </button>
@@ -281,7 +319,8 @@ export function NotificationsPage() {
                       {selectedNotification.subject}
                     </h2>
                     <p className="truncate text-sm text-gray-500">
-                      {selectedNotification.course} • {getTypeLabel(selectedNotification.type)}
+                      {selectedNotification.course} ·{" "}
+                      {getTypeLabel(selectedNotification.type)}
                     </p>
                   </div>
                 </div>
@@ -289,8 +328,13 @@ export function NotificationsPage() {
                 <div className="flex items-center gap-1 text-gray-500">
                   <button
                     type="button"
-                    onClick={() => toggleDone(selectedNotification.id)}
-                    className="rounded-lg p-2 transition-colors hover:bg-gray-100"
+                    disabled={pendingId === selectedNotification.id}
+                    onClick={() =>
+                      updateNotification(selectedNotification.id, {
+                        isDone: !selectedNotification.isDone,
+                      })
+                    }
+                    className="rounded-lg p-2 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
                     aria-label={
                       selectedNotification.isDone
                         ? "Als offen markieren"
@@ -306,10 +350,17 @@ export function NotificationsPage() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => toggleArchived(selectedNotification.id)}
-                    className="rounded-lg p-2 transition-colors hover:bg-gray-100"
+                    disabled={pendingId === selectedNotification.id}
+                    onClick={() =>
+                      updateNotification(selectedNotification.id, {
+                        isArchived: !selectedNotification.isArchived,
+                      })
+                    }
+                    className="rounded-lg p-2 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
                     aria-label={
-                      selectedNotification.isArchived ? "Wiederherstellen" : "Archivieren"
+                      selectedNotification.isArchived
+                        ? "Wiederherstellen"
+                        : "Archivieren"
                     }
                   >
                     {selectedNotification.isArchived ? (
@@ -320,32 +371,47 @@ export function NotificationsPage() {
                   </button>
                   <button
                     type="button"
-                    className="rounded-lg p-2 transition-colors hover:bg-gray-100"
-                    aria-label="Mehr Optionen"
+                    disabled={pendingId === selectedNotification.id}
+                    onClick={() => deleteNotification(selectedNotification.id)}
+                    className="rounded-lg p-2 transition-colors hover:bg-gray-100 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Benachrichtigung löschen"
                   >
-                    <MoreHorizontal className="h-4 w-4" />
+                    <Trash2 className="h-4 w-4" />
                   </button>
                 </div>
               </div>
 
               <div className="min-h-0 flex-1 space-y-6 overflow-auto px-6 py-6">
+                {error && (
+                  <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    {error}
+                  </p>
+                )}
                 <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
                   <div className="space-y-4">
                     <div>
-                      <h3 className="mb-2 text-sm font-semibold text-gray-600">Beschreibung</h3>
-                      <p className="text-gray-800">{selectedNotification.description}</p>
+                      <h3 className="mb-2 text-sm font-semibold text-gray-600">
+                        Beschreibung
+                      </h3>
+                      <p className="text-gray-800">
+                        {selectedNotification.description}
+                      </p>
                     </div>
 
                     <div className="border-t border-gray-200 pt-4">
                       <div className="grid grid-cols-2 gap-4">
                         <div>
-                          <p className="text-xs font-medium uppercase text-gray-500">Fällig am</p>
+                          <p className="text-xs font-medium uppercase text-gray-500">
+                            Fällig am
+                          </p>
                           <p className="mt-1 text-lg font-bold text-gray-900">
-                            {selectedNotification.dueDate}
+                            {formatDate(selectedNotification.dueDate)}
                           </p>
                         </div>
                         <div>
-                          <p className="text-xs font-medium uppercase text-gray-500">Status</p>
+                          <p className="text-xs font-medium uppercase text-gray-500">
+                            Status
+                          </p>
                           <p
                             className={cn(
                               "mt-1 text-lg font-bold",
@@ -371,7 +437,9 @@ export function NotificationsPage() {
             </>
           ) : (
             <div className="flex flex-1 items-center justify-center p-6 text-sm text-gray-500">
-              Wähle eine Benachrichtigung aus der Liste aus.
+              {loading
+                ? "Benachrichtigungen werden geladen..."
+                : "Wähle eine Benachrichtigung aus der Liste aus."}
             </div>
           )}
         </section>

--- a/src/components/notifications/NotificationsPage.tsx
+++ b/src/components/notifications/NotificationsPage.tsx
@@ -19,12 +19,14 @@ import { cn } from "@/lib/utils";
 const filters = ["Alle", "Offen", "Abgaben", "Klausuren", "Archiviert"] as const;
 type Filter = (typeof filters)[number];
 
+const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+});
+
 function formatDate(value: string) {
-  return new Intl.DateTimeFormat("de-DE", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-  }).format(new Date(value));
+  return DATE_FORMATTER.format(new Date(value));
 }
 
 export function NotificationsPage() {

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,44 @@
+import type {
+  Notification as DbNotification,
+  NotificationType as DbNotificationType,
+} from "@prisma/client";
+
+export type NotificationType = "assignment" | "exam";
+
+export interface NotificationDTO {
+  id: string;
+  type: NotificationType;
+  subject: string;
+  course: string;
+  dueDate: string;
+  description: string;
+  isUrgent: boolean;
+  isDone: boolean;
+  isArchived: boolean;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export function toDbNotificationType(type: NotificationType): DbNotificationType {
+  return type === "exam" ? "EXAM" : "ASSIGNMENT";
+}
+
+export function isNotificationType(value: unknown): value is NotificationType {
+  return value === "assignment" || value === "exam";
+}
+
+export function serializeNotification(notification: DbNotification): NotificationDTO {
+  return {
+    id: notification.id,
+    type: notification.type === "EXAM" ? "exam" : "assignment",
+    subject: notification.subject,
+    course: notification.course,
+    dueDate: notification.dueDate.toISOString(),
+    description: notification.description,
+    isUrgent: notification.isUrgent,
+    isDone: notification.isDone,
+    isArchived: notification.isArchived,
+    createdAt: notification.createdAt.toISOString(),
+    expiresAt: notification.expiresAt.toISOString(),
+  };
+}


### PR DESCRIPTION
## Zusammenfassung
- entfernt die Dummy-Daten aus der Benachrichtigungsseite
- ergänzt ein benutzerspezifisches Prisma-Modell und authentifizierte CRUD-API-Routen
- persistiert Erledigt- und Archiviert-Status
- löscht Benachrichtigungen nach sieben Tagen beim nächsten API-Abruf automatisch
- ergänzt Lade-, Leer- und Fehlerzustände in der UI

## Tests
- `npm.cmd run prisma:generate`
- `npm.cmd run lint`
- `npx.cmd tsc --noEmit`
- `npm.cmd run build`
- `npx.cmd prisma migrate deploy`
- API-End-to-End-Test: Erstellen, Abrufen, Statusänderung und automatische Löschung abgelaufener Benachrichtigungen