### PR TITLE
fix(scheduler): heutigen Tag und Sonntag einplanen

### DIFF
--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -247,8 +247,11 @@ export function scheduleStudyPlan(
   const warnings: string[] = [];
   const now = options.now ?? new Date();
   const deadline = startOfDay(options.deadline);
-  const firstDay = startOfDay(options.startDate ?? addDays(now, 1));
-  const allowedWeekdays = options.allowedWeekdays ?? [1, 2, 3, 4, 5, 6]; // Mo–Sa
+  // Auch der heutige Tag ist planbar: findFreeSlot filtert ueber notBefore=now
+  // ohnehin bereits vergangene Uhrzeiten heraus, sodass z. B. am Vormittag noch
+  // ein Slot fuer den Nachmittag belegt werden kann.
+  const firstDay = startOfDay(options.startDate ?? now);
+  const allowedWeekdays = options.allowedWeekdays ?? [0, 1, 2, 3, 4, 5, 6]; // Mo–So
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;
   const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   const maxPerDay = options.maxSessionsPerDay ?? MAX_SESSIONS_PER_DAY;

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -47,11 +47,11 @@ export const HOCHSCHUL_BUFFER_MIN = 30;
 export interface ScheduleOptions {
   /** Klausur-/Zieldatum; am Tag selbst wird nicht mehr geplant. */
   deadline: Date;
-  /** Erster planbarer Tag (Default: morgen). */
+  /** Erster planbarer Tag (Default: heute). */
   startDate?: Date;
   /** Für deterministische Planung (z. B. Tests/Preview). Default: aktuelle Zeit. */
   now?: Date;
-  /** Erlaubte Wochentage, 0 = So … 6 = Sa (Default: Mo–Sa, Entscheidung 8.1). */
+  /** Erlaubte Wochentage, 0 = So … 6 = Sa (Default: Mo–So, alle Tage). */
   allowedWeekdays?: number[];
   /** Bevorzugte Startstunde der Einheiten (Default: 16). */
   preferredStartHour?: number;

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -247,21 +247,23 @@ export function scheduleStudyPlan(
   const warnings: string[] = [];
   const now = options.now ?? new Date();
   const deadline = startOfDay(options.deadline);
+  const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   // Startdatum: explizites startDate übernehmen; fehlt es, wird „heute“ nur
   // dann gewählt, wenn auf dem 30-Min-Raster noch mindestens ein 2-h-Slot ins
   // Tageszeitfenster passt – andernfalls auf morgen zurückfallen, um die
   // Kapazitäts- und Wochenberechnung nicht zu überschätzen.
   const firstDay = (() => {
     if (options.startDate !== undefined) return startOfDay(options.startDate);
-    const effectiveLatestEnd = (options.latestEndHour ?? LATEST_END_HOUR) * 60;
-    const nowMinutes = now.getHours() * 60 + now.getMinutes();
-    const nextGridStart = Math.ceil(nowMinutes / 30) * 30;
-    if (nextGridStart + SLOT_HOURS * 60 <= effectiveLatestEnd) return startOfDay(now);
+    const nowSinceDayStartMs =
+      (((now.getHours() * 60 + now.getMinutes()) * 60 + now.getSeconds()) * 1000 +
+        now.getMilliseconds());
+    const nextGridStartMs = Math.ceil(nowSinceDayStartMs / (30 * 60 * 1000)) * (30 * 60 * 1000);
+    const effectiveLatestEndMs = latestEndHour * 60 * 60 * 1000;
+    if (nextGridStartMs + SLOT_HOURS * 60 * 60 * 1000 <= effectiveLatestEndMs) return startOfDay(now);
     return startOfDay(addDays(now, 1));
   })();
   const allowedWeekdays = options.allowedWeekdays ?? [0, 1, 2, 3, 4, 5, 6]; // Mo–So
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;
-  const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   const maxPerDay = options.maxSessionsPerDay ?? MAX_SESSIONS_PER_DAY;
   // Hochschul-Blöcke pro Tag (für Tageslimit + frühere Startzeit an freien Tagen)
   const uniBlockCountCache = new Map<string, number>();

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -247,9 +247,9 @@ export function scheduleStudyPlan(
   const warnings: string[] = [];
   const now = options.now ?? new Date();
   const deadline = startOfDay(options.deadline);
-  // Auch der heutige Tag ist planbar: findFreeSlot filtert ueber notBefore=now
+  // Auch der heutige Tag ist planbar: findFreeSlot filtert über notBefore=now
   // ohnehin bereits vergangene Uhrzeiten heraus, sodass z. B. am Vormittag noch
-  // ein Slot fuer den Nachmittag belegt werden kann.
+  // ein Slot für den Nachmittag belegt werden kann.
   const firstDay = startOfDay(options.startDate ?? now);
   const allowedWeekdays = options.allowedWeekdays ?? [0, 1, 2, 3, 4, 5, 6]; // Mo–So
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -47,7 +47,7 @@ export const HOCHSCHUL_BUFFER_MIN = 30;
 export interface ScheduleOptions {
   /** Klausur-/Zieldatum; am Tag selbst wird nicht mehr geplant. */
   deadline: Date;
-  /** Erster planbarer Tag (Default: heute). */
+  /** Erster planbarer Tag (Default: heute, falls noch ein 2-h-Slot passt, sonst morgen). */
   startDate?: Date;
   /** Für deterministische Planung (z. B. Tests/Preview). Default: aktuelle Zeit. */
   now?: Date;
@@ -247,10 +247,18 @@ export function scheduleStudyPlan(
   const warnings: string[] = [];
   const now = options.now ?? new Date();
   const deadline = startOfDay(options.deadline);
-  // Auch der heutige Tag ist planbar: findFreeSlot filtert über notBefore=now
-  // ohnehin bereits vergangene Uhrzeiten heraus, sodass z. B. am Vormittag noch
-  // ein Slot für den Nachmittag belegt werden kann.
-  const firstDay = startOfDay(options.startDate ?? now);
+  // Startdatum: explizites startDate übernehmen; fehlt es, wird „heute" nur
+  // dann gewählt, wenn auf dem 30-Min-Raster noch mindestens ein 2-h-Slot ins
+  // Tageszeitfenster passt – andernfalls auf morgen zurückfallen, um die
+  // Kapazitäts- und Wochenberechnung nicht zu überschätzen.
+  const firstDay = (() => {
+    if (options.startDate !== undefined) return startOfDay(options.startDate);
+    const effectiveLatestEnd = (options.latestEndHour ?? LATEST_END_HOUR) * 60;
+    const nowMinutes = now.getHours() * 60 + now.getMinutes();
+    const nextGridStart = Math.ceil(nowMinutes / 30) * 30;
+    if (nextGridStart + SLOT_HOURS * 60 <= effectiveLatestEnd) return startOfDay(now);
+    return startOfDay(addDays(now, 1));
+  })();
   const allowedWeekdays = options.allowedWeekdays ?? [0, 1, 2, 3, 4, 5, 6]; // Mo–So
   const preferredStartHour = options.preferredStartHour ?? PREFERRED_START_HOUR;
   const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -247,7 +247,7 @@ export function scheduleStudyPlan(
   const warnings: string[] = [];
   const now = options.now ?? new Date();
   const deadline = startOfDay(options.deadline);
-  // Startdatum: explizites startDate übernehmen; fehlt es, wird „heute" nur
+  // Startdatum: explizites startDate übernehmen; fehlt es, wird „heute“ nur
   // dann gewählt, wenn auf dem 30-Min-Raster noch mindestens ein 2-h-Slot ins
   // Tageszeitfenster passt – andernfalls auf morgen zurückfallen, um die
   // Kapazitäts- und Wochenberechnung nicht zu überschätzen.


### PR DESCRIPTION
## Problem
Beim Einplanen eines Lernplans wurden zwei nutzbare Lerntage stillschweigend ausgelassen:

1. **Heute fiel raus.** `firstDay = addDays(now, 1)` — der Erstelltag war nie planbar, auch wenn man am Vormittag anlegt und abends noch Zeit ist.
2. **Sonntag fiel raus.** `allowedWeekdays = [1..6]` (Mo–Sa). Bei knappen/kritischen Plänen ging dadurch ein ganzer Lerntag verloren.

## Änderung
- `firstDay` startet ab **heute**. `findFreeSlot` filtert vergangene Uhrzeiten ohnehin über `notBefore = now` heraus, es entstehen also keine Slots in der Vergangenheit.
- `allowedWeekdays` = **Mo–So**.

## Hinweis zur Produktentscheidung
PR #109 hatte Sonntag bewusst ausgeschlossen ("Sundays remain excluded"). Diese Änderung kehrt das um — Begründung: bei kurzer Frist ist jeder Tag wertvoll, und der Nutzer kann Sonntage ja freilassen, indem er sie nicht nutzt. Falls das Team das anders sehen will, gern hier diskutieren.

## Test
- `npm run lint` + `npm run build` grün
- Manuell: Plan mit naher Deadline einplanen → Sessions verteilen sich jetzt auch auf heute (nach aktueller Uhrzeit) und Sonntag