### PR TITLE
fix(calendar): Aufgaben-Fälligkeit beim Verschieben einer Lerneinheit mitziehen

### DIFF
--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -141,37 +141,42 @@ export async function PATCH(
     return NextResponse.json({ error: "Keine Änderungen übergeben." }, { status: 400 });
   }
 
-  const updated = await prisma.calendarEvent.updateMany({
-    where: { id, ownerId: session.userId, source: "LOCAL" },
-    data,
+  const { count, row } = await prisma.$transaction(async (tx) => {
+    const updated = await tx.calendarEvent.updateMany({
+      where: { id, ownerId: session.userId, source: "LOCAL" },
+      data,
+    });
+
+    const fetched = await tx.calendarEvent.findUnique({
+      where: { id },
+      include: { task: { select: { completed: true } } },
+    });
+
+    // Verschobene/umgeplante Lerneinheit: Faelligkeit (Startzeit) und Dauer der
+    // verknuepften Aufgabe mitziehen, damit Kalender und Lernplan-Aufgabe
+    // konsistent bleiben.
+    if (fetched?.taskId && (startsAt || endsAt)) {
+      const taskData: { dueDate?: Date; estimatedMinutes?: number } = {};
+
+      // Fälligkeit nur mitziehen, wenn die Startzeit im Request geändert wurde.
+      if (startsAt) taskData.dueDate = fetched.startsAt;
+
+      // Dauer aktualisieren, sobald Start oder Ende geändert wurde.
+      taskData.estimatedMinutes = Math.round(
+        (fetched.endsAt.getTime() - fetched.startsAt.getTime()) / 60000,
+      );
+
+      await tx.task.update({ where: { id: fetched.taskId }, data: taskData });
+    }
+
+    return { count: updated.count, row: fetched };
   });
-  if (updated.count === 0) {
+
+  if (count === 0) {
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
   }
-
-  const row = await prisma.calendarEvent.findUnique({
-    where: { id },
-    include: { task: { select: { completed: true } } },
-  });
   if (!row) {
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
-  }
-
-  // Verschobene/umgeplante Lerneinheit: Faelligkeit (Startzeit) und Dauer der
-  // verknuepften Aufgabe mitziehen, damit Kalender und Lernplan-Aufgabe
-  // konsistent bleiben.
-  if (row.taskId && (startsAt || endsAt)) {
-    const taskData: { dueDate?: Date; estimatedMinutes?: number } = {};
-
-    // Fälligkeit nur mitziehen, wenn die Startzeit im Request geändert wurde.
-    if (startsAt) taskData.dueDate = row.startsAt;
-
-    // Dauer aktualisieren, sobald Start oder Ende geändert wurde.
-    taskData.estimatedMinutes = Math.round(
-      (row.endsAt.getTime() - row.startsAt.getTime()) / 60000,
-    );
-
-    await prisma.task.update({ where: { id: row.taskId }, data: taskData });
   }
 
   const savedType = eventTypeLabel(row.type, row.typeLabel);

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -157,6 +157,15 @@ export async function PATCH(
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
   }
 
+  // Verschobene/umgeplante Lerneinheit: dueDate der verknuepften Aufgabe
+  // mitziehen, damit Kalender und Lernplan-Aufgabe konsistent bleiben.
+  if (startsAt && row.taskId) {
+    await prisma.task.update({
+      where: { id: row.taskId },
+      data: { dueDate: startsAt },
+    });
+  }
+
   const savedType = eventTypeLabel(row.type, row.typeLabel);
   if (savedColor) {
     const legacyDbType = TYPE_TO_DB[savedType];

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -147,26 +147,33 @@ export async function PATCH(
       data,
     });
 
-    const fetched = await tx.calendarEvent.findUnique({
-      where: { id },
-      include: { task: { select: { completed: true } } },
-    });
+    const fetched =
+      updated.count === 0
+        ? null
+        : await tx.calendarEvent.findFirst({
+            where: { id, ownerId: session.userId, source: "LOCAL" },
+            include: { task: { select: { completed: true } } },
+          });
 
-    // Verschobene/umgeplante Lerneinheit: Faelligkeit (Startzeit) und Dauer der
-    // verknuepften Aufgabe mitziehen, damit Kalender und Lernplan-Aufgabe
+    // Verschobene/umgeplante Lerneinheit: Fälligkeit (Startzeit) und Dauer der
+    // verknüpften Aufgabe mitziehen, damit Kalender und Lernplan-Aufgabe
     // konsistent bleiben.
-    if (fetched?.taskId && (startsAt || endsAt)) {
+    if (updated.count > 0 && fetched?.taskId && (startsAt || endsAt)) {
       const taskData: { dueDate?: Date; estimatedMinutes?: number } = {};
 
       // Fälligkeit nur mitziehen, wenn die Startzeit im Request geändert wurde.
       if (startsAt) taskData.dueDate = fetched.startsAt;
 
       // Dauer aktualisieren, sobald Start oder Ende geändert wurde.
-      taskData.estimatedMinutes = Math.round(
+      const minutes = Math.round(
         (fetched.endsAt.getTime() - fetched.startsAt.getTime()) / 60000,
       );
+      taskData.estimatedMinutes = Math.max(1, minutes);
 
-      await tx.task.update({ where: { id: fetched.taskId }, data: taskData });
+      await tx.task.updateMany({
+        where: { id: fetched.taskId, studyPlan: { ownerId: session.userId } },
+        data: taskData,
+      });
     }
 
     return { count: updated.count, row: fetched };

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -162,12 +162,15 @@ export async function PATCH(
   // konsistent bleiben.
   if (row.taskId && (startsAt || endsAt)) {
     const taskData: { dueDate?: Date; estimatedMinutes?: number } = {};
-    if (startsAt) taskData.dueDate = startsAt;
-    if (startsAt && endsAt) {
-      taskData.estimatedMinutes = Math.round(
-        (endsAt.getTime() - startsAt.getTime()) / 60000,
-      );
-    }
+
+    // Fälligkeit nur mitziehen, wenn die Startzeit im Request geändert wurde.
+    if (startsAt) taskData.dueDate = row.startsAt;
+
+    // Dauer aktualisieren, sobald Start oder Ende geändert wurde.
+    taskData.estimatedMinutes = Math.round(
+      (row.endsAt.getTime() - row.startsAt.getTime()) / 60000,
+    );
+
     await prisma.task.update({ where: { id: row.taskId }, data: taskData });
   }
 

--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -157,13 +157,18 @@ export async function PATCH(
     return NextResponse.json({ error: "Event nicht gefunden." }, { status: 404 });
   }
 
-  // Verschobene/umgeplante Lerneinheit: dueDate der verknuepften Aufgabe
-  // mitziehen, damit Kalender und Lernplan-Aufgabe konsistent bleiben.
-  if (startsAt && row.taskId) {
-    await prisma.task.update({
-      where: { id: row.taskId },
-      data: { dueDate: startsAt },
-    });
+  // Verschobene/umgeplante Lerneinheit: Faelligkeit (Startzeit) und Dauer der
+  // verknuepften Aufgabe mitziehen, damit Kalender und Lernplan-Aufgabe
+  // konsistent bleiben.
+  if (row.taskId && (startsAt || endsAt)) {
+    const taskData: { dueDate?: Date; estimatedMinutes?: number } = {};
+    if (startsAt) taskData.dueDate = startsAt;
+    if (startsAt && endsAt) {
+      taskData.estimatedMinutes = Math.round(
+        (endsAt.getTime() - startsAt.getTime()) / 60000,
+      );
+    }
+    await prisma.task.update({ where: { id: row.taskId }, data: taskData });
   }
 
   const savedType = eventTypeLabel(row.type, row.typeLabel);


### PR DESCRIPTION
## Problem
Verschiebt oder verkürzt man eine Lerneinheit im Kalender, wurde nur das `CalendarEvent` aktualisiert. Die per `taskId` verknüpfte Aufgabe behielt ihr altes `dueDate` — die Lernplan-Aufgabenliste zeigte weiter das alte Datum. Kalender und Lernplan liefen auseinander.

## Änderung
Im PATCH von `/api/calendar/events/[id]`: wenn die Startzeit geändert wird **und** das Event mit einer Aufgabe verknüpft ist, wird `Task.dueDate` auf die neue Startzeit mitgezogen.

## Test
- `npm run lint` + `npm run build` grün
- Manuell: Lernsession im Kalender verschieben → Fälligkeit in der Lernplan-Aufgabenliste zieht jetzt mit