### PR TITLE
[codex] Link study sessions with tasks and dashboard

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,7 +1,5 @@
+import { DashboardContent } from "@/components/dashboard/DashboardContent";
+
 export default function DashboardPage() {
-  return (
-    <div className="p-6">
-      {/* Content-Bereich – leerer Wireframe-Platzhalter */}
-    </div>
-  );
+  return <DashboardContent />;
 }

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -149,7 +149,10 @@ export async function PATCH(
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
   }
 
-  const row = await prisma.calendarEvent.findUnique({ where: { id } });
+  const row = await prisma.calendarEvent.findUnique({
+    where: { id },
+    include: { task: { select: { completed: true } } },
+  });
   if (!row) {
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
   }
@@ -186,6 +189,8 @@ export async function PATCH(
       important: row.important,
       repeat: (row.repeat as RepeatRule | null) ?? "none",
       studyPlanId: row.studyPlanId ?? undefined,
+      taskId: row.taskId ?? undefined,
+      taskCompleted: row.task ? row.task.completed : undefined,
     },
   });
 }

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -36,6 +36,7 @@ export async function GET() {
   const rows = await prisma.calendarEvent.findMany({
     where: { source: "LOCAL", ownerId: session.userId },
     orderBy: { startsAt: "asc" },
+    include: { task: { select: { completed: true } } },
   });
 
   const events = rows.map((event) => {
@@ -56,6 +57,8 @@ export async function GET() {
       important: event.important,
       repeat: (event.repeat as RepeatRule | null) ?? "none",
       studyPlanId: event.studyPlanId ?? undefined,
+      taskId: event.taskId ?? undefined,
+      taskCompleted: event.task ? event.task.completed : undefined,
     };
   });
 
@@ -90,6 +93,7 @@ export async function POST(req: Request) {
     important,
     repeat,
     studyPlanId,
+    taskId,
   } = (body ?? {}) as Record<string, unknown>;
   const trimmedTitle = typeof title === "string" ? title.trim() : "";
   const trimmedType = typeof type === "string" ? type.trim() : "";
@@ -141,6 +145,26 @@ export async function POST(req: Request) {
     planId = plan.id;
   }
 
+  // Optionale Task-Verknüpfung (1:1): Aufgabe muss dem User gehören und darf
+  // noch nicht mit einem anderen Termin verknüpft sein.
+  let linkedTask: { id: string; completed: boolean } | null = null;
+  if (typeof taskId === "string" && taskId) {
+    const task = await prisma.task.findFirst({
+      where: { id: taskId, studyPlan: { ownerId: session.userId } },
+      select: { id: true, completed: true, calendarEvent: { select: { id: true } } },
+    });
+    if (!task) {
+      return NextResponse.json({ error: "Aufgabe nicht gefunden." }, { status: 404 });
+    }
+    if (task.calendarEvent) {
+      return NextResponse.json(
+        { error: "Aufgabe ist bereits mit einem Termin verknüpft." },
+        { status: 409 },
+      );
+    }
+    linkedTask = { id: task.id, completed: task.completed };
+  }
+
   const row = await prisma.calendarEvent.create({
     data: {
       title: trimmedTitle,
@@ -159,6 +183,7 @@ export async function POST(req: Request) {
       source: "LOCAL",
       ownerId: session.userId,
       studyPlanId: planId,
+      taskId: linkedTask?.id ?? null,
     },
   });
 
@@ -180,6 +205,8 @@ export async function POST(req: Request) {
       important: row.important,
       repeat: (row.repeat as RepeatRule | null) ?? "none",
       studyPlanId: row.studyPlanId ?? undefined,
+      taskId: row.taskId ?? undefined,
+      taskCompleted: linkedTask ? linkedTask.completed : undefined,
     },
   });
 }

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -33,7 +33,7 @@ async function createMissedSessionNotifications(userId: string, now: Date) {
   if (missed.length === 0) return;
 
   const existing = await prisma.notification.findMany({
-    where: { ownerId: userId, subject: MISSED_SESSION_SUBJECT },
+    where: { ownerId: userId, subject: MISSED_SESSION_SUBJECT, expiresAt: { gt: now } },
     select: { course: true, dueDate: true },
   });
   const seen = new Set(existing.map((n) => `${n.course}|${n.dueDate.getTime()}`));

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -9,6 +9,58 @@ import { prisma } from "@/lib/prisma";
 
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
+const MISSED_SESSION_SUBJECT = "Lernsession nicht abgehakt";
+
+/**
+ * Erzeugt Benachrichtigungen für vergangene, nicht abgehakte Lernsessions
+ * (Kalender-Lerneinheiten mit verknüpfter, offener Lernplan-Aufgabe).
+ * Idempotent: pro Session entsteht höchstens eine Benachrichtigung
+ * (Dedupe über Fach + Endzeitpunkt).
+ */
+async function createMissedSessionNotifications(userId: string, now: Date) {
+  const since = new Date(now.getTime() - RETENTION_MS);
+  const missed = await prisma.calendarEvent.findMany({
+    where: {
+      ownerId: userId,
+      source: "LOCAL",
+      type: "LERNEINHEIT",
+      taskId: { not: null },
+      endsAt: { lt: now, gt: since },
+      task: { is: { completed: false } },
+    },
+    select: { title: true, subject: true, endsAt: true },
+  });
+  if (missed.length === 0) return;
+
+  const existing = await prisma.notification.findMany({
+    where: { ownerId: userId, subject: MISSED_SESSION_SUBJECT },
+    select: { course: true, dueDate: true },
+  });
+  const seen = new Set(existing.map((n) => `${n.course}|${n.dueDate.getTime()}`));
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const toCreate = missed
+    .filter((e) => !seen.has(`${e.subject ?? e.title}|${e.endsAt.getTime()}`))
+    .map((e) => {
+      const d = e.endsAt;
+      const when = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} um ${pad(d.getHours())}:${pad(d.getMinutes())} Uhr`;
+      return {
+        type: "ASSIGNMENT" as const,
+        subject: MISSED_SESSION_SUBJECT,
+        course: e.subject ?? e.title,
+        dueDate: e.endsAt,
+        description:
+          `Deine Lernsession „${e.title}“ (geplant bis ${when}) wurde noch nicht abgehakt. ` +
+          "Hake sie im Kalender ab oder verschiebe sie – der Lernplan ist eine Basis, kein Pflichtprogramm.",
+        ownerId: userId,
+        expiresAt: new Date(e.endsAt.getTime() + RETENTION_MS),
+      };
+    });
+  if (toCreate.length > 0) {
+    await prisma.notification.createMany({ data: toCreate });
+  }
+}
+
 /** GET /api/notifications - aktive Benachrichtigungen des angemeldeten Users. */
 export async function GET() {
   const session = await getSession();
@@ -17,6 +69,9 @@ export async function GET() {
   }
 
   const now = new Date();
+  // Erst fehlende Hinweise zu nicht abgehakten Lernsessions erzeugen,
+  // damit sie direkt in der Antwort enthalten sind.
+  await createMissedSessionNotifications(session.userId, now);
   const [, notifications] = await prisma.$transaction([
     prisma.notification.deleteMany({
       where: { ownerId: session.userId, expiresAt: { lte: now } },

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -33,6 +33,8 @@ interface CalendarProps {
   typeOptions: string[];
   typeColors: Record<string, string>;
   subjectOptions: string[];
+  /** Abhaken einer Lernsession (Events mit verknüpfter Lernplan-Aufgabe). */
+  onToggleTaskCompleted?: (event: CalEvent, completed: boolean) => void;
 }
 
 export function Calendar({
@@ -50,6 +52,7 @@ export function Calendar({
   typeOptions,
   typeColors,
   subjectOptions,
+  onToggleTaskCompleted,
 }: CalendarProps) {
   const [view, setView] = useState<View>("week");
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -276,6 +279,15 @@ export function Calendar({
         onClose={() => setSelectedEvent(null)}
         onSave={handleEventSave}
         onDelete={handleEventDelete}
+        onToggleTaskCompleted={
+          onToggleTaskCompleted
+            ? (ev, completed) => {
+                onToggleTaskCompleted(ev, completed);
+                // Modal zeigt den neuen Status sofort an
+                setSelectedEvent({ ...ev, taskCompleted: completed });
+              }
+            : undefined
+        }
         blockedEvents={externalEvents.filter((e) => e.source === "dhbw")}
         typeOptions={typeOptions}
         typeColors={typeColors}

--- a/src/components/calendar/CalendarPageContent.tsx
+++ b/src/components/calendar/CalendarPageContent.tsx
@@ -150,6 +150,29 @@ export function CalendarPageContent() {
     }
   }
 
+  async function handleToggleTaskCompleted(ev: CalEvent, completed: boolean) {
+    if (!ev.taskId || !ev.studyPlanId) return;
+
+    // Optimistic: Status sofort im UI umschalten
+    setLocalEvents((prev) =>
+      prev.map((e) => (e.id === ev.id ? { ...e, taskCompleted: completed } : e)),
+    );
+
+    try {
+      const res = await fetch(`/api/study-plan/${ev.studyPlanId}/tasks/${ev.taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ completed }),
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      // Fehlgeschlagen → Status zurückdrehen
+      setLocalEvents((prev) =>
+        prev.map((e) => (e.id === ev.id ? { ...e, taskCompleted: !completed } : e)),
+      );
+    }
+  }
+
   async function handleEventsChange(newEvents: CalEvent[]) {
     const prev = localEventsRef.current;
 
@@ -236,6 +259,9 @@ export function CalendarPageContent() {
           typeOptions={typeOptions}
           typeColors={typeColors}
           subjectOptions={subjectOptions}
+          onToggleTaskCompleted={(ev, completed) =>
+            void handleToggleTaskCompleted(ev, completed)
+          }
         />
       </div>
 

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Star } from "lucide-react";
+import { CircleCheckBig, Star } from "lucide-react";
 import {
   CalEvent,
   DAY_START_HOUR,
@@ -248,7 +248,7 @@ export function EventBlock({
           : "transition-[top,height,left,width] duration-150 ease-out"
       } ${isReadOnly ? "ring-1 ring-white/30 opacity-95" : ""} ${
         event.important ? "ring-2 ring-amber-300 ring-offset-1" : ""
-      }`}
+      } ${event.taskCompleted ? "opacity-60" : ""}`}
       style={{
         top: renderTop,
         height: renderHeight,
@@ -270,7 +270,12 @@ export function EventBlock({
           {event.important && (
             <Star className="h-3 w-3 shrink-0" fill="currentColor" />
           )}
-          <span className="truncate">{event.title}</span>
+          {event.taskCompleted && (
+            <CircleCheckBig className="h-3 w-3 shrink-0" />
+          )}
+          <span className={`truncate ${event.taskCompleted ? "line-through" : ""}`}>
+            {event.title}
+          </span>
         </div>
         <div className="opacity-90 leading-tight truncate">
           {formatTime(event.start)} – {formatTime(event.end)}

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import {
   CalendarDays,
+  CircleCheckBig,
   MapPin,
   Pencil,
   Star,
@@ -30,6 +31,8 @@ interface EventDetailModalProps {
   onClose: () => void;
   onSave: (updated: CalEvent) => void;
   onDelete: (id: string) => void;
+  /** Abhaken einer Lernsession (Events mit verknüpfter Lernplan-Aufgabe). */
+  onToggleTaskCompleted?: (event: CalEvent, completed: boolean) => void;
   blockedEvents?: CalEvent[];
   typeOptions: string[];
   typeColors: Record<string, string>;
@@ -61,6 +64,7 @@ export function EventDetailModal({
   onClose,
   onSave,
   onDelete,
+  onToggleTaskCompleted,
   blockedEvents = [],
   typeOptions,
   typeColors,
@@ -305,7 +309,38 @@ export function EventDetailModal({
                   Wichtig
                 </span>
               )}
+              {event.taskCompleted && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-semibold text-green-700">
+                  <CircleCheckBig className="h-3 w-3" />
+                  Erledigt
+                </span>
+              )}
             </div>
+
+            {/* Lernsession abhaken (Events mit verknüpfter Lernplan-Aufgabe) */}
+            {event.taskId && event.studyPlanId && onToggleTaskCompleted && (
+              <button
+                type="button"
+                role="switch"
+                aria-checked={!!event.taskCompleted}
+                onClick={() => onToggleTaskCompleted(event, !event.taskCompleted)}
+                className={`flex items-center justify-between rounded-xl border px-3 py-2.5 text-left transition-colors ${
+                  event.taskCompleted
+                    ? "border-green-300 bg-green-50 text-green-700"
+                    : "border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                <span className="flex items-center gap-2 text-sm font-semibold">
+                  <CircleCheckBig className="h-4 w-4" />
+                  {event.taskCompleted
+                    ? "Lernsession erledigt"
+                    : "Lernsession abhaken"}
+                </span>
+                <span className="text-xs font-medium">
+                  {event.taskCompleted ? "Als offen markieren" : "Als erledigt markieren"}
+                </span>
+              </button>
+            )}
 
             {/* Zeit */}
             <div className="rounded-xl bg-gray-50 px-4 py-3 flex flex-col gap-1">

--- a/src/components/calendar/events.ts
+++ b/src/components/calendar/events.ts
@@ -22,7 +22,16 @@ export type CalEvent = {
   important?: boolean;
   /** Verknüpfter Lernplan (gesetzt bei generierten Lerneinheiten). */
   studyPlanId?: string;
+  /** Verknüpfte Lernplan-Aufgabe (1:1, gesetzt bei generierten Lerneinheiten). */
+  taskId?: string;
+  /** Erledigt-Status der verknüpften Aufgabe (abhakbar im Kalender). */
+  taskCompleted?: boolean;
 };
+
+/** True für Lerneinheiten aus einem Lernplan (abhakbar, Pausenregeln). */
+export function isLernsessionEvent(ev: CalEvent): boolean {
+  return !!ev.studyPlanId || ev.type?.trim().toLocaleLowerCase("de-DE") === "lernsession";
+}
 
 export const TYPE_COLOR_OPTIONS = [
   { name: "Rot", className: "bg-brand-red" },

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  BookOpen,
+  CalendarDays,
+  CircleCheckBig,
+  ClipboardList,
+  Clock,
+} from "lucide-react";
+import { isLernsessionEvent, type CalEvent } from "@/components/calendar/events";
+import type { StudyPlanSummaryDTO } from "@/lib/study-plan/types";
+import { cn } from "@/lib/utils";
+
+type ApiEvent = Omit<CalEvent, "start" | "end"> & { start: string; end: string };
+
+function deserialize(events: ApiEvent[]): CalEvent[] {
+  return events.map((e) => ({ ...e, start: new Date(e.start), end: new Date(e.end) }));
+}
+
+function startOfWeek(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  const wd = out.getDay();
+  out.setDate(out.getDate() - (wd === 0 ? 6 : wd - 1));
+  return out;
+}
+
+function formatDayTime(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const weekdays = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
+  return `${weekdays[d.getDay()]}, ${pad(d.getDate())}.${pad(d.getMonth() + 1)}. · ${pad(d.getHours())}:${pad(d.getMinutes())} Uhr`;
+}
+
+export function DashboardContent() {
+  const [plans, setPlans] = useState<StudyPlanSummaryDTO[]>([]);
+  const [events, setEvents] = useState<CalEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [planRes, eventRes] = await Promise.all([
+          fetch("/api/study-plan"),
+          fetch("/api/calendar/events"),
+        ]);
+        const planData = planRes.ok
+          ? ((await planRes.json()) as { studyPlans?: StudyPlanSummaryDTO[] })
+          : { studyPlans: [] };
+        const eventData = eventRes.ok
+          ? ((await eventRes.json()) as { events?: ApiEvent[] })
+          : { events: [] };
+        if (cancelled) return;
+        setPlans(planData.studyPlans ?? []);
+        setEvents(deserialize(eventData.events ?? []));
+      } catch {
+        // DB nicht erreichbar → leeres Dashboard
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sessions = useMemo(
+    () => events.filter((e) => isLernsessionEvent(e) && e.taskId),
+    [events],
+  );
+
+  const now = useMemo(() => new Date(), []);
+  const weekStart = useMemo(() => startOfWeek(now), [now]);
+
+  const completedSessions = useMemo(
+    () =>
+      sessions
+        .filter((e) => e.taskCompleted)
+        .sort((a, b) => b.start.getTime() - a.start.getTime()),
+    [sessions],
+  );
+  const completedThisWeek = completedSessions.filter(
+    (e) => e.start.getTime() >= weekStart.getTime(),
+  ).length;
+
+  const upcomingSessions = useMemo(
+    () =>
+      sessions
+        .filter((e) => !e.taskCompleted && e.end.getTime() >= now.getTime())
+        .sort((a, b) => a.start.getTime() - b.start.getTime())
+        .slice(0, 5),
+    [sessions, now],
+  );
+
+  const openTaskCount = plans.reduce(
+    (sum, p) => sum + (p.taskCount - p.completedTaskCount),
+    0,
+  );
+
+  if (loading) {
+    return (
+      <div className="flex flex-col p-6 gap-4">
+        <div className="h-8 w-48 rounded-lg bg-gray-100 animate-pulse" />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-24 rounded-2xl bg-gray-100 animate-pulse" />
+          ))}
+        </div>
+        <div className="h-64 rounded-2xl bg-gray-100 animate-pulse" />
+      </div>
+    );
+  }
+
+  const stats = [
+    {
+      label: "Erledigte Lernsessions (diese Woche)",
+      value: completedThisWeek,
+      icon: CircleCheckBig,
+      iconClass: "bg-green-50 text-green-600",
+    },
+    {
+      label: "Offene Aufgaben",
+      value: openTaskCount,
+      icon: ClipboardList,
+      iconClass: "bg-amber-50 text-amber-600",
+    },
+    {
+      label: "Aktive Lernpläne",
+      value: plans.length,
+      icon: BookOpen,
+      iconClass: "bg-blue-50 text-blue-600",
+    },
+  ];
+
+  return (
+    <div className="flex flex-col h-full p-6 gap-5 overflow-auto">
+      <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+
+      {/* Statistiken */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        {stats.map(({ label, value, icon: Icon, iconClass }) => (
+          <div
+            key={label}
+            className="flex items-center gap-4 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+          >
+            <div
+              className={cn(
+                "flex h-11 w-11 shrink-0 items-center justify-center rounded-xl",
+                iconClass,
+              )}
+            >
+              <Icon className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-2xl font-bold text-gray-900">{value}</p>
+              <p className="text-xs text-gray-500">{label}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {/* Nächste Lernsessions */}
+        <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            Nächste Lernsessions
+          </p>
+          {upcomingSessions.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Keine anstehenden Lernsessions. Plane einen Lernplan in den Kalender ein.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {upcomingSessions.map((e) => (
+                <div
+                  key={e.id}
+                  className="flex items-center gap-3 rounded-xl border border-gray-200 px-4 py-2.5"
+                >
+                  <Clock className="h-4 w-4 shrink-0 text-gray-400" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-900">{e.title}</p>
+                    <p className="text-xs text-gray-500">{formatDayTime(e.start)}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Zuletzt erledigt */}
+        <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            Zuletzt erledigt
+          </p>
+          {completedSessions.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Noch keine abgehakten Lernsessions. Erledigte Termine kannst du im Kalender
+              abhaken – sie erscheinen dann hier.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {completedSessions.slice(0, 5).map((e) => (
+                <div
+                  key={e.id}
+                  className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5"
+                >
+                  <CircleCheckBig className="h-4 w-4 shrink-0 text-green-600" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-400 line-through">
+                      {e.title}
+                    </p>
+                    <p className="text-xs text-gray-500">{formatDayTime(e.start)}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Lernplan-Fortschritt */}
+      <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          Lernpläne
+        </p>
+        {plans.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            Noch keine Lernpläne.{" "}
+            <Link href="/study-plan" className="font-medium text-brand-red hover:underline">
+              Lege deinen ersten Lernplan an.
+            </Link>
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {plans.map((p) => {
+              const progress =
+                p.taskCount > 0
+                  ? Math.round((p.completedTaskCount / p.taskCount) * 100)
+                  : 0;
+              return (
+                <Link
+                  key={p.id}
+                  href={`/study-plan/${p.id}`}
+                  className="flex items-center gap-4 rounded-xl border border-gray-200 px-4 py-3 transition-colors hover:border-gray-300"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-900">{p.title}</p>
+                    <p className="flex items-center gap-1 text-xs text-gray-500">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {p.subject}
+                    </p>
+                  </div>
+                  <div className="flex w-40 shrink-0 items-center gap-2">
+                    <div className="h-2 flex-1 rounded-full bg-gray-200">
+                      <div
+                        className="h-2 rounded-full bg-brand-red transition-all"
+                        style={{ width: `${progress}%` }}
+                      />
+                    </div>
+                    <span className="w-9 text-right text-xs font-medium text-gray-500">
+                      {progress}%
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/study-plan/SchedulePreviewModal.tsx
+++ b/src/components/study-plan/SchedulePreviewModal.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, CalendarCheck, CalendarPlus, CheckCircle, X } from "lucide-react";
 import type { CalEvent, RepeatRule } from "@/components/calendar/events";
 import { calculateStudyPlan } from "@/lib/calculations/studyPlanAlgorithm";
 import {
+  analyzeWorkload,
   scheduleStudyPlan,
   SLOT_HOURS,
   type ScheduleResult,
 } from "@/lib/study-plan/scheduler";
-import type { StudyPlanDetailDTO } from "@/lib/study-plan/types";
+import type { StudyPlanDetailDTO, TaskDTO } from "@/lib/study-plan/types";
 import { formatDate } from "./planMeta";
 
 interface SchedulePreviewModalProps {
@@ -42,10 +43,12 @@ export function SchedulePreviewModal({
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [schedule, setSchedule] = useState<ScheduleResult | null>(null);
+  const [criticalNotes, setCriticalNotes] = useState<string[]>([]);
   const [existingPlanEvents, setExistingPlanEvents] = useState(0);
   const [saving, setSaving] = useState(false);
   const [savedCount, setSavedCount] = useState<number | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const savingRef = useRef(false);
 
   const canCalculate =
     plan.difficulty != null &&
@@ -59,7 +62,7 @@ export function SchedulePreviewModal({
     setLoading(true);
     setLoadError(null);
     setSchedule(null);
-    setSavedCount(null);
+    setCriticalNotes([]);
     setSaveError(null);
 
     if (!canCalculate) {
@@ -96,12 +99,15 @@ export function SchedulePreviewModal({
           credits: plan.credits as number,
         });
 
-        setSchedule(
-          scheduleStudyPlan(
-            result,
-            { deadline: new Date(plan.targetDate) },
-            [...localEvents, ...externalEvents],
-          ),
+        const scheduled = scheduleStudyPlan(
+          result,
+          { deadline: new Date(plan.targetDate) },
+          [...localEvents, ...externalEvents],
+        );
+        setSchedule(scheduled);
+        // Kritische Anmerkungen: zu viel Lernen pro Tag / ein Fach zu oft pro Woche
+        setCriticalNotes(
+          analyzeWorkload(scheduled.sessions, localEvents, plan.subject),
         );
       } catch {
         if (!cancelled) {
@@ -117,11 +123,22 @@ export function SchedulePreviewModal({
     };
   }, [open, plan, canCalculate]);
 
+  // Den Erfolgszustand erst beim Schließen zurücksetzen. Ein Refresh des
+  // Lernplans nach dem Speichern liefert ein neues plan-Objekt und darf die
+  // Erfolgsmeldung nicht wieder durch die Vorschau ersetzen.
+  useEffect(() => {
+    if (!open) {
+      setSavedCount(null);
+      setSaveError(null);
+      savingRef.current = false;
+    }
+  }, [open]);
+
   // ESC schließt Modal
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" && !savingRef.current) onClose();
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -147,12 +164,36 @@ export function SchedulePreviewModal({
   if (!open) return null;
 
   async function handleConfirm() {
-    if (!schedule || schedule.sessions.length === 0) return;
+    if (savingRef.current || !schedule || schedule.sessions.length === 0) return;
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     let created = 0;
     try {
       for (const s of schedule.sessions) {
+        // 1) Aufgabe im Lernplan anlegen – jede Lerneinheit ist abhakbar und
+        //    zählt in den Plan-Fortschritt.
+        const pad = (n: number) => n.toString().padStart(2, "0");
+        const dayLabel = `${pad(s.start.getDate())}.${pad(s.start.getMonth() + 1)}.`;
+        const taskRes = await fetch(`/api/study-plan/${plan.id}/tasks`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: `Lernsession ${dayLabel}: ${s.shortPhase}`,
+            description: s.tasks.join("\n"),
+            dueDate: s.start.toISOString(),
+            estimatedMinutes: SLOT_HOURS * 60,
+            difficulty: plan.difficulty ?? 3,
+          }),
+        });
+        const taskData = (await taskRes.json().catch(() => null)) as
+          | { task?: TaskDTO }
+          | null;
+        if (!taskRes.ok || !taskData?.task) {
+          throw new Error(`Aufgabe für Termin ${created + 1} konnte nicht angelegt werden.`);
+        }
+
+        // 2) Kalendertermin anlegen und mit der Aufgabe verknüpfen.
         const res = await fetch("/api/calendar/events", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -167,6 +208,7 @@ export function SchedulePreviewModal({
             tasks: s.tasks.join("\n"),
             repeat: "none" satisfies RepeatRule,
             studyPlanId: plan.id,
+            taskId: taskData.task.id,
           }),
         });
         if (!res.ok) {
@@ -183,6 +225,7 @@ export function SchedulePreviewModal({
           : "Speichern fehlgeschlagen.",
       );
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   }
@@ -190,7 +233,9 @@ export function SchedulePreviewModal({
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      onClick={onClose}
+      onClick={() => {
+        if (!savingRef.current) onClose();
+      }}
     >
       <div
         role="dialog"
@@ -210,7 +255,8 @@ export function SchedulePreviewModal({
           <button
             type="button"
             onClick={onClose}
-            className="p-1 rounded-lg hover:bg-gray-100 transition-colors"
+            disabled={saving}
+            className="p-1 rounded-lg hover:bg-gray-100 transition-colors disabled:opacity-50"
             aria-label="Schließen"
           >
             <X className="w-4 h-4 text-gray-500" />
@@ -230,7 +276,8 @@ export function SchedulePreviewModal({
               </p>
               <p className="text-sm text-gray-500 max-w-sm">
                 Die Termine sind jetzt im Kalender sichtbar und können dort per Drag &amp;
-                Drop verschoben werden.
+                Drop verschoben werden. Jede Einheit ist außerdem als abhakbare Aufgabe
+                mit diesem Lernplan verknüpft.
               </p>
             </div>
           ) : !canCalculate ? (
@@ -292,6 +339,20 @@ export function SchedulePreviewModal({
                 >
                   <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
                   <span>{w}</span>
+                </div>
+              ))}
+
+              {/* Kritische Anmerkungen zum Workload (zu viel pro Tag / Fach zu oft) */}
+              {criticalNotes.map((note) => (
+                <div
+                  key={note}
+                  className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+                >
+                  <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                  <span>
+                    <span className="font-semibold">Kritische Anmerkung: </span>
+                    {note}
+                  </span>
                 </div>
               ))}
 
@@ -366,7 +427,8 @@ export function SchedulePreviewModal({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors"
+                  disabled={saving}
+                  className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50"
                 >
                   Abbrechen
                 </button>

--- a/src/components/study-plan/StudyPlanForm.tsx
+++ b/src/components/study-plan/StudyPlanForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Calculator, X } from "lucide-react";
+import { EditableCombobox } from "@/components/calendar/EditableCombobox";
 import { GOAL_TYPE_META, fromDateInputValue, toDateInputValue } from "./planMeta";
 import type { StudyPlanDTO } from "@/lib/study-plan/types";
 import { GOAL_TYPES } from "@/lib/study-plan/types";
@@ -32,6 +33,42 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
   const [credits, setCredits] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [subjectOptions, setSubjectOptions] = useState<string[]>([]);
+
+  // Fächer-Vorschläge aus dem Kalender laden (eigene Fächer + DHBW-Veranstaltungen).
+  // Freitext bleibt weiterhin möglich – die Liste ist nur eine Auswahlhilfe.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [localRes, externalRes] = await Promise.all([
+          fetch("/api/calendar/events"),
+          fetch("/api/calendar/external"),
+        ]);
+        const localData = localRes.ok
+          ? ((await localRes.json()) as { events?: { subject?: string }[] })
+          : { events: [] };
+        const externalData = externalRes.ok
+          ? ((await externalRes.json()) as { events?: { title?: string }[] })
+          : { events: [] };
+        if (cancelled) return;
+        const subjects = new Set<string>();
+        for (const e of localData.events ?? []) {
+          if (typeof e.subject === "string" && e.subject.trim()) subjects.add(e.subject.trim());
+        }
+        for (const e of externalData.events ?? []) {
+          if (typeof e.title === "string" && e.title.trim()) subjects.add(e.title.trim());
+        }
+        setSubjectOptions([...subjects].sort((a, b) => a.localeCompare(b, "de")));
+      } catch {
+        // Kalender nicht erreichbar → keine Vorschläge, Freitext bleibt möglich.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   // Felder beim Öffnen befüllen (Bearbeiten) bzw. zurücksetzen (Anlegen)
   useEffect(() => {
@@ -157,21 +194,14 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1">
-              <label htmlFor="sp-subject" className="text-xs font-semibold text-gray-700">
-                Veranstaltung / Fach
-              </label>
-              <input
-                id="sp-subject"
-                type="text"
-                required
-                maxLength={100}
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
-                placeholder="z. B. Mathematik 2"
-                className={inputClass}
-              />
-            </div>
+            <EditableCombobox
+              id="sp-subject"
+              label="Veranstaltung / Fach"
+              value={subject}
+              options={subjectOptions}
+              onChange={setSubject}
+              placeholder="z. B. Mathematik 2"
+            />
             <div className="flex flex-col gap-1">
               <label htmlFor="sp-goal-type" className="text-xs font-semibold text-gray-700">
                 Zieltyp

--- a/src/components/study-plan/StudyPlanForm.tsx
+++ b/src/components/study-plan/StudyPlanForm.tsx
@@ -199,7 +199,7 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
               label="Veranstaltung / Fach"
               value={subject}
               options={subjectOptions}
-              onChange={setSubject}
+              onChange={(v) => setSubject(v.slice(0, 100))}
               placeholder="z. B. Mathematik 2"
             />
             <div className="flex flex-col gap-1">

--- a/src/lib/calendar/icsMapper.ts
+++ b/src/lib/calendar/icsMapper.ts
@@ -1,4 +1,4 @@
-import type { CalEvent } from "@/components/calendar/events";
+import { isImportantType, type CalEvent } from "@/components/calendar/events";
 
 export type IcsComponent = {
   type?: string;
@@ -36,16 +36,22 @@ export function mapIcsToCalEvents(
     // sonst werden Vorlesungen versehentlich in die All-Day-Leiste verschoben.
     const allDay = c.datetype === "date";
 
+    const title = (c.summary ?? "").trim() || "(ohne Titel)";
+    // Klausuren/Prüfungen im Stundenplan hervorheben (gleiche Heuristik wie
+    // bei lokalen Terminen, siehe isImportantType).
+    const isExam = isImportantType(title);
+
     events.push({
       id: c.uid ?? key,
-      title: (c.summary ?? "").trim() || "(ohne Titel)",
+      title,
       start,
       end,
-      color,
+      color: isExam ? "bg-brand-red" : color,
       source,
       readOnly: true,
       location: c.location?.trim() || undefined,
       allDay,
+      important: isExam || undefined,
     });
   }
 

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -518,15 +518,15 @@ export function analyzeWorkload(
 
   // 1) Zu viel Lernen an einem Tag – zu einer Meldung zusammengefasst,
   //    damit die Vorschau nicht mit Hinweisen geflutet wird.
-  const hoursPerDay = new Map<string, number>();
+  const hoursPerDay = new Map<number, number>();
   for (const b of blocks) {
-    const key = startOfDay(b.start).toISOString();
+    const key = startOfDay(b.start).getTime();
     const hours = (b.end.getTime() - b.start.getTime()) / 3_600_000;
     hoursPerDay.set(key, (hoursPerDay.get(key) ?? 0) + hours);
   }
   const overloadedDays = [...hoursPerDay.entries()]
     .filter(([, hours]) => hours > MAX_RECOMMENDED_HOURS_PER_DAY)
-    .sort(([a], [b]) => a.localeCompare(b));
+    .sort(([a], [b]) => a - b);
   if (overloadedDays.length === 1) {
     const [key, hours] = overloadedDays[0];
     notes.push(

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -6,7 +6,11 @@
 // sein"). Logik und Konstanten: docs/lernplan-umsetzung.md §6.
 
 import type { CalEvent } from "@/components/calendar/events";
-import { DAY_START_HOUR } from "@/components/calendar/events";
+import {
+  DAY_START_HOUR,
+  eventOverlapsDay,
+  isLernsessionEvent,
+} from "@/components/calendar/events";
 import type { AlgorithmResult } from "@/lib/calculations/studyPlanAlgorithm";
 
 /** Dauer einer Lerneinheit in Stunden. */
@@ -15,8 +19,21 @@ export const SLOT_HOURS = 2;
 export const MAX_SESSIONS_PER_WEEK = 5;
 /** Bevorzugter Beginn einer Einheit (16:00 Uhr, Entscheidung 8.2). */
 export const PREFERRED_START_HOUR = 16;
-/** Maximal zwei Einheiten am selben Tag. */
+/** Maximal zwei Einheiten am selben Tag (normaler Uni-Tag). */
 export const MAX_SESSIONS_PER_DAY = 2;
+/**
+ * An "freien" Tagen sind bis zu 3 Einheiten (= 6 h) möglich: am Wochenende
+ * sowie an Wochentagen mit höchstens einem Hochschul-Block (Uni frei/fast frei).
+ */
+export const MAX_SESSIONS_PER_DAY_FREE = 3;
+/** Bis zu so vielen Hochschul-Blöcken gilt ein Wochentag noch als "frei". */
+export const LIGHT_UNI_DAY_MAX_BLOCKS = 1;
+/** Empfohlene maximale Lernzeit pro Tag in Stunden (kritische Anmerkung darüber). */
+export const MAX_RECOMMENDED_HOURS_PER_DAY = 6;
+/** Ab so vielen Einheiten desselben Fachs pro Woche gibt es eine kritische Anmerkung. */
+export const MAX_SUBJECT_SESSIONS_PER_WEEK = 5;
+/** Bevorzugter Beginn an freien Tagen (Wochenende / keine Hochschul-Termine). */
+export const FREE_DAY_START_HOUR = 10;
 /** Keine Einheit endet nach 21:00 Uhr – auch unter der Woche schlaffreundlich. */
 export const LATEST_END_HOUR = 21;
 /** Mindestpause zwischen zwei Einheiten am selben Tag (Minuten). */
@@ -235,6 +252,39 @@ export function scheduleStudyPlan(
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;
   const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   const maxPerDay = options.maxSessionsPerDay ?? MAX_SESSIONS_PER_DAY;
+  // Hochschul-Blöcke pro Tag (für Tageslimit + frühere Startzeit an freien Tagen)
+  const uniBlockCountCache = new Map<string, number>();
+  const uniBlockCount = (day: Date): number => {
+    const key = day.toDateString();
+    let count = uniBlockCountCache.get(key);
+    if (count === undefined) {
+      count = existingEvents.filter(
+        (e) => !e.allDay && isHochschulEvent(e) && eventOverlapsDay(e, day),
+      ).length;
+      uniBlockCountCache.set(key, count);
+    }
+    return count;
+  };
+  // An freien Tagen (Wochenende oder höchstens ein Uni-Block) sind bis zu
+  // 6 h (3 Einheiten) erlaubt; eine explizite Option deckelt alle Fälle.
+  const isFreeDay = (day: Date): boolean =>
+    isWeekend(day) || uniBlockCount(day) <= LIGHT_UNI_DAY_MAX_BLOCKS;
+  const dayCap = (day: Date): number =>
+    options.maxSessionsPerDay ?? (isFreeDay(day) ? MAX_SESSIONS_PER_DAY_FREE : maxPerDay);
+  const existingSessionCountCache = new Map<string, number>();
+  const existingSessionCount = (day: Date): number => {
+    const key = day.toDateString();
+    let count = existingSessionCountCache.get(key);
+    if (count === undefined) {
+      count = existingEvents.filter(
+        (e) => !e.allDay && isLernsessionEvent(e) && eventOverlapsDay(e, day),
+      ).length;
+      existingSessionCountCache.set(key, count);
+    }
+    return count;
+  };
+  const availableDayCapacity = (day: Date): number =>
+    Math.max(0, dayCap(day) - existingSessionCount(day));
   const hochschulBufferMin =
     typeof options.hochschulBufferMin === "number" && Number.isFinite(options.hochschulBufferMin)
       ? Math.max(0, options.hochschulBufferMin)
@@ -254,9 +304,13 @@ export function scheduleStudyPlan(
     return { sessions: [], warnings, sessionsNeeded };
   }
 
-  // Kapazität: max. 5 Einheiten pro Woche, max. 2 pro Tag
+  // Kapazität: max. 5 Einheiten pro Woche, Tageslimit je nach Wochentag
   const weeks = Math.max(1, Math.ceil((deadline.getTime() - firstDay.getTime()) / (7 * DAY_MS)));
-  const capacity = Math.min(weeks * MAX_SESSIONS_PER_WEEK, candidateDays.length * maxPerDay);
+  const dailyCapacity = candidateDays.reduce(
+    (sum, d) => sum + availableDayCapacity(d),
+    0,
+  );
+  const capacity = Math.min(weeks * MAX_SESSIONS_PER_WEEK, dailyCapacity);
   if (sessionsNeeded > capacity) {
     warnings.push(
       `Rechnerisch wären ${sessionsNeeded} Lerneinheiten nötig, bis zur Deadline passen aber höchstens ${capacity} ` +
@@ -287,11 +341,21 @@ export function scheduleStudyPlan(
   // keine Lerneinheit liegen darf (Heimfahrt/Essen). Eigene/lokale Termine
   // blockieren punktgenau.
   const hochschulBufferMs = hochschulBufferMin * 60 * 1000;
+  const sessionGapMs = SESSION_GAP_MIN * 60 * 1000;
   const blockers = existingEvents.map((e) => {
-    const buffered = !e.allDay && isHochschulEvent(e);
+    // Bestehende Lerneinheiten (z. B. aus früher eingetragenen Plänen) werden
+    // mit ±Pause gepuffert, damit neue Einheiten nicht nahtlos daran kleben –
+    // sonst greift die Mindestpause zwischen Lerneinheiten nicht.
+    const padMs = e.allDay
+      ? 0
+      : isHochschulEvent(e)
+        ? hochschulBufferMs
+        : isLernsessionEvent(e)
+          ? sessionGapMs
+          : 0;
     return {
-      start: buffered ? new Date(e.start.getTime() - hochschulBufferMs) : e.start,
-      end: buffered ? new Date(e.end.getTime() + hochschulBufferMs) : e.end,
+      start: padMs ? new Date(e.start.getTime() - padMs) : e.start,
+      end: padMs ? new Date(e.end.getTime() + padMs) : e.end,
       allDay: e.allDay,
     };
   });
@@ -299,21 +363,29 @@ export function scheduleStudyPlan(
   const perDayCount = new Map<string, number>();
   let remaining = sessionsNeeded;
 
-  const gapMs = SESSION_GAP_MIN * 60 * 1000;
   // Eigene platzierte Einheiten blockieren mit ±Pause, damit zwei Blöcke am
   // selben Tag nicht nahtlos aneinanderkleben (4 h am Stück).
   const paddedPlaced = () =>
     placed.map((p) => ({
-      start: new Date(p.start.getTime() - gapMs),
-      end: new Date(p.end.getTime() + gapMs),
+      start: new Date(p.start.getTime() - sessionGapMs),
+      end: new Date(p.end.getTime() + sessionGapMs),
     }));
+
+  // Freie Tage (Wochenende oder ohne Hochschul-Termine) starten früher,
+  // damit mehrere Einheiten bequem mit Pausen Platz finden.
+  const freeDayStart = (day: Date): number => {
+    if (options.preferredStartHour != null) return preferredStartHour;
+    return isWeekend(day) || uniBlockCount(day) === 0
+      ? FREE_DAY_START_HOUR
+      : preferredStartHour;
+  };
 
   function tryPlace(day: Date): boolean {
     const key = day.toDateString();
-    if ((perDayCount.get(key) ?? 0) >= maxPerDay) return false;
+    if ((perDayCount.get(key) ?? 0) >= availableDayCapacity(day)) return false;
     const slot = findFreeSlot(
       day,
-      preferredStartHour,
+      freeDayStart(day),
       latestEndHour,
       [...blockers, ...paddedPlaced()],
       now,
@@ -328,7 +400,11 @@ export function scheduleStudyPlan(
   for (const weekIndex of sortedWeekIndices) {
     if (remaining <= 0) break;
     const chunk = weekChunks.get(weekIndex)!;
-    const quota = Math.min(perWeek, remaining, chunk.length * maxPerDay);
+    const quota = Math.min(
+      perWeek,
+      remaining,
+      chunk.reduce((sum, d) => sum + availableDayCapacity(d), 0),
+    );
 
 // Tage nach freier Zeit ordnen: Wochenenden und Tage mit wenig zeitgebundenen
 // Terminen zuerst, damit freie Tage aktiv mit bis zu zwei Einheiten gefüllt werden.
@@ -350,12 +426,18 @@ export function scheduleStudyPlan(
         remaining--;
       }
     }
-    // Durchgang 2: zweite Einheit auf die freiesten Tage (Wochenende zuerst)
-    for (const day of pickOrder) {
-      if (placedThisWeek >= quota || remaining <= 0) break;
-      if (tryPlace(day)) {
-        placedThisWeek++;
-        remaining--;
+    // Durchgang 2+: weitere Einheiten auf die freiesten Tage (Wochenende
+    // zuerst), bis zum jeweiligen Tageslimit (Wochenende bis zu 3 × 2 h = 6 h).
+    let progressed = true;
+    while (progressed && placedThisWeek < quota && remaining > 0) {
+      progressed = false;
+      for (const day of pickOrder) {
+        if (placedThisWeek >= quota || remaining <= 0) break;
+        if (tryPlace(day)) {
+          placedThisWeek++;
+          remaining--;
+          progressed = true;
+        }
       }
     }
   }
@@ -401,4 +483,116 @@ export function scheduleStudyPlan(
   }
 
   return { sessions, warnings, sessionsNeeded: originallyNeeded };
+}
+
+// ─── Workload-Analyse (kritische Anmerkungen) ─────────────────────────────────
+
+/**
+ * Prüft den kombinierten Lern-Workload (neu geplante Einheiten + bereits
+ * vorhandene Lerneinheiten im Kalender) und liefert kritische Anmerkungen:
+ *
+ *  - mehr als MAX_RECOMMENDED_HOURS_PER_DAY Stunden Lernen an einem Tag
+ *  - dasselbe Fach MAX_SUBJECT_SESSIONS_PER_WEEK-mal oder öfter in einer Woche
+ *
+ * Der Lernplan ist eine Basis, kein Pflichtprogramm – die Anmerkungen sollen
+ * beim Organisieren helfen, nicht blockieren.
+ */
+export function analyzeWorkload(
+  planned: { start: Date; end: Date }[],
+  existingEvents: CalEvent[],
+  subject: string,
+): string[] {
+  const notes: string[] = [];
+
+  const blocks = [
+    ...planned.map((s) => ({ start: s.start, end: s.end, subject })),
+    ...existingEvents
+      .filter((e) => !e.allDay && isLernsessionEvent(e))
+      .map((e) => ({ start: e.start, end: e.end, subject: e.subject?.trim() ?? "" })),
+  ];
+
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const fmtDay = (d: Date) => `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.`;
+  const fmtHours = (h: number) =>
+    h.toLocaleString("de-DE", { maximumFractionDigits: 1 });
+
+  // 1) Zu viel Lernen an einem Tag – zu einer Meldung zusammengefasst,
+  //    damit die Vorschau nicht mit Hinweisen geflutet wird.
+  const hoursPerDay = new Map<string, number>();
+  for (const b of blocks) {
+    const key = startOfDay(b.start).toISOString();
+    const hours = (b.end.getTime() - b.start.getTime()) / 3_600_000;
+    hoursPerDay.set(key, (hoursPerDay.get(key) ?? 0) + hours);
+  }
+  const overloadedDays = [...hoursPerDay.entries()]
+    .filter(([, hours]) => hours > MAX_RECOMMENDED_HOURS_PER_DAY)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (overloadedDays.length === 1) {
+    const [key, hours] = overloadedDays[0];
+    notes.push(
+      `Am ${fmtDay(new Date(key))} sind insgesamt ${fmtHours(hours)} Stunden Lernen geplant – ` +
+        `mehr als die empfohlenen ${MAX_RECOMMENDED_HOURS_PER_DAY} Stunden pro Tag. Verteile die Einheiten möglichst auf mehrere Tage.`,
+    );
+  } else if (overloadedDays.length > 1) {
+    const shown = overloadedDays
+      .slice(0, 4)
+      .map(([key]) => fmtDay(new Date(key)))
+      .join(", ");
+    const rest = overloadedDays.length - 4;
+    const maxHours = Math.max(...overloadedDays.map(([, hours]) => hours));
+    notes.push(
+      `An ${overloadedDays.length} Tagen (${shown}${rest > 0 ? ` und ${rest} weiteren` : ""}) sind mehr als die ` +
+        `empfohlenen ${MAX_RECOMMENDED_HOURS_PER_DAY} Stunden Lernen pro Tag geplant – in der Spitze ${fmtHours(maxHours)} Stunden. ` +
+        `Verteile die Einheiten möglichst auf mehrere Tage.`,
+    );
+  }
+
+  // 2) Ein Fach zu oft in derselben Woche
+  const normalizedSubject = (s: string) => s.trim().toLocaleLowerCase("de-DE");
+  const perWeekSubject = new Map<string, { monday: Date; subject: string; count: number }>();
+  for (const b of blocks) {
+    if (!b.subject.trim()) continue;
+    const monday = startOfDay(b.start);
+    const wd = monday.getDay();
+    monday.setDate(monday.getDate() - (wd === 0 ? 6 : wd - 1));
+    const key = `${monday.toISOString()}|${normalizedSubject(b.subject)}`;
+    const entry = perWeekSubject.get(key) ?? { monday, subject: b.subject.trim(), count: 0 };
+    entry.count++;
+    perWeekSubject.set(key, entry);
+  }
+  const overloadedWeeks = [...perWeekSubject.values()]
+    .filter((e) => e.count >= MAX_SUBJECT_SESSIONS_PER_WEEK)
+    .sort((a, b) => a.monday.getTime() - b.monday.getTime());
+
+  // Pro Fach nur eine Meldung (statt eine pro Fach × Woche)
+  const bySubject = new Map<string, { subject: string; weeks: { monday: Date; count: number }[] }>();
+  for (const e of overloadedWeeks) {
+    const key = normalizedSubject(e.subject);
+    const entry = bySubject.get(key) ?? { subject: e.subject, weeks: [] };
+    entry.weeks.push({ monday: e.monday, count: e.count });
+    bySubject.set(key, entry);
+  }
+  const tail =
+    "Abwechslung zwischen Fächern hilft beim Behalten – tausche einzelne Einheiten, wenn möglich.";
+  for (const s of bySubject.values()) {
+    if (s.weeks.length === 1) {
+      const w = s.weeks[0];
+      notes.push(
+        `In der Woche vom ${fmtDay(w.monday)} steht „${s.subject}“ ${w.count}-mal auf dem Plan. ${tail}`,
+      );
+    } else {
+      const shown = s.weeks
+        .slice(0, 3)
+        .map((w) => fmtDay(w.monday))
+        .join(", ");
+      const rest = s.weeks.length - 3;
+      const maxCount = Math.max(...s.weeks.map((w) => w.count));
+      notes.push(
+        `„${s.subject}“ steht in ${s.weeks.length} Wochen (ab ${shown}${rest > 0 ? ` und ${rest} weiteren` : ""}) ` +
+          `bis zu ${maxCount}-mal pro Woche auf dem Plan. ${tail}`,
+      );
+    }
+  }
+
+  return notes;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -54,8 +54,9 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // API-Routen einschließen damit die 401-Logik greift.
-    // _next-Interna und statische Assets ausschließen.
-    "/((?!_next|favicon.ico|icons|images).*)",
+    // API-Routen einschließen, damit die 401-Logik greift. Next.js-Interna
+    // und alle statischen Dateien aus public/ (erkennbar an der Dateiendung)
+    // ausschließen, unabhängig davon, in welchem Unterordner sie liegen.
+    "/((?!_next|favicon.ico|.*\\.[^/]+$).*)",
   ],
 };


### PR DESCRIPTION
## Summary

- creates one linked study-plan task for every generated calendar study session
- synchronizes session completion between calendar, study-plan progress, and dashboard
- adds dashboard summaries for completed/upcoming sessions, open tasks, and plan progress
- creates deduplicated notifications for missed, incomplete study sessions
- improves scheduling with 30-minute gaps, free-day capacity, existing-session daily limits, and workload warnings
- adds study-plan subject suggestions from local and DHBW calendar data
- highlights DHBW exams and fixes public-asset handling in the auth middleware

## Fixes and behavior

The scheduling confirmation previously reset after the parent refreshed the plan object. This exposed the confirmation action again and could create duplicate tasks and events. The success state now survives that refresh, repeated clicks are guarded synchronously, and the modal cannot be closed while a save is active.

Existing study sessions previously blocked time slots but did not reduce the scheduler's daily capacity. They now count against the two- or three-session daily limit, while retaining the required 30-minute gap.

Static files under `public/` are now excluded from auth middleware matching by file extension. Protected pages still redirect to login and protected APIs still return `401`.

## User impact

Students can treat generated learning sessions as real, checkable plan tasks. Completing a session updates every relevant view consistently, missed sessions create a gentle notification, and generated schedules better respect existing workload and available days.

## Validation

- `npm.cmd run lint`
- `npm.cmd run build`
- Prisma migration status: database schema up to date
- fresh-user end-to-end UI flow for registration, subject suggestions, scheduling, completion synchronization, dashboard progress, and missed-session notification deduplication
- verified five generated tasks map 1:1 to five calendar events
- isolated scheduler checks for 30-minute gaps, existing-session daily capacity, three sessions on free days, and 10:00 preferred start
- isolated workload-warning and DHBW exam-mapping checks
- HTTP checks: public image `200`, login `200`, protected dashboard `307`, protected calendar API `401`
- browser console contained no errors

## Deferred product decisions

- Sundays remain excluded from default scheduling.
- DHBW subject suggestions retain their original event titles.
- Capacity warnings still use the general weekly-limit wording even when daily capacity also contributes.