### PR TITLE
Kalender nach Fächern und DHBW-Stundenplan filtern

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -248,6 +248,7 @@ export function Calendar({
           <WeekView
             currentDate={currentDate}
             events={visibleEvents}
+            blockedEvents={externalEvents.filter((e) => e.source === "dhbw")}
             onEventChange={handleEventChange}
             onRequestCreate={onRequestCreate}
             onEventClick={setSelectedEvent}
@@ -256,6 +257,7 @@ export function Calendar({
           <DayView
             currentDate={currentDate}
             events={visibleEvents}
+            blockedEvents={externalEvents.filter((e) => e.source === "dhbw")}
             onEventChange={handleEventChange}
             onRequestCreate={onRequestCreate}
             onEventClick={setSelectedEvent}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -26,6 +26,7 @@ interface CalendarProps {
   externalLoading: boolean;
   externalError: string | null;
   refreshExternal: (force?: boolean) => void;
+  showExternalEvents: boolean;
   hiddenSubjects: Set<string>;
   showImportantOnly: boolean;
   searchQuery: string;
@@ -42,6 +43,7 @@ export function Calendar({
   externalLoading,
   externalError,
   refreshExternal,
+  showExternalEvents,
   hiddenSubjects,
   showImportantOnly,
   searchQuery,
@@ -88,28 +90,29 @@ export function Calendar({
   const range = getViewRange();
   const expandedLocal = expandRecurring(localEvents, range.start, range.end);
   const normalizedQuery = searchQuery.trim().toLocaleLowerCase("de-DE");
-  const visibleEvents: CalEvent[] = [...expandedLocal, ...externalEvents].filter(
-    (ev) => {
-      const searchableText = [
-        ev.title,
-        ev.type,
-        ev.subject,
-        ev.location,
-        ev.notes,
-        ev.tasks,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLocaleLowerCase("de-DE");
-      return (
-        ev.end.getTime() >= range.start.getTime() &&
-        ev.start.getTime() <= range.end.getTime() &&
-        (ev.source !== "local" || !ev.subject || !hiddenSubjects.has(ev.subject)) &&
-        (!showImportantOnly || ev.important) &&
-        (!normalizedQuery || searchableText.includes(normalizedQuery))
-      );
-    },
-  );
+  const visibleEvents: CalEvent[] = [
+    ...expandedLocal,
+    ...(showExternalEvents ? externalEvents : []),
+  ].filter((ev) => {
+    const searchableText = [
+      ev.title,
+      ev.type,
+      ev.subject,
+      ev.location,
+      ev.notes,
+      ev.tasks,
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLocaleLowerCase("de-DE");
+    return (
+      ev.end.getTime() >= range.start.getTime() &&
+      ev.start.getTime() <= range.end.getTime() &&
+      (ev.source !== "local" || !ev.subject || !hiddenSubjects.has(ev.subject)) &&
+      (!showImportantOnly || ev.important) &&
+      (!normalizedQuery || searchableText.includes(normalizedQuery))
+    );
+  });
 
   function handleEventChange(next: CalEvent) {
     if (next.readOnly) return;

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -28,6 +28,7 @@ export function CalendarPageContent() {
     () => new Set(),
   );
   const [showImportantOnly, setShowImportantOnly] = useState(false);
+  const [showExternalEvents, setShowExternalEvents] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [modal, setModal] = useState<ModalState>({ open: false });
   const localEventsRef = useRef(localEvents);
@@ -228,6 +229,7 @@ export function CalendarPageContent() {
           externalLoading={externalLoading}
           externalError={externalError}
           refreshExternal={refreshExternal}
+          showExternalEvents={showExternalEvents}
           hiddenSubjects={hiddenSubjects}
           showImportantOnly={showImportantOnly}
           searchQuery={searchQuery}
@@ -247,6 +249,10 @@ export function CalendarPageContent() {
         typeColors={typeColors}
         hiddenSubjects={hiddenSubjects}
         onToggleSubject={toggleSubject}
+        showExternalEvents={showExternalEvents}
+        onToggleExternalEvents={() =>
+          setShowExternalEvents((current) => !current)
+        }
         showImportantOnly={showImportantOnly}
         onToggleImportantOnly={() =>
           setShowImportantOnly((current) => !current)

--- a/src/components/calendar/CalendarSidebar.tsx
+++ b/src/components/calendar/CalendarSidebar.tsx
@@ -1,4 +1,12 @@
-import { Plus, Filter, Lightbulb, Search, Star, X } from "lucide-react";
+import {
+  CalendarDays,
+  Plus,
+  Filter,
+  Lightbulb,
+  Search,
+  Star,
+  X,
+} from "lucide-react";
 import { getEventColor } from "./events";
 
 interface CalendarSidebarProps {
@@ -10,6 +18,8 @@ interface CalendarSidebarProps {
   typeColors: Record<string, string>;
   hiddenSubjects: Set<string>;
   onToggleSubject: (subject: string) => void;
+  showExternalEvents: boolean;
+  onToggleExternalEvents: () => void;
   showImportantOnly: boolean;
   onToggleImportantOnly: () => void;
 }
@@ -23,6 +33,8 @@ export function CalendarSidebar({
   typeColors,
   hiddenSubjects,
   onToggleSubject,
+  showExternalEvents,
+  onToggleExternalEvents,
   showImportantOnly,
   onToggleImportantOnly,
 }: CalendarSidebarProps) {
@@ -77,6 +89,33 @@ export function CalendarSidebar({
             Fächer-Filter
           </span>
         </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showExternalEvents}
+          onClick={onToggleExternalEvents}
+          className={`mb-3 flex w-full items-center justify-between gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors ${
+            showExternalEvents
+              ? "border-blue-300/80 bg-blue-300/20"
+              : "border-blue-200/25 bg-black/10 hover:bg-blue-300/10"
+          }`}
+        >
+          <span className="flex items-center gap-2 text-sm font-medium text-white">
+            <CalendarDays className="h-4 w-4 text-blue-200" />
+            DHBW-Stundenplan
+          </span>
+          <span
+            className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
+              showExternalEvents ? "bg-blue-400" : "bg-white/25"
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                showExternalEvents ? "translate-x-[18px]" : "translate-x-0.5"
+              }`}
+            />
+          </span>
+        </button>
         <button
           type="button"
           role="switch"

--- a/src/components/calendar/DayView.tsx
+++ b/src/components/calendar/DayView.tsx
@@ -19,6 +19,7 @@ import { useDragCreate } from "./useDragCreate";
 interface DayViewProps {
   currentDate: Date;
   events: CalEvent[];
+  blockedEvents?: CalEvent[];
   onEventChange: (next: CalEvent) => void;
   onRequestCreate?: (defaults: { start: Date; end: Date }) => void;
   onEventClick?: (event: CalEvent) => void;
@@ -29,12 +30,12 @@ const HOURS = Array.from(
   (_, i) => i + DAY_START_HOUR
 );
 
-export function DayView({ currentDate, events, onEventChange, onRequestCreate, onEventClick }: DayViewProps) {
+export function DayView({ currentDate, events, blockedEvents, onEventChange, onRequestCreate, onEventClick }: DayViewProps) {
   const today = new Date();
   const isToday = isSameDay(currentDate, today);
   const totalHeight = HOURS.length * HOUR_HEIGHT;
   const dayEvents = events.filter((e) => !e.allDay && eventOnDay(e, currentDate));
-  const dhbwEvents = events.filter((e) => e.source === "dhbw");
+  const dhbwEvents = (blockedEvents ?? events).filter((e) => e.source === "dhbw");
   const { onColumnMouseDown, preview } = useDragCreate(onRequestCreate, dhbwEvents);
 
   return (

--- a/src/components/calendar/WeekView.tsx
+++ b/src/components/calendar/WeekView.tsx
@@ -20,6 +20,7 @@ import { useDragCreate } from "./useDragCreate";
 interface WeekViewProps {
   currentDate: Date;
   events: CalEvent[];
+  blockedEvents?: CalEvent[];
   onEventChange: (next: CalEvent) => void;
   onRequestCreate?: (defaults: { start: Date; end: Date }) => void;
   onEventClick?: (event: CalEvent) => void;
@@ -30,12 +31,12 @@ const HOURS = Array.from(
   (_, i) => i + DAY_START_HOUR
 );
 
-export function WeekView({ currentDate, events, onEventChange, onRequestCreate, onEventClick }: WeekViewProps) {
+export function WeekView({ currentDate, events, blockedEvents, onEventChange, onRequestCreate, onEventClick }: WeekViewProps) {
   const days = getWeekDays(currentDate);
   const today = new Date();
   const todayIndex = days.findIndex((day) => isSameDay(day, today));
   const totalHeight = HOURS.length * HOUR_HEIGHT;
-  const dhbwEvents = events.filter((e) => e.source === "dhbw");
+  const dhbwEvents = (blockedEvents ?? events).filter((e) => e.source === "dhbw");
   const { onColumnMouseDown, preview } = useDragCreate(onRequestCreate, dhbwEvents);
 
   // Spaltenbreite messen, damit EventBlock weiß, wie viele px = 1 Tag


### PR DESCRIPTION
## Änderungen
- bestehende Fächerauswahl als gemeinsamen Kalenderfilter für Tages-, Wochen-, Monats- und Listenansicht verwendet
- separaten Schalter zum Ein- und Ausblenden des externen DHBW-Stundenplans ergänzt
- externe Termine weiterhin für Kollisionsprüfungen berücksichtigt, auch wenn sie ausgeblendet sind

## Motivation
Beim Filtern nach eigenen Fächern soll insbesondere die Listenansicht nicht durch alle externen Stundenplantermine verlängert werden. Der Stundenplan kann nun unabhängig von den Fachfiltern ausgeblendet werden.

## Validierung
- `npm run lint`
- `npm run build`
- Anwendung antwortet lokal auf `/calendar` mit HTTP 200