### PR TITLE
feat(calendar): Zieldaten der Lernpläne als Zieltermine im Kalender (E3)

### DIFF
--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -1,4 +1,4 @@
-import { EventType as DbEventType } from "@prisma/client";
+import { EventType as DbEventType, GoalType } from "@prisma/client";
 import { NextResponse } from "next/server";
 import {
   getEventColor,
@@ -7,6 +7,15 @@ import {
 } from "@/components/calendar/events";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
+
+// Beschriftung des Zieltermins je Lernplan-Zieltyp (z. B. "Klausur: Mathe 2").
+const GOAL_LABEL: Record<GoalType, string> = {
+  KLAUSUR: "Klausur",
+  ABGABE: "Abgabe",
+  PRAESENTATION: "Präsentation",
+  SELBSTLERNZIEL: "Lernziel",
+  SONSTIGES: "Zieltermin",
+};
 
 const TYPE_TO_DB: Record<string, DbEventType> = {
   Lernsession: "LERNEINHEIT",
@@ -62,7 +71,34 @@ export async function GET() {
     };
   });
 
-  return NextResponse.json({ events });
+  // Zieldaten der Lernplaene als abgeleitete, read-only Zieltermine ergaenzen.
+  // Quelle bleibt StudyPlan.targetDate (kein doppeltes Speichern) – aendert sich
+  // das Zieldatum, zieht der Kalender automatisch mit. Nicht editierbar, da
+  // abgeleitet (siehe CLAUDE.md: read-only Events duerfen nicht editierbar sein).
+  const plans = await prisma.studyPlan.findMany({
+    where: { ownerId: session.userId },
+    select: { id: true, subject: true, goalType: true, targetDate: true },
+  });
+
+  const deadlineEvents = plans.map((plan) => {
+    const iso = plan.targetDate.toISOString();
+    return {
+      id: `plan-deadline-${plan.id}`,
+      title: `${GOAL_LABEL[plan.goalType]}: ${plan.subject}`,
+      start: iso,
+      end: iso,
+      allDay: true,
+      type: "Deadline",
+      color: getEventColor("Deadline", "bg-brand-red"),
+      source: "local" as const,
+      important: true,
+      readOnly: true,
+      repeat: "none" as const,
+      studyPlanId: plan.id,
+    };
+  });
+
+  return NextResponse.json({ events: [...events, ...deadlineEvents] });
 }
 
 /** POST /api/calendar/events - neues lokales Event speichern */

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -81,16 +81,25 @@ export async function GET() {
   });
 
   const deadlineEvents = plans.map((plan) => {
-    const iso = plan.targetDate.toISOString();
+    // Ganztaegiger Zieltermin: Ende exklusiv auf den Folgetag, damit
+    // eventOverlapsDay() (verlangt end > dayStart) den Termin am Zieltag in
+    // Monats-, Wochen- und Tagesansicht anzeigt.
+    const dayStart = new Date(plan.targetDate);
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date(dayStart);
+    dayEnd.setDate(dayEnd.getDate() + 1);
     return {
       id: `plan-deadline-${plan.id}`,
       title: `${GOAL_LABEL[plan.goalType]}: ${plan.subject}`,
-      start: iso,
-      end: iso,
+      start: dayStart.toISOString(),
+      end: dayEnd.toISOString(),
       allDay: true,
       type: "Deadline",
       color: getEventColor("Deadline", "bg-brand-red"),
       source: "local" as const,
+      // Fach mitgeben, damit der Fachfilter greift und das Fach in der
+      // Detailansicht erscheint.
+      subject: plan.subject,
       important: true,
       readOnly: true,
       repeat: "none" as const,


### PR DESCRIPTION
## Worum geht's (Issue #48 / E3)
Bisher erschienen nur die generierten Lernsessions im Kalender, aber **nicht das Zieldatum selbst** (Klausur/Abgabe). Der Tag, auf den der ganze Plan hinarbeitet, war im Kalender unsichtbar.

## Änderung
Die GET-Route `/api/calendar/events` ergänzt pro Lernplan ein **abgeleitetes, read-only Zieltermin-Event** am `targetDate` (z. B. "Klausur: Mathe 2").

- **Einzige Quelle bleibt `StudyPlan.targetDate`** — kein doppeltes Speichern. Ändert man das Zieldatum, zieht der Kalender automatisch mit.
- **read-only** (nicht verschieb-/löschbar, wie die DHBW-Events) — entspricht der CLAUDE.md-Regel für abgeleitete Events.
- **Ganztägig, rot, `important`** → visuell klar abgesetzt von den blauen Lerneinheiten.

## Erfüllt von #48
- [x] AK1 Zieldatum erscheint im Kalender (neu)
- [x] AK2 Fällige Lernaufgaben erscheinen im Kalender (war schon)
- [x] AK3 Zieltermine/Lerneinheiten/manuell visuell unterscheidbar (neu)
- [x] AK4 Klick → Details (war schon)

## Test
- `npm run lint` + `npm run build` grün
- Geprüft, dass die allDay-Zieltermine den Scheduler nicht stören (kollidieren nicht, blockieren keine Lern-Slots)
- DB-Check: Plan mit Zieldatum 17.6. erzeugt korrektes Zieltermin-Event