### PR TITLE
fix(study-plan): Lerneinheiten beim Löschen des Lernplans entfernen

### DIFF
--- a/prisma/migrations/20260614124527_studyplan_delete_cascades_events/migration.sql
+++ b/prisma/migrations/20260614124527_studyplan_delete_cascades_events/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "CalendarEvent" DROP CONSTRAINT "CalendarEvent_studyPlanId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_studyPlanId_fkey" FOREIGN KEY ("studyPlanId") REFERENCES "StudyPlan"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -162,7 +162,10 @@ model CalendarEvent {
   // Bei Task-Löschung bleibt der Kalendereintrag erhalten und verliert nur
   // die Verknüpfung (PRD §8.1).
   task      Task?      @relation(fields: [taskId], references: [id], onDelete: SetNull)
-  studyPlan StudyPlan? @relation(fields: [studyPlanId], references: [id], onDelete: SetNull)
+  // Beim Löschen eines Lernplans werden die generierten Lerneinheiten im
+  // Kalender mitgelöscht – sonst bleiben verwaiste Termine ohne Plan-Bezug
+  // zurück (analog zu Task, das ebenfalls per Cascade am Plan hängt).
+  studyPlan StudyPlan? @relation(fields: [studyPlanId], references: [id], onDelete: Cascade)
 
   @@index([ownerId])
   @@index([startsAt])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -164,7 +164,7 @@ model CalendarEvent {
   task      Task?      @relation(fields: [taskId], references: [id], onDelete: SetNull)
   // Beim Löschen eines Lernplans werden die generierten Lerneinheiten im
   // Kalender mitgelöscht – sonst bleiben verwaiste Termine ohne Plan-Bezug
-  // zurück (analog zu Task, das ebenfalls per Cascade am Plan hängt).
+  // zurück (analog zu Task.studyPlan, das ebenfalls per Cascade am Plan hängt).
   studyPlan StudyPlan? @relation(fields: [studyPlanId], references: [id], onDelete: Cascade)
 
   @@index([ownerId])


### PR DESCRIPTION
## Problem
Beim Löschen eines Lernplans blieben die generierten Lerneinheiten als **verwaiste Termine** im Kalender zurück. Ursache: `CalendarEvent.studyPlan` stand auf `onDelete: SetNull` — der Plan-Bezug wurde genullt, das Event aber nicht gelöscht. Konkret aufgefallen: nach Löschen + Neuanlage eines Plans hingen alte Lernsessions ohne Plan-Bezug im Kalender.

## Änderung
`onDelete: SetNull` → `onDelete: Cascade` für `CalendarEvent.studyPlan`, analog zu `Task`, das ebenfalls per Cascade am Plan hängt. Migration enthalten.

## Hinweis
`Task` (onDelete SetNull) bleibt bewusst unverändert — dort ist das gewollte Verhalten dokumentiert (PRD §8.1: bei Task-Löschung bleibt der Kalendereintrag erhalten).

## Test
- `npm run lint` + `npm run build` grün
- Migration `20260614124527_studyplan_delete_cascades_events` erstellt + lokal angewandt
- Manuell: Plan mit Lerneinheiten löschen → Lerneinheiten verschwinden jetzt mit aus dem Kalender