### PR TITLE
[codex] Lernplan-Tageslimits und Belastungswarnung präzisieren

### DIFF
--- a/docs/Algorithmus/Ausgabeformat.md
+++ b/docs/Algorithmus/Ausgabeformat.md
@@ -210,7 +210,7 @@ Beispiel:
         "2 typische Klausuraufgaben lösen"
       ],
       "review": "Fehler aus den Aufgaben notieren",
-      "note": "Im kritischen Plan werden maximal 2 Stunden pro Tag angezeigt. Weniger wichtige Themen können entfallen."
+      "note": "Im kritischen Plan werden maximal zwei 2-Stunden-Einheiten desselben Fachs pro Tag geplant. Weniger wichtige Themen können entfallen."
     }
   ],
   "warnings": [
@@ -229,4 +229,7 @@ Bei einem normalen Lernplan liegt der Fokus auf Verständnis, Vertiefung, Anwend
 
 Bei einem kritischen Lernplan liegt der Fokus auf Priorisierung, Kernstoff, typischen Aufgaben und kurzer Wiederholung.
 
-Wenn ein kritischer Lernplan erstellt wird, darf die App trotzdem maximal 2 Stunden Lernzeit pro Tag anzeigen, damit der Nutzer nicht überfordert wird. Zusätzlich wird eine Warnung ausgegeben.
+Wenn ein kritischer Lernplan erstellt wird, plant die App maximal zwei 2-Stunden-Einheiten desselben
+Fachs pro Tag. An freien Tagen dürfen insgesamt bis zu drei Einheiten stattfinden, sofern sie sich
+auf mindestens zwei Fächer verteilen. Bei drei Tagen hintereinander mit jeweils zwei Einheiten
+desselben Fachs wird zusätzlich eine kritische Pausenempfehlung ausgegeben.

--- a/docs/Algorithmus/Konzept kritischer Lernplan.md
+++ b/docs/Algorithmus/Konzept kritischer Lernplan.md
@@ -95,7 +95,13 @@ Tagesplanung
 
 Auch wenn rechnerisch mehr nötig wäre:
 
-Maximal 2 Stunden pro Tag anzeigen
+Maximal zwei 2-Stunden-Einheiten desselben Fachs pro Tag planen.
+
+An freien Tagen sind insgesamt bis zu drei 2-Stunden-Einheiten möglich, wenn die dritte Einheit
+zu einem anderen Fach gehört.
+
+Wenn an drei Tagen hintereinander jeweils zwei Einheiten desselben Fachs liegen, wird eine
+kritische Warnung mit der Empfehlung für einen Fach- oder Pausentag angezeigt.
 
 Der User soll nicht überfordert werden.
 

--- a/docs/lernplan-umsetzung.md
+++ b/docs/lernplan-umsetzung.md
@@ -35,11 +35,13 @@ werden die Einheiten als **Kalender-Termine** (Typ „Lernsession") gespeichert 
 ### Wichtige bereits definierte Regeln (aus der Konzept-Doku)
 
 - **Formel:** `Gesamtstunden = 25 × D × ((S + W + V + C) / 4)`
-- **Plantyp:** `Stunden/Tag ≤ 2` → *normal*, sonst *kritisch* (max. 2 h/Tag anzeigen + Warnung).
+- **Plantyp:** `Stunden/Tag ≤ 2` → *normal*, sonst *kritisch*. Im kritischen Plan werden maximal
+  zwei 2-h-Einheiten desselben Fachs pro Tag geplant; an freien Tagen bleiben insgesamt bis zu
+  drei Einheiten aus mindestens zwei Fächern möglich.
 - **Phasen normal:** Grundlagen 40 %, Vertiefung 35 %, Anwendung 15 %, Wiederholung 10 %.
 - **Phasen kritisch:** Priorisierung 10 %, Kernstoff 50 %, Aufgaben 30 %, Wiederholung 10 %.
 - **Scheduling-Constraints** ([study-plan-redesign.md §5](study-plan-redesign.md)):
-  - Ziel: **3–4 Lerneinheiten pro Woche**
+  - Orientierung: häufig **3–4 Lerneinheiten pro Woche**, bei geringem Aufwand auch 1–2
   - Maximum: **5 Lerneinheiten pro Woche**
   - Dauer: **2 h pro Einheit**
 
@@ -116,9 +118,9 @@ Datei: `src/lib/study-plan/scheduler.ts`
 ### Konstanten
 ```ts
 const SLOT_HOURS = 2;                // Dauer einer Lerneinheit
-const TARGET_SESSIONS_PER_WEEK = 4;  // Ziel 3–4
 const MAX_SESSIONS_PER_WEEK = 5;     // hartes Limit
-const MAX_SESSIONS_PER_DAY = 2;      // zweiter Block am selben Tag erlaubt
+const MAX_SESSIONS_PER_SUBJECT_PER_DAY = 2; // höchstens 4 h desselben Fachs
+const MAX_SESSIONS_PER_DAY_FREE = 3; // global höchstens 6 h an freien Tagen
 const LATEST_END_HOUR = 21;          // keine Einheit endet nach 21 Uhr (schlaffreundlich)
 const SESSION_GAP_MIN = 30;          // Mindestpause zwischen zwei Blöcken am selben Tag
 ```
@@ -129,7 +131,8 @@ const SESSION_GAP_MIN = 30;          // Mindestpause zwischen zwei Blöcken am s
    `weeks = max(1, ceil(daysUntilDeadline / 7))`, `capacity = weeks × MAX_SESSIONS_PER_WEEK`.
    Wenn `sessionsNeeded > capacity` → **Warnung „Überlastung"** und auf `capacity` deckeln
    (im kritischen Plan erwartbar – passt zur Konzept-Doku).
-3. **Einheiten pro Woche:** `perWeek = clamp(ceil(sessionsNeeded / weeks), TARGET..MAX)`.
+3. **Einheiten pro Woche:** `perWeek = min(MAX, max(1, ceil(sessionsNeeded / weeks)))`.
+   3–4 Einheiten sind ein Orientierungsbereich, aber kein künstliches Minimum.
 4. **Phasen → Einheiten:** Pro Phase `sessions_phase = round(phase.hours / totalHours × sessionsNeeded)`.
    Phasen werden **chronologisch** zugewiesen (erst Grundlagen-Einheiten, dann Vertiefung, …),
    damit die Lernlogik (verstehen → vertiefen → anwenden → wiederholen) erhalten bleibt.
@@ -256,8 +259,13 @@ Nach jeder Phase soll `npm run build` grün sein.
 ## 10. Definition von „schönes Ergebnis" (Akzeptanzkriterien)
 
 - Aus den Klausurdaten entstehen **konkrete, datierte 2-h-Lerneinheiten**, nicht nur Summen.
-- Die Einheiten respektieren **3–4 (max. 5) pro Woche** und kollidieren **nicht** mit DHBW-Vorlesungen
+- Die Einheiten werden aufwandsabhängig gleichmäßig verteilt und respektieren **max. 5 pro Woche**.
+  Häufig entstehen 3–4 Einheiten, bei geringem Aufwand sind auch 1–2 korrekt. Sie kollidieren **nicht** mit DHBW-Vorlesungen
   oder bereits geplanten Lernsessions.
+- Pro Fach werden maximal **2 × 2 h pro Tag** geplant; an freien Tagen sind fachübergreifend weiterhin
+  maximal **3 × 2 h** möglich.
+- Bei drei aufeinanderfolgenden Tagen mit jeweils zwei Einheiten desselben Fachs erscheint eine
+  kritische Empfehlung für einen Fach- oder Pausentag.
 - Die Phasen sind **chronologisch sinnvoll** verteilt (Grundlagen früh, Wiederholung spät).
 - Jede Einheit hat **konkrete Aufgaben** (im `tasks`-Feld des Termins sichtbar).
 - Mit **einem Klick** landen alle Einheiten im Kalender und sind dort normal bearbeitbar/löschbar.

--- a/docs/study-plan-redesign.md
+++ b/docs/study-plan-redesign.md
@@ -159,11 +159,13 @@ Ein **Modal oder Slide-Over** öffnet sich bei „+ Neuer Lernplan" / „Bearbei
 
 | Constraint | Wert |
 |------------|------|
-| **Ziel-Häufigkeit** | 3–4 Lerneinheiten pro Woche je Thema |
+| **Orientierungsbereich** | häufig 3–4 Lerneinheiten pro Woche je Thema, abhängig vom berechneten Aufwand |
 | **Maximale Häufigkeit** | max. 5 Lerneinheiten pro Woche je Thema |
 | **Einheitsdauer** | 2 h pro Timeslot |
+| **Maximum je Fach und Tag** | max. 2 Lerneinheiten (= 4 h) |
+| **Globales Tagesmaximum** | an freien Tagen max. 3 Lerneinheiten (= 6 h), verteilt auf mindestens zwei Fächer |
 
-> Der Algorithmus verteilt die berechnete Gesamtstundenzahl so, dass pro Thema **bevorzugt 3–4 Lerneinheiten à 2 h pro Woche** eingeplant werden. Mehr als **5 Lerneinheiten pro Woche** sind nicht zulässig, um Überlastung zu vermeiden.
+> Der Algorithmus verteilt die berechnete Gesamtstundenzahl gleichmäßig über die verbleibenden Wochen. **3–4 Lerneinheiten sind ein Orientierungsbereich, kein Mindestwert**: Bei geringem Aufwand können auch 1–2 Einheiten pro Woche entstehen. Mehr als **5 Lerneinheiten pro Woche** sind nicht zulässig.
 
 ---
 

--- a/src/components/study-plan/AlgorithmResultWidget.tsx
+++ b/src/components/study-plan/AlgorithmResultWidget.tsx
@@ -3,6 +3,10 @@
 import { useState } from "react";
 import { AlertTriangle, CheckCircle, Calculator, CalendarPlus, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  MAX_SESSIONS_PER_SUBJECT_PER_DAY,
+  SLOT_HOURS,
+} from "@/lib/study-plan/scheduler";
 import type { StudyPlanDTO } from "@/lib/study-plan/types";
 
 interface AlgorithmResultWidgetProps {
@@ -27,6 +31,7 @@ export function AlgorithmResultWidget({
     plan.pages != null &&
     plan.credits != null;
   const isKritisch = plan.planType === "kritisch";
+  const maxSubjectHoursPerDay = MAX_SESSIONS_PER_SUBJECT_PER_DAY * SLOT_HOURS;
   async function recalculate() {
     setBusy(true);
     try {
@@ -103,16 +108,19 @@ export function AlgorithmResultWidget({
             </div>
             <div className="flex flex-col items-center justify-center rounded-xl bg-gray-50 border border-gray-200 p-3 text-center">
               <span className="text-xl font-bold text-gray-900">
-                {isKritisch ? "2" : plan.hoursPerDay} h
+                {isKritisch ? `max. ${maxSubjectHoursPerDay}` : plan.hoursPerDay} h
               </span>
-              <span className="text-xs text-gray-500 mt-0.5">pro Tag geplant</span>
+              <span className="text-xs text-gray-500 mt-0.5">
+                {isKritisch ? "dieses Fach pro Tag" : "pro Tag geplant"}
+              </span>
             </div>
           </div>
 
           {isKritisch && (
             <p className="text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2">
-              Rechnerisch wären {plan.hoursPerDay} h pro Tag nötig. Angezeigt werden maximal
-              2 h pro Tag – priorisiere die wichtigsten Inhalte.
+              Rechnerisch wären {plan.hoursPerDay} h pro Tag nötig. Automatisch geplant werden
+              maximal zwei 2-Stunden-Einheiten dieses Fachs pro Tag – priorisiere die wichtigsten
+              Inhalte und plane Pausen ein.
             </p>
           )}
 

--- a/src/components/study-plan/SchedulePreviewModal.tsx
+++ b/src/components/study-plan/SchedulePreviewModal.tsx
@@ -101,7 +101,7 @@ export function SchedulePreviewModal({
 
         const scheduled = scheduleStudyPlan(
           result,
-          { deadline: new Date(plan.targetDate) },
+          { deadline: new Date(plan.targetDate), subject: plan.subject },
           [...localEvents, ...externalEvents],
         );
         setSchedule(scheduled);

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -21,6 +21,8 @@ export const MAX_SESSIONS_PER_WEEK = 5;
 export const PREFERRED_START_HOUR = 16;
 /** Maximal zwei Einheiten am selben Tag (normaler Uni-Tag). */
 export const MAX_SESSIONS_PER_DAY = 2;
+/** Maximal zwei Einheiten desselben Fachs/Lernplans pro Tag. */
+export const MAX_SESSIONS_PER_SUBJECT_PER_DAY = 2;
 /**
  * An "freien" Tagen sind bis zu 3 Einheiten (= 6 h) möglich: am Wochenende
  * sowie an Wochentagen mit höchstens einem Hochschul-Block (Uni frei/fast frei).
@@ -32,6 +34,8 @@ export const LIGHT_UNI_DAY_MAX_BLOCKS = 1;
 export const MAX_RECOMMENDED_HOURS_PER_DAY = 6;
 /** Ab so vielen Einheiten desselben Fachs pro Woche gibt es eine kritische Anmerkung. */
 export const MAX_SUBJECT_SESSIONS_PER_WEEK = 5;
+/** Ab so vielen Doppel-Lerntagen in Folge gibt es eine kritische Anmerkung. */
+export const CONSECUTIVE_DOUBLE_SESSION_DAYS = 3;
 /** Bevorzugter Beginn an freien Tagen (Wochenende / keine Hochschul-Termine). */
 export const FREE_DAY_START_HOUR = 10;
 /** Keine Einheit endet nach 21:00 Uhr – auch unter der Woche schlaffreundlich. */
@@ -57,8 +61,12 @@ export interface ScheduleOptions {
   preferredStartHour?: number;
   /** Späteste Endzeit einer Einheit in Stunden (Default: 21). */
   latestEndHour?: number;
-  /** Maximale Einheiten pro Tag (Default: 2). */
+  /** Globales Tageslimit; überschreibt bei Angabe auch das Limit freier Tage. */
   maxSessionsPerDay?: number;
+  /** Fach des aktuell geplanten Lernplans, um bestehende Einheiten mitzuzählen. */
+  subject?: string;
+  /** Maximale Einheiten dieses Fachs pro Tag (Default: 2). */
+  maxSessionsPerSubjectPerDay?: number;
   /** Puffer vor/nach Hochschul-Terminen in Minuten (Default: 30). */
   hochschulBufferMin?: number;
 }
@@ -142,6 +150,14 @@ function addDays(d: Date, n: number): Date {
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function normalizeSubject(subject: string): string {
+  return subject.trim().toLocaleLowerCase("de-DE");
+}
+
+function isNextCalendarDay(previous: Date, current: Date): boolean {
+  return addDays(startOfDay(previous), 1).getTime() === startOfDay(current).getTime();
+}
 
 function isWeekend(d: Date): boolean {
   const wd = d.getDay();
@@ -252,6 +268,9 @@ export function scheduleStudyPlan(
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;
   const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   const maxPerDay = options.maxSessionsPerDay ?? MAX_SESSIONS_PER_DAY;
+  const maxPerSubjectDay =
+    options.maxSessionsPerSubjectPerDay ?? MAX_SESSIONS_PER_SUBJECT_PER_DAY;
+  const scheduledSubject = normalizeSubject(options.subject ?? "");
   // Hochschul-Blöcke pro Tag (für Tageslimit + frühere Startzeit an freien Tagen)
   const uniBlockCountCache = new Map<string, number>();
   const uniBlockCount = (day: Date): number => {
@@ -283,8 +302,28 @@ export function scheduleStudyPlan(
     }
     return count;
   };
+  const existingSubjectSessionCountCache = new Map<string, number>();
+  const existingSubjectSessionCount = (day: Date): number => {
+    if (!scheduledSubject) return 0;
+    const key = day.toDateString();
+    let count = existingSubjectSessionCountCache.get(key);
+    if (count === undefined) {
+      count = existingEvents.filter(
+        (e) =>
+          !e.allDay &&
+          isLernsessionEvent(e) &&
+          eventOverlapsDay(e, day) &&
+          normalizeSubject(e.subject ?? "") === scheduledSubject,
+      ).length;
+      existingSubjectSessionCountCache.set(key, count);
+    }
+    return count;
+  };
   const availableDayCapacity = (day: Date): number =>
-    Math.max(0, dayCap(day) - existingSessionCount(day));
+    Math.min(
+      Math.max(0, dayCap(day) - existingSessionCount(day)),
+      Math.max(0, maxPerSubjectDay - existingSubjectSessionCount(day)),
+    );
   const hochschulBufferMin =
     typeof options.hochschulBufferMin === "number" && Number.isFinite(options.hochschulBufferMin)
       ? Math.max(0, options.hochschulBufferMin)
@@ -335,8 +374,8 @@ export function scheduleStudyPlan(
 
   // Pro Woche `perWeek` Tage möglichst gleichmäßig wählen; volle Tage werden
   // durch die übrigen Tage der Woche ersetzt (Fallback-Reihenfolge). Reicht das
-  // nicht, darf in einem zweiten Durchgang eine zweite Einheit auf bereits
-  // belegte Tage gelegt werden (max. 2/Tag, mit Pause dazwischen).
+  // nicht, darf in einem zweiten Durchgang eine zweite Einheit desselben Fachs
+  // auf bereits belegte Tage gelegt werden (max. 2/Fach/Tag, mit Pause dazwischen).
   // Hochschul-Termine bekommen vor und nach dem Termin einen Puffer, in dem
   // keine Lerneinheit liegen darf (Heimfahrt/Essen). Eigene/lokale Termine
   // blockieren punktgenau.
@@ -427,7 +466,9 @@ export function scheduleStudyPlan(
       }
     }
     // Durchgang 2+: weitere Einheiten auf die freiesten Tage (Wochenende
-    // zuerst), bis zum jeweiligen Tageslimit (Wochenende bis zu 3 × 2 h = 6 h).
+    // zuerst), bis zum Fachlimit. Das globale Tageslimit lässt an freien Tagen
+    // weiterhin bis zu 3 × 2 h zu, die dritte Einheit muss aber aus einem
+    // anderen Fach stammen.
     let progressed = true;
     while (progressed && placedThisWeek < quota && remaining > 0) {
       progressed = false;
@@ -475,7 +516,7 @@ export function scheduleStudyPlan(
     usedInPhase++;
   }
 
-  // Hinweis aus dem Konzept: kritischer Plan zeigt trotzdem max. 2 h/Tag
+  // Kritische Pläne werden zusätzlich durch Wochen- und Tageskapazitäten gedeckelt.
   if (result.planType === "kritisch" && originallyNeeded > sessionsNeeded) {
     warnings.push(
       "Der berechnete Lernaufwand ist höher als die empfohlene maximale Wochenlernzeit.",
@@ -493,6 +534,7 @@ export function scheduleStudyPlan(
  *
  *  - mehr als MAX_RECOMMENDED_HOURS_PER_DAY Stunden Lernen an einem Tag
  *  - dasselbe Fach MAX_SUBJECT_SESSIONS_PER_WEEK-mal oder öfter in einer Woche
+ *  - drei Tage in Folge jeweils zwei Einheiten desselben Fachs
  *
  * Der Lernplan ist eine Basis, kein Pflichtprogramm – die Anmerkungen sollen
  * beim Organisieren helfen, nicht blockieren.
@@ -548,14 +590,13 @@ export function analyzeWorkload(
   }
 
   // 2) Ein Fach zu oft in derselben Woche
-  const normalizedSubject = (s: string) => s.trim().toLocaleLowerCase("de-DE");
   const perWeekSubject = new Map<string, { monday: Date; subject: string; count: number }>();
   for (const b of blocks) {
     if (!b.subject.trim()) continue;
     const monday = startOfDay(b.start);
     const wd = monday.getDay();
     monday.setDate(monday.getDate() - (wd === 0 ? 6 : wd - 1));
-    const key = `${monday.toISOString()}|${normalizedSubject(b.subject)}`;
+    const key = `${monday.toISOString()}|${normalizeSubject(b.subject)}`;
     const entry = perWeekSubject.get(key) ?? { monday, subject: b.subject.trim(), count: 0 };
     entry.count++;
     perWeekSubject.set(key, entry);
@@ -567,7 +608,7 @@ export function analyzeWorkload(
   // Pro Fach nur eine Meldung (statt eine pro Fach × Woche)
   const bySubject = new Map<string, { subject: string; weeks: { monday: Date; count: number }[] }>();
   for (const e of overloadedWeeks) {
-    const key = normalizedSubject(e.subject);
+    const key = normalizeSubject(e.subject);
     const entry = bySubject.get(key) ?? { subject: e.subject, weeks: [] };
     entry.weeks.push({ monday: e.monday, count: e.count });
     bySubject.set(key, entry);
@@ -591,6 +632,45 @@ export function analyzeWorkload(
         `„${s.subject}“ steht in ${s.weeks.length} Wochen (ab ${shown}${rest > 0 ? ` und ${rest} weiteren` : ""}) ` +
           `bis zu ${maxCount}-mal pro Woche auf dem Plan. ${tail}`,
       );
+    }
+  }
+
+  // 3) Drei Tage hintereinander jeweils zwei oder mehr Einheiten desselben Fachs.
+  const perDaySubject = new Map<
+    string,
+    { subject: string; days: Map<number, number> }
+  >();
+  for (const block of blocks) {
+    if (!block.subject.trim()) continue;
+    const subjectKey = normalizeSubject(block.subject);
+    const entry = perDaySubject.get(subjectKey) ?? {
+      subject: block.subject.trim(),
+      days: new Map<number, number>(),
+    };
+    const dayKey = startOfDay(block.start).getTime();
+    entry.days.set(dayKey, (entry.days.get(dayKey) ?? 0) + 1);
+    perDaySubject.set(subjectKey, entry);
+  }
+
+  for (const entry of perDaySubject.values()) {
+    const doubleDays = [...entry.days.entries()]
+      .filter(([, count]) => count >= MAX_SESSIONS_PER_SUBJECT_PER_DAY)
+      .map(([day]) => new Date(day))
+      .sort((a, b) => a.getTime() - b.getTime());
+    let run: Date[] = [];
+    for (const day of doubleDays) {
+      const previous = run.at(-1);
+      run = previous && isNextCalendarDay(previous, day) ? [...run, day] : [day];
+      if (run.length < CONSECUTIVE_DOUBLE_SESSION_DAYS) continue;
+
+      const first = run[0];
+      const last = run.at(-1)!;
+      notes.push(
+        `„${entry.subject}“ ist vom ${fmtDay(first)} bis ${fmtDay(last)} an ${run.length} Tagen hintereinander ` +
+          `mit jeweils mindestens zwei Lerneinheiten geplant. Gönne dir zwischendurch einen Pausentag von diesem Fach ` +
+          `oder wechsle den Schwerpunkt, damit die Belastung nicht zu einseitig wird.`,
+      );
+      break;
     }
   }
 


### PR DESCRIPTION
## Was wurde geändert?

- Begrenzt automatisch geplante Lerneinheiten auf maximal zwei 2-Stunden-Blöcke desselben Fachs pro Tag.
- Behält das globale Maximum von drei Lerneinheiten an freien Tagen bei; die dritte Einheit muss aus einem anderen Fach stammen.
- Berücksichtigt bereits vorhandene Kalender-Lernsessions desselben Fachs beim Tageslimit.
- Ergänzt eine kritische Warnung, wenn drei Tage hintereinander jeweils mindestens zwei Einheiten desselben Fachs geplant sind.
- Passt die kritische Lernplan-Anzeige auf maximal vier Stunden pro Fach und Tag an.
- Präzisiert die Dokumentation: 3–4 Einheiten pro Woche sind ein Orientierungsbereich und kein Mindestwert.

## Warum?

Die bisherige Planung konnte an freien Tagen drei Einheiten desselben Fachs erzeugen. Gleichzeitig war die Dokumentation zur Wochenhäufigkeit missverständlich und stellte 3–4 Einheiten teilweise wie ein festes Minimum dar.

## Auswirkung

Die Planung verteilt hohe Lernlast fachlich ausgewogener, ohne die globale Tageskapazität unnötig zu reduzieren. Nutzer erhalten zusätzlich einen konkreten Hinweis, wenn mehrere intensive Tage desselben Fachs direkt aufeinanderfolgen.

## Validierung

- `npm.cmd run lint`
- `npm.cmd run build`
- Gezielter Scheduler-Check: zwei Mathematik-Einheiten plus eine Physik-Einheit an einem freien Tag
- Gezielter Warnungs-Check: drei aufeinanderfolgende Tage mit jeweils zwei Mathematik-Einheiten