### PR TITLE
[codex] D3 Aufgabenvalidierung und Fortschrittstests absichern

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "test": "node --test --experimental-strip-types tests/study-plan/taskValidation.test.mjs tests/study-plan/progress.test.mjs",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "setup": "node scripts/setup.mjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "node --test --experimental-strip-types tests/study-plan/taskValidation.test.mjs tests/study-plan/progress.test.mjs",
+    "test": "node --test --experimental-strip-types tests"
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "setup": "node scripts/setup.mjs"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "node --test --experimental-strip-types tests"
+    "test": "node --test --experimental-strip-types tests",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "setup": "node scripts/setup.mjs"

--- a/src/app/api/study-plan/[id]/tasks/[taskId]/route.ts
+++ b/src/app/api/study-plan/[id]/tasks/[taskId]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
-import { serializeTask, toIntInRange, toPositiveInt } from "@/lib/study-plan/types";
+import { serializeTask } from "@/lib/study-plan/types";
+import { validateTaskInput } from "@/lib/study-plan/taskValidation";
 
 /** Prüft, dass Lernplan + Aufgabe existieren und dem User gehören. */
 async function ownsTask(userId: string, planId: string, taskId: string) {
@@ -33,41 +34,16 @@ export async function PATCH(
   } catch {
     return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
   }
-  const b = (body ?? {}) as Record<string, unknown>;
-
-  const data: Record<string, unknown> = {};
-
-  if (typeof b.title === "string" && b.title.trim()) data.title = b.title.trim();
-
-  if (b.description === null) data.description = null;
-  else if (typeof b.description === "string") data.description = b.description.trim() || null;
-
-  if ("estimatedMinutes" in b) {
-    const m = toPositiveInt(b.estimatedMinutes);
-    if (m) data.estimatedMinutes = m;
+  const validation = validateTaskInput(body, "patch");
+  if ("error" in validation) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
   }
 
-  if ("difficulty" in b) {
-    const d = toIntInRange(b.difficulty, 1, 5);
-    if (d) data.difficulty = d;
-  }
+  const data: Record<string, unknown> = { ...validation.data };
 
-  if (typeof b.dueDate === "string") {
-    const due = new Date(b.dueDate);
-    if (Number.isNaN(due.getTime())) {
-      return NextResponse.json({ error: "Ungültiges Fälligkeitsdatum." }, { status: 400 });
-    }
-    data.dueDate = due;
-  }
-
-  if (typeof b.completed === "boolean") {
-    data.completed = b.completed;
+  if (typeof validation.data.completed === "boolean") {
     // completedAt mitführen, damit der Erledigungszeitpunkt korrekt ist.
-    data.completedAt = b.completed ? new Date() : null;
-  }
-
-  if (Object.keys(data).length === 0) {
-    return NextResponse.json({ error: "Keine Änderungen übergeben." }, { status: 400 });
+    data.completedAt = validation.data.completed ? new Date() : null;
   }
 
   const updated = await prisma.task.update({ where: { id: taskId }, data });

--- a/src/app/api/study-plan/[id]/tasks/route.ts
+++ b/src/app/api/study-plan/[id]/tasks/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
-import { serializeTask, toIntInRange, toPositiveInt } from "@/lib/study-plan/types";
+import { serializeTask } from "@/lib/study-plan/types";
+import { validateTaskInput } from "@/lib/study-plan/taskValidation";
 
 /** POST /api/study-plan/[id]/tasks — neue Aufgabe zu einem Lernplan anlegen. */
 export async function POST(
@@ -30,33 +31,18 @@ export async function POST(
   } catch {
     return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
   }
-  const b = (body ?? {}) as Record<string, unknown>;
-
-  if (typeof b.title !== "string" || !b.title.trim() || typeof b.dueDate !== "string") {
-    return NextResponse.json(
-      { error: "Pflichtfelder fehlen oder sind ungültig." },
-      { status: 400 },
-    );
+  const validation = validateTaskInput(body, "create");
+  if ("error" in validation) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
   }
-
-  const due = new Date(b.dueDate);
-  if (Number.isNaN(due.getTime())) {
-    return NextResponse.json({ error: "Ungültiges Fälligkeitsdatum." }, { status: 400 });
-  }
-
-  const estimatedMinutes = toPositiveInt(b.estimatedMinutes) ?? 60;
-  const difficulty = toIntInRange(b.difficulty, 1, 5) ?? 3;
 
   const task = await prisma.task.create({
     data: {
-      title: b.title.trim(),
-      description:
-        typeof b.description === "string" && b.description.trim()
-          ? b.description.trim()
-          : null,
-      estimatedMinutes,
-      difficulty,
-      dueDate: due,
+      title: validation.data.title!,
+      description: validation.data.description ?? null,
+      estimatedMinutes: validation.data.estimatedMinutes!,
+      difficulty: validation.data.difficulty!,
+      dueDate: validation.data.dueDate!,
       studyPlanId: id,
     },
   });

--- a/src/app/api/study-plan/route.ts
+++ b/src/app/api/study-plan/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
 import { calculateStudyPlan } from "@/lib/calculations/studyPlanAlgorithm";
+import { calculateTaskProgress } from "@/lib/study-plan/progress";
 import {
   isValidGoalType,
   serializeStudyPlan,
@@ -29,7 +30,7 @@ export async function GET() {
   });
 
   const studyPlans: StudyPlanSummaryDTO[] = plans.map((p) => {
-    const completedTaskCount = p.tasks.filter((t) => t.completed).length;
+    const { completedTaskCount } = calculateTaskProgress(p.tasks);
     const next = p.tasks.find((t) => !t.completed) ?? null;
     return {
       ...serializeStudyPlan(p),

--- a/src/components/study-plan/StudyPlanDetail.tsx
+++ b/src/components/study-plan/StudyPlanDetail.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, CalendarDays, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { calculateTaskProgress } from "@/lib/study-plan/progress";
 import type { StudyPlanDetailDTO } from "@/lib/study-plan/types";
 import { GOAL_TYPE_META, formatDate, remainingLabel } from "./planMeta";
 import { AlgorithmResultWidget } from "./AlgorithmResultWidget";
@@ -75,9 +76,10 @@ export function StudyPlanDetail({ planId }: StudyPlanDetailProps) {
   const meta = GOAL_TYPE_META[plan.goalType];
   const GoalIcon = meta.icon;
   const remaining = remainingLabel(plan.targetDate);
-  const completedCount = plan.tasks.filter((t) => t.completed).length;
-  const progress =
-    plan.tasks.length > 0 ? Math.round((completedCount / plan.tasks.length) * 100) : 0;
+  const {
+    completedTaskCount: completedCount,
+    percentage: progress,
+  } = calculateTaskProgress(plan.tasks);
 
   return (
     <div className="flex flex-col h-full p-6 gap-5 overflow-auto">

--- a/src/lib/study-plan/progress.ts
+++ b/src/lib/study-plan/progress.ts
@@ -1,0 +1,20 @@
+interface TaskCompletion {
+  completed: boolean;
+}
+
+export interface TaskProgress {
+  taskCount: number;
+  completedTaskCount: number;
+  percentage: number;
+}
+
+export function calculateTaskProgress(tasks: readonly TaskCompletion[]): TaskProgress {
+  const completedTaskCount = tasks.filter((task) => task.completed).length;
+  const taskCount = tasks.length;
+
+  return {
+    taskCount,
+    completedTaskCount,
+    percentage: taskCount > 0 ? Math.round((completedTaskCount / taskCount) * 100) : 0,
+  };
+}

--- a/src/lib/study-plan/progress.ts
+++ b/src/lib/study-plan/progress.ts
@@ -9,8 +9,9 @@ export interface TaskProgress {
 }
 
 export function calculateTaskProgress(tasks: readonly TaskCompletion[]): TaskProgress {
-  const completedTaskCount = tasks.filter((task) => task.completed).length;
   const taskCount = tasks.length;
+  let completedTaskCount = 0;
+  for (const task of tasks) if (task.completed) completedTaskCount++;
 
   return {
     taskCount,

--- a/src/lib/study-plan/taskValidation.ts
+++ b/src/lib/study-plan/taskValidation.ts
@@ -1,0 +1,99 @@
+export interface ValidatedTaskInput {
+  title?: string;
+  description?: string | null;
+  estimatedMinutes?: number;
+  difficulty?: number;
+  dueDate?: Date;
+  completed?: boolean;
+}
+
+interface ValidTaskInput {
+  data: ValidatedTaskInput;
+}
+
+interface InvalidTaskInput {
+  error: string;
+}
+
+export type TaskValidationResult = ValidTaskInput | InvalidTaskInput;
+
+function parseInteger(value: unknown): number | null {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+export function validateTaskInput(
+  body: unknown,
+  mode: "create" | "patch",
+): TaskValidationResult {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { error: "Ungültiger Anfrage-Body." };
+  }
+
+  const input = body as Record<string, unknown>;
+  const data: ValidatedTaskInput = {};
+
+  if (mode === "create" || "title" in input) {
+    if (typeof input.title !== "string" || !input.title.trim()) {
+      return { error: "Ein Titel ist erforderlich." };
+    }
+    data.title = input.title.trim();
+  }
+
+  if ("description" in input) {
+    if (input.description === null) {
+      data.description = null;
+    } else if (typeof input.description === "string") {
+      data.description = input.description.trim() || null;
+    } else {
+      return { error: "Die Beschreibung ist ungültig." };
+    }
+  }
+
+  if (mode === "create" || "estimatedMinutes" in input) {
+    const estimatedMinutes = parseInteger(input.estimatedMinutes);
+    if (estimatedMinutes === null || estimatedMinutes <= 0) {
+      return { error: "Der geschätzte Aufwand muss eine positive Ganzzahl sein." };
+    }
+    data.estimatedMinutes = estimatedMinutes;
+  }
+
+  if (mode === "create" || "difficulty" in input) {
+    const difficulty = parseInteger(input.difficulty);
+    if (difficulty === null || difficulty < 1 || difficulty > 5) {
+      return { error: "Die Schwierigkeit muss zwischen 1 und 5 liegen." };
+    }
+    data.difficulty = difficulty;
+  }
+
+  if (mode === "create" || "dueDate" in input) {
+    if (typeof input.dueDate !== "string" || !input.dueDate.trim()) {
+      return { error: "Ein Fälligkeitsdatum ist erforderlich." };
+    }
+
+    const dueDate = new Date(input.dueDate);
+    if (Number.isNaN(dueDate.getTime())) {
+      return { error: "Ungültiges Fälligkeitsdatum." };
+    }
+    data.dueDate = dueDate;
+  }
+
+  if ("completed" in input) {
+    if (typeof input.completed !== "boolean") {
+      return { error: "Der Aufgabenstatus ist ungültig." };
+    }
+    data.completed = input.completed;
+  }
+
+  if (mode === "patch" && Object.keys(data).length === 0) {
+    return { error: "Keine Änderungen übergeben." };
+  }
+
+  return { data };
+}

--- a/tests/study-plan/progress.test.mjs
+++ b/tests/study-plan/progress.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { calculateTaskProgress } from "../../src/lib/study-plan/progress.ts";
+
+test("liefert für einen leeren Lernplan null Prozent", () => {
+  assert.deepEqual(calculateTaskProgress([]), {
+    taskCount: 0,
+    completedTaskCount: 0,
+    percentage: 0,
+  });
+});
+
+test("leitet den Fortschritt aus erledigten Aufgaben ab", () => {
+  assert.deepEqual(
+    calculateTaskProgress([
+      { completed: true },
+      { completed: false },
+      { completed: true },
+    ]),
+    {
+      taskCount: 3,
+      completedTaskCount: 2,
+      percentage: 67,
+    },
+  );
+});
+
+test("liefert bei vollständig erledigten Aufgaben hundert Prozent", () => {
+  assert.deepEqual(
+    calculateTaskProgress([{ completed: true }, { completed: true }]),
+    {
+      taskCount: 2,
+      completedTaskCount: 2,
+      percentage: 100,
+    },
+  );
+});

--- a/tests/study-plan/taskValidation.test.mjs
+++ b/tests/study-plan/taskValidation.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateTaskInput } from "../../src/lib/study-plan/taskValidation.ts";
+
+const validTask = {
+  title: "Übungsblatt bearbeiten",
+  estimatedMinutes: 90,
+  difficulty: 4,
+  dueDate: "2026-06-20T00:00:00.000Z",
+};
+
+test("validiert und normalisiert eine neue Aufgabe", () => {
+  const result = validateTaskInput(
+    { ...validTask, title: "  Übungsblatt bearbeiten  ", description: "  Kapitel 3  " },
+    "create",
+  );
+
+  assert.equal(result.error, undefined);
+  assert.equal(result.data.title, "Übungsblatt bearbeiten");
+  assert.equal(result.data.description, "Kapitel 3");
+  assert.equal(result.data.estimatedMinutes, 90);
+  assert.equal(result.data.difficulty, 4);
+  assert.equal(result.data.dueDate.toISOString(), validTask.dueDate);
+});
+
+test("verlangt beim Anlegen alle D3-Pflichtfelder", () => {
+  for (const field of ["title", "estimatedMinutes", "difficulty", "dueDate"]) {
+    const input = { ...validTask };
+    delete input[field];
+
+    const result = validateTaskInput(input, "create");
+    assert.ok(result.error, `${field} muss erforderlich sein`);
+  }
+});
+
+test("lehnt ungültigen Aufwand ab, statt einen Standardwert zu verwenden", () => {
+  for (const estimatedMinutes of [0, -15, 1.5, "unbekannt"]) {
+    const result = validateTaskInput({ ...validTask, estimatedMinutes }, "create");
+    assert.match(result.error, /Aufwand/);
+  }
+});
+
+test("lehnt ungültige Schwierigkeit ab, statt einen Standardwert zu verwenden", () => {
+  for (const difficulty of [0, 6, 2.5, "schwer"]) {
+    const result = validateTaskInput({ ...validTask, difficulty }, "create");
+    assert.match(result.error, /Schwierigkeit/);
+  }
+});
+
+test("weist ungültige Werte auch beim Bearbeiten zurück", () => {
+  assert.match(validateTaskInput({ title: "   " }, "patch").error, /Titel/);
+  assert.match(validateTaskInput({ estimatedMinutes: 0 }, "patch").error, /Aufwand/);
+  assert.match(validateTaskInput({ difficulty: 9 }, "patch").error, /Schwierigkeit/);
+  assert.match(validateTaskInput({ dueDate: "kein-datum" }, "patch").error, /Fälligkeitsdatum/);
+  assert.match(validateTaskInput({ completed: "ja" }, "patch").error, /status/i);
+});
+
+test("akzeptiert Statusänderungen und lehnt leere Änderungen ab", () => {
+  assert.deepEqual(validateTaskInput({ completed: true }, "patch"), {
+    data: { completed: true },
+  });
+  assert.match(validateTaskInput({}, "patch").error, /Keine Änderungen/);
+});


### PR DESCRIPTION
## Zusammenfassung

- validiert Titel, Aufwand, Schwierigkeit, Fälligkeit und Status von Lernplan-Aufgaben zentral
- weist ungültige Create- und Patch-Eingaben mit HTTP 400 zurück, statt Standardwerte einzusetzen oder Werte stillschweigend zu ignorieren
- verwendet eine gemeinsame Fortschrittsberechnung in Lernplan-Detailansicht und Übersichts-API
- ergänzt automatisierte Tests für Aufgabenvalidierung und Fortschrittsberechnung

## Hintergrund

D3 war funktional umgesetzt, aber ungültiger Aufwand und ungültige Schwierigkeit konnten beim Anlegen auf Standardwerte zurückfallen. Beim Bearbeiten wurden einzelne ungültige Werte teilweise ignoriert. Außerdem fehlten automatisierte Tests für die D3-Kernlogik.

## Auswirkung

Die D3-Akzeptanzkriterien sind weiterhin vollständig abgedeckt. Fehlerhafte API-Eingaben werden nun eindeutig abgelehnt und die aus erledigten Aufgaben abgeleitete Fortschrittsberechnung ist automatisiert getestet.

## Validierung

- `npm test` - 9 Tests bestanden
- `npm run lint` - erfolgreich
- `npm run build` - erfolgreich