### PR TITLE
[codex] Implement deterministic learning plan calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "node --test --experimental-strip-types tests",
+    "test": "node --test --experimental-strip-types \"tests/**/*.test.mjs\"",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "setup": "node scripts/setup.mjs"

--- a/src/app/api/study-plan/[id]/replan/route.ts
+++ b/src/app/api/study-plan/[id]/replan/route.ts
@@ -62,15 +62,11 @@ export async function POST(
       const existingTask = tasksById.get(replannedTask.id);
       if (!existingTask || existingTask.completed) continue;
 
-      await transaction.task.update({
-        where: { id: existingTask.id },
-        data: { dueDate: replannedTask.dueDate },
-      });
-
       if (existingTask.calendarEvent) {
         const duration =
           existingTask.calendarEvent.endsAt.getTime() -
           existingTask.calendarEvent.startsAt.getTime();
+
         const startsAt = new Date(replannedTask.dueDate);
         startsAt.setHours(
           existingTask.calendarEvent.startsAt.getHours(),
@@ -79,12 +75,22 @@ export async function POST(
           existingTask.calendarEvent.startsAt.getMilliseconds(),
         );
 
+        await transaction.task.update({
+          where: { id: existingTask.id },
+          data: { dueDate: startsAt },
+        });
+
         await transaction.calendarEvent.update({
           where: { id: existingTask.calendarEvent.id },
           data: {
             startsAt,
             endsAt: new Date(startsAt.getTime() + duration),
           },
+        });
+      } else {
+        await transaction.task.update({
+          where: { id: existingTask.id },
+          data: { dueDate: replannedTask.dueDate },
         });
       }
     }

--- a/src/app/api/study-plan/[id]/replan/route.ts
+++ b/src/app/api/study-plan/[id]/replan/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import {
+  ReplanTasksInputError,
+  replanOpenTasks,
+} from "@/lib/calculations/replanTasks";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const plan = await prisma.studyPlan.findFirst({
+    where: { id, ownerId: session.userId },
+    include: {
+      tasks: {
+        include: {
+          calendarEvent: {
+            select: { id: true, startsAt: true, endsAt: true },
+          },
+        },
+        orderBy: [{ dueDate: "asc" }, { id: "asc" }],
+      },
+    },
+  });
+
+  if (!plan) {
+    return NextResponse.json({ error: "Lernplan nicht gefunden." }, { status: 404 });
+  }
+
+  let replanned: ReturnType<typeof replanOpenTasks>;
+  try {
+    replanned = replanOpenTasks({
+      referenceDate: new Date(),
+      deadlineDate: plan.targetDate,
+      tasks: plan.tasks.map((task) => ({
+        id: task.id,
+        dueDate: task.dueDate,
+        estimatedMinutes: task.estimatedMinutes,
+        difficulty: task.difficulty as 1 | 2 | 3 | 4 | 5,
+        completed: task.completed,
+      })),
+    });
+  } catch (error) {
+    if (error instanceof ReplanTasksInputError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+
+  const changedTasks = replanned.tasks.filter((task) => task.changed);
+  const tasksById = new Map(plan.tasks.map((task) => [task.id, task]));
+
+  await prisma.$transaction(async (transaction) => {
+    for (const replannedTask of changedTasks) {
+      const existingTask = tasksById.get(replannedTask.id);
+      if (!existingTask || existingTask.completed) continue;
+
+      await transaction.task.update({
+        where: { id: existingTask.id },
+        data: { dueDate: replannedTask.dueDate },
+      });
+
+      if (existingTask.calendarEvent) {
+        const duration =
+          existingTask.calendarEvent.endsAt.getTime() -
+          existingTask.calendarEvent.startsAt.getTime();
+        const startsAt = new Date(replannedTask.dueDate);
+        startsAt.setHours(
+          existingTask.calendarEvent.startsAt.getHours(),
+          existingTask.calendarEvent.startsAt.getMinutes(),
+          existingTask.calendarEvent.startsAt.getSeconds(),
+          existingTask.calendarEvent.startsAt.getMilliseconds(),
+        );
+
+        await transaction.calendarEvent.update({
+          where: { id: existingTask.calendarEvent.id },
+          data: {
+            startsAt,
+            endsAt: new Date(startsAt.getTime() + duration),
+          },
+        });
+      }
+    }
+  });
+
+  return NextResponse.json({
+    updatedTaskCount: changedTasks.length,
+    warnings: replanned.warnings,
+  });
+}

--- a/src/app/api/study-plan/[id]/route.ts
+++ b/src/app/api/study-plan/[id]/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
-import { calculateStudyPlan } from "@/lib/calculations/studyPlanAlgorithm";
+import {
+  AlgorithmInputError,
+  calculateStudyPlan,
+} from "@/lib/calculations/studyPlanAlgorithm";
 import {
   isValidGoalType,
   serializeStudyPlan,
@@ -100,13 +103,22 @@ export async function PATCH(
 
   // Ergebnis neu berechnen, wenn alle Eingaben vorhanden sind – sonst zurücksetzen.
   if (diff && know && pgs && crd) {
-    const r = calculateStudyPlan({
-      deadlineDate: target,
-      difficulty: diff as 1 | 2 | 3 | 4 | 5,
-      priorKnowledge: know as 1 | 2 | 3 | 4 | 5,
-      pages: pgs,
-      credits: crd,
-    });
+    let r: ReturnType<typeof calculateStudyPlan>;
+    try {
+      r = calculateStudyPlan({
+        referenceDate: new Date(),
+        deadlineDate: target,
+        difficulty: diff as 1 | 2 | 3 | 4 | 5,
+        priorKnowledge: know as 1 | 2 | 3 | 4 | 5,
+        pages: pgs,
+        credits: crd,
+      });
+    } catch (error) {
+      if (error instanceof AlgorithmInputError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
     data.totalHours = r.totalHours;
     data.hoursPerDay = r.hoursPerDay;
     data.planType = r.planType;

--- a/src/app/api/study-plan/route.ts
+++ b/src/app/api/study-plan/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { prisma } from "@/lib/prisma";
-import { calculateStudyPlan } from "@/lib/calculations/studyPlanAlgorithm";
+import {
+  AlgorithmInputError,
+  calculateStudyPlan,
+} from "@/lib/calculations/studyPlanAlgorithm";
 import { calculateTaskProgress } from "@/lib/study-plan/progress";
 import {
   isValidGoalType,
@@ -100,13 +103,22 @@ export async function POST(req: Request) {
   let hoursPerDay: number | null = null;
   let planType: string | null = null;
   if (diff && know && pgs && crd) {
-    const r = calculateStudyPlan({
-      deadlineDate: target,
-      difficulty: diff as 1 | 2 | 3 | 4 | 5,
-      priorKnowledge: know as 1 | 2 | 3 | 4 | 5,
-      pages: pgs,
-      credits: crd,
-    });
+    let r: ReturnType<typeof calculateStudyPlan>;
+    try {
+      r = calculateStudyPlan({
+        referenceDate: new Date(),
+        deadlineDate: target,
+        difficulty: diff as 1 | 2 | 3 | 4 | 5,
+        priorKnowledge: know as 1 | 2 | 3 | 4 | 5,
+        pages: pgs,
+        credits: crd,
+      });
+    } catch (error) {
+      if (error instanceof AlgorithmInputError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
     totalHours = r.totalHours;
     hoursPerDay = r.hoursPerDay;
     planType = r.planType;

--- a/src/components/study-plan/AlgorithmResultWidget.tsx
+++ b/src/components/study-plan/AlgorithmResultWidget.tsx
@@ -79,6 +79,8 @@ export function AlgorithmResultWidget({
           : data?.warnings?.[0] ?? "Keine offenen Aufgaben mussten verschoben werden.",
       );
       onReplanned?.();
+    } catch {
+      setActionMessage("Umplanung fehlgeschlagen.");
     } finally {
       setBusyAction(null);
     }

--- a/src/components/study-plan/AlgorithmResultWidget.tsx
+++ b/src/components/study-plan/AlgorithmResultWidget.tsx
@@ -13,6 +13,7 @@ interface AlgorithmResultWidgetProps {
   plan: StudyPlanDTO;
   /** Nach erfolgreicher Neuberechnung aufgerufen (Caller lädt neu). */
   onRecalculated: () => void;
+  onReplanned?: () => void;
   /** Öffnet die Kalender-Planung (Vorschau-Modal). */
   onSchedule?: () => void;
 }
@@ -20,9 +21,11 @@ interface AlgorithmResultWidgetProps {
 export function AlgorithmResultWidget({
   plan,
   onRecalculated,
+  onReplanned,
   onSchedule,
 }: AlgorithmResultWidgetProps) {
-  const [busy, setBusy] = useState(false);
+  const [busyAction, setBusyAction] = useState<"calculate" | "replan" | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   const hasResult = plan.totalHours != null && plan.planType != null;
   const hasInputs =
@@ -33,7 +36,8 @@ export function AlgorithmResultWidget({
   const isKritisch = plan.planType === "kritisch";
   const maxSubjectHoursPerDay = MAX_SESSIONS_PER_SUBJECT_PER_DAY * SLOT_HOURS;
   async function recalculate() {
-    setBusy(true);
+    setBusyAction("calculate");
+    setActionMessage(null);
     try {
       // PATCH ohne Änderungen → Server rechnet mit gespeicherten Eingaben
       // und dem aktuellen Datum neu (Tage bis Deadline ändern sich täglich).
@@ -42,9 +46,41 @@ export function AlgorithmResultWidget({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
-      if (res.ok) onRecalculated();
+      if (res.ok) {
+        onRecalculated();
+      } else {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        setActionMessage(data?.error ?? "Neuberechnung fehlgeschlagen.");
+      }
     } finally {
-      setBusy(false);
+      setBusyAction(null);
+    }
+  }
+
+  async function replan() {
+    setBusyAction("replan");
+    setActionMessage(null);
+    try {
+      const res = await fetch(`/api/study-plan/${plan.id}/replan`, {
+        method: "POST",
+      });
+      const data = (await res.json().catch(() => null)) as
+        | { error?: string; updatedTaskCount?: number; warnings?: string[] }
+        | null;
+      if (!res.ok) {
+        setActionMessage(data?.error ?? "Umplanung fehlgeschlagen.");
+        return;
+      }
+
+      const count = data?.updatedTaskCount ?? 0;
+      setActionMessage(
+        count > 0
+          ? `${count} offene Aufgaben wurden neu verteilt.`
+          : data?.warnings?.[0] ?? "Keine offenen Aufgaben mussten verschoben werden.",
+      );
+      onReplanned?.();
+    } finally {
+      setBusyAction(null);
     }
   }
 
@@ -58,10 +94,15 @@ export function AlgorithmResultWidget({
           <button
             type="button"
             onClick={() => void recalculate()}
-            disabled={busy}
+            disabled={busyAction !== null}
             className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-500 rounded-lg hover:bg-gray-100 hover:text-gray-700 transition-colors disabled:opacity-50"
           >
-            <RefreshCw className={cn("w-3.5 h-3.5", busy && "animate-spin")} />
+            <RefreshCw
+              className={cn(
+                "w-3.5 h-3.5",
+                busyAction === "calculate" && "animate-spin",
+              )}
+            />
             Neu berechnen
           </button>
         )}
@@ -134,6 +175,29 @@ export function AlgorithmResultWidget({
               <CalendarPlus className="w-4 h-4" />
               In Kalender eintragen
             </button>
+          )}
+
+          {onReplanned && (
+            <button
+              type="button"
+              onClick={() => void replan()}
+              disabled={busyAction !== null}
+              className="flex items-center justify-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+            >
+              <RefreshCw
+                className={cn(
+                  "w-4 h-4",
+                  busyAction === "replan" && "animate-spin",
+                )}
+              />
+              Offene Aufgaben neu verteilen
+            </button>
+          )}
+
+          {actionMessage && (
+            <p className="rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-600">
+              {actionMessage}
+            </p>
           )}
         </>
       ) : (

--- a/src/components/study-plan/AlgorithmResultWidget.tsx
+++ b/src/components/study-plan/AlgorithmResultWidget.tsx
@@ -52,6 +52,8 @@ export function AlgorithmResultWidget({
         const data = (await res.json().catch(() => null)) as { error?: string } | null;
         setActionMessage(data?.error ?? "Neuberechnung fehlgeschlagen.");
       }
+    } catch {
+      setActionMessage("Neuberechnung fehlgeschlagen.");
     } finally {
       setBusyAction(null);
     }

--- a/src/components/study-plan/SchedulePreviewModal.tsx
+++ b/src/components/study-plan/SchedulePreviewModal.tsx
@@ -91,7 +91,9 @@ export function SchedulePreviewModal({
           localEvents.filter((e) => e.studyPlanId === plan.id).length,
         );
 
+        const referenceDate = new Date();
         const result = calculateStudyPlan({
+          referenceDate,
           deadlineDate: new Date(plan.targetDate),
           difficulty: plan.difficulty as 1 | 2 | 3 | 4 | 5,
           priorKnowledge: plan.priorKnowledge as 1 | 2 | 3 | 4 | 5,
@@ -101,7 +103,11 @@ export function SchedulePreviewModal({
 
         const scheduled = scheduleStudyPlan(
           result,
-          { deadline: new Date(plan.targetDate), subject: plan.subject },
+          {
+            deadline: new Date(plan.targetDate),
+            now: referenceDate,
+            subject: plan.subject,
+          },
           [...localEvents, ...externalEvents],
         );
         setSchedule(scheduled);
@@ -109,9 +115,13 @@ export function SchedulePreviewModal({
         setCriticalNotes(
           analyzeWorkload(scheduled.sessions, localEvents, plan.subject),
         );
-      } catch {
+      } catch (error) {
         if (!cancelled) {
-          setLoadError("Bestehende Termine konnten nicht geladen werden.");
+          setLoadError(
+            error instanceof Error
+              ? error.message
+              : "Bestehende Termine konnten nicht geladen werden.",
+          );
         }
       } finally {
         if (!cancelled) setLoading(false);

--- a/src/components/study-plan/StudyPlanDetail.tsx
+++ b/src/components/study-plan/StudyPlanDetail.tsx
@@ -154,6 +154,7 @@ export function StudyPlanDetail({ planId }: StudyPlanDetailProps) {
         <AlgorithmResultWidget
           plan={plan}
           onRecalculated={() => void refresh()}
+          onReplanned={() => void refresh()}
           onSchedule={() => setScheduleOpen(true)}
         />
       </div>

--- a/src/lib/calculations/replanTasks.ts
+++ b/src/lib/calculations/replanTasks.ts
@@ -167,11 +167,18 @@ export function replanOpenTasks(input: ReplanTasksInput): ReplanTasksResult {
           changed: false,
         };
       }
+      const nextDueDate = new Date(replannedDate);
+      nextDueDate.setHours(
+        task.dueDate.getHours(),
+        task.dueDate.getMinutes(),
+        task.dueDate.getSeconds(),
+        task.dueDate.getMilliseconds(),
+      );
       return {
         id: task.id,
-        dueDate: new Date(replannedDate),
+        dueDate: nextDueDate,
         completed: false,
-        changed: replannedDate.getTime() !== task.dueDate.getTime(),
+        changed: nextDueDate.getTime() !== task.dueDate.getTime(),
       };
     }),
     warnings: [],

--- a/src/lib/calculations/replanTasks.ts
+++ b/src/lib/calculations/replanTasks.ts
@@ -1,0 +1,179 @@
+export interface ReplanningTask {
+  id: string;
+  dueDate: Date;
+  estimatedMinutes: number;
+  difficulty: 1 | 2 | 3 | 4 | 5;
+  completed: boolean;
+}
+
+export interface ReplanTasksInput {
+  tasks: readonly ReplanningTask[];
+  referenceDate: Date;
+  deadlineDate: Date;
+  /** 0 = Sonntag bis 6 = Samstag. Standard: alle Tage. */
+  allowedWeekdays?: readonly number[];
+}
+
+export interface ReplannedTask {
+  id: string;
+  dueDate: Date;
+  completed: boolean;
+  changed: boolean;
+}
+
+export interface ReplanTasksResult {
+  tasks: ReplannedTask[];
+  warnings: string[];
+}
+
+export class ReplanTasksInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReplanTasksInputError";
+  }
+}
+
+function startOfDay(value: Date): Date {
+  const result = new Date(value);
+  result.setHours(0, 0, 0, 0);
+  return result;
+}
+
+function addDays(value: Date, days: number): Date {
+  const result = new Date(value);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+function isValidDate(value: Date): boolean {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+function validateInput(input: ReplanTasksInput): number[] {
+  if (!input || typeof input !== "object") {
+    throw new ReplanTasksInputError("Umplanungs-Eingaben fehlen.");
+  }
+  if (!Array.isArray(input.tasks)) {
+    throw new ReplanTasksInputError("tasks muss eine Liste sein.");
+  }
+  if (!isValidDate(input.referenceDate) || !isValidDate(input.deadlineDate)) {
+    throw new ReplanTasksInputError("Bezugs- und Zieldatum müssen gültig sein.");
+  }
+
+  const referenceDate = startOfDay(input.referenceDate);
+  const deadlineDate = startOfDay(input.deadlineDate);
+  if (deadlineDate.getTime() <= referenceDate.getTime()) {
+    throw new ReplanTasksInputError("Das Zieldatum muss nach dem Bezugsdatum liegen.");
+  }
+
+  const allowedWeekdays = [...(input.allowedWeekdays ?? [0, 1, 2, 3, 4, 5, 6])];
+  if (
+    allowedWeekdays.length === 0 ||
+    allowedWeekdays.some((day) => !Number.isInteger(day) || day < 0 || day > 6)
+  ) {
+    throw new ReplanTasksInputError("allowedWeekdays enthält ungültige Wochentage.");
+  }
+
+  const ids = new Set<string>();
+  for (const task of input.tasks) {
+    if (
+      !task ||
+      typeof task.id !== "string" ||
+      !task.id ||
+      ids.has(task.id) ||
+      !isValidDate(task.dueDate) ||
+      !Number.isInteger(task.estimatedMinutes) ||
+      task.estimatedMinutes <= 0 ||
+      !Number.isInteger(task.difficulty) ||
+      task.difficulty < 1 ||
+      task.difficulty > 5 ||
+      typeof task.completed !== "boolean"
+    ) {
+      throw new ReplanTasksInputError("Mindestens eine Aufgabe ist ungültig.");
+    }
+    ids.add(task.id);
+  }
+
+  return allowedWeekdays;
+}
+
+function workload(task: ReplanningTask): number {
+  return task.estimatedMinutes * (0.8 + task.difficulty * 0.1);
+}
+
+/**
+ * Verteilt ausschließlich offene Aufgaben neu. Erledigte Aufgaben behalten
+ * Status und Fälligkeitsdatum unverändert.
+ */
+export function replanOpenTasks(input: ReplanTasksInput): ReplanTasksResult {
+  const allowedWeekdays = validateInput(input);
+  const referenceDate = startOfDay(input.referenceDate);
+  const deadlineDate = startOfDay(input.deadlineDate);
+  const planningDays: Date[] = [];
+
+  for (
+    let day = new Date(referenceDate);
+    day.getTime() < deadlineDate.getTime();
+    day = addDays(day, 1)
+  ) {
+    if (allowedWeekdays.includes(day.getDay())) planningDays.push(new Date(day));
+  }
+
+  const openTasks = input.tasks
+    .filter((task) => !task.completed)
+    .sort((left, right) => {
+      const dueDateDelta = left.dueDate.getTime() - right.dueDate.getTime();
+      if (dueDateDelta !== 0) return dueDateDelta;
+      return left.id < right.id ? -1 : left.id > right.id ? 1 : 0;
+    });
+
+  if (openTasks.length === 0 || planningDays.length === 0) {
+    return {
+      tasks: input.tasks.map((task) => ({
+        id: task.id,
+        dueDate: new Date(task.dueDate),
+        completed: task.completed,
+        changed: false,
+      })),
+      warnings:
+        planningDays.length === 0 && openTasks.length > 0
+          ? ["Vor dem Zieldatum stehen keine erlaubten Planungstage zur Verfügung."]
+          : [],
+    };
+  }
+
+  const totalWorkload = openTasks.reduce((sum, task) => sum + workload(task), 0);
+  let cumulativeWorkload = 0;
+  const replannedDates = new Map<string, Date>();
+
+  for (const task of openTasks) {
+    cumulativeWorkload += workload(task);
+    const progress = cumulativeWorkload / totalWorkload;
+    const dayIndex = Math.min(
+      planningDays.length - 1,
+      Math.max(0, Math.ceil(progress * planningDays.length) - 1),
+    );
+    replannedDates.set(task.id, planningDays[dayIndex]);
+  }
+
+  return {
+    tasks: input.tasks.map((task) => {
+      const replannedDate = replannedDates.get(task.id);
+      if (!replannedDate || task.completed) {
+        return {
+          id: task.id,
+          dueDate: new Date(task.dueDate),
+          completed: task.completed,
+          changed: false,
+        };
+      }
+      return {
+        id: task.id,
+        dueDate: new Date(replannedDate),
+        completed: false,
+        changed: replannedDate.getTime() !== task.dueDate.getTime(),
+      };
+    }),
+    warnings: [],
+  };
+}

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -8,6 +8,8 @@ export type PlanType = "normal" | "kritisch";
 export const CRITICAL_STUDY_HOURS_PER_DAY = 2;
 
 export interface AlgorithmInput {
+  /** Bezugsdatum der Berechnung; macht die Funktion deterministisch. */
+  referenceDate: Date;
   /** Datum der Klausur */
   deadlineDate: Date;
   /** Schwierigkeit der Klausur: 1 (leicht) – 5 (schwer) */
@@ -50,6 +52,19 @@ export interface Phase {
   description: string;
 }
 
+export class AlgorithmInputError extends Error {
+  readonly field: keyof AlgorithmInput;
+
+  constructor(
+    field: keyof AlgorithmInput,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AlgorithmInputError";
+    this.field = field;
+  }
+}
+
 // ─── Faktoren ────────────────────────────────────────────────────────────────
 
 function getDeadlineFactor(daysUntilDeadline: number): number {
@@ -78,9 +93,57 @@ function getVolumeFactor(pages: number): number {
 }
 
 function getCreditFactor(credits: number): number {
-  const value = Number.isFinite(credits) ? credits : 1;
-  const clamped = Math.min(Math.max(value, 1), 10);
-  return clamped * 0.2;
+  return credits * 0.2;
+}
+
+function assertValidDate(
+  value: Date,
+  field: "referenceDate" | "deadlineDate",
+): void {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new AlgorithmInputError(field, `${field} muss ein gültiges Datum sein.`);
+  }
+}
+
+function assertIntegerInRange(
+  value: number,
+  field: "difficulty" | "priorKnowledge" | "credits",
+  min: number,
+  max: number,
+): void {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new AlgorithmInputError(
+      field,
+      `${field} muss eine ganze Zahl zwischen ${min} und ${max} sein.`,
+    );
+  }
+}
+
+function calendarDayNumber(value: Date): number {
+  return Date.UTC(value.getFullYear(), value.getMonth(), value.getDate());
+}
+
+function validateInput(input: AlgorithmInput): void {
+  if (!input || typeof input !== "object") {
+    throw new AlgorithmInputError("deadlineDate", "Algorithmus-Eingaben fehlen.");
+  }
+
+  assertValidDate(input.referenceDate, "referenceDate");
+  assertValidDate(input.deadlineDate, "deadlineDate");
+  assertIntegerInRange(input.difficulty, "difficulty", 1, 5);
+  assertIntegerInRange(input.priorKnowledge, "priorKnowledge", 1, 5);
+  assertIntegerInRange(input.credits, "credits", 1, 10);
+
+  if (!Number.isInteger(input.pages) || input.pages <= 0) {
+    throw new AlgorithmInputError("pages", "pages muss eine positive ganze Zahl sein.");
+  }
+
+  if (calendarDayNumber(input.deadlineDate) <= calendarDayNumber(input.referenceDate)) {
+    throw new AlgorithmInputError(
+      "deadlineDate",
+      "deadlineDate muss nach referenceDate liegen.",
+    );
+  }
 }
 
 // ─── Phasen ──────────────────────────────────────────────────────────────────
@@ -146,14 +209,11 @@ function buildKritischPhases(totalHours: number): Phase[] {
 // ─── Hauptfunktion ────────────────────────────────────────────────────────────
 
 export function calculateStudyPlan(input: AlgorithmInput): AlgorithmResult {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const deadline = new Date(input.deadlineDate);
-  deadline.setHours(0, 0, 0, 0);
+  validateInput(input);
 
-  const diffMs = deadline.getTime() - today.getTime();
-  const diffDays = Number.isFinite(diffMs) ? diffMs / (1000 * 60 * 60 * 24) : 0;
-  const daysUntilDeadline = Math.max(1, Math.ceil(diffDays));
+  const diffMs =
+    calendarDayNumber(input.deadlineDate) - calendarDayNumber(input.referenceDate);
+  const daysUntilDeadline = diffMs / (1000 * 60 * 60 * 24);
 
   const D = getDeadlineFactor(daysUntilDeadline);
   const S = getDifficultyFactor(input.difficulty);

--- a/src/lib/study-plan/scheduler.ts
+++ b/src/lib/study-plan/scheduler.ts
@@ -5,13 +5,19 @@
 // Plan (docs/Algorithmus/Ausgabeformat.md: "Die Ausgabe soll deterministisch
 // sein"). Logik und Konstanten: docs/lernplan-umsetzung.md §6.
 
-import type { CalEvent } from "@/components/calendar/events";
-import {
-  DAY_START_HOUR,
-  eventOverlapsDay,
-  isLernsessionEvent,
-} from "@/components/calendar/events";
 import type { AlgorithmResult } from "@/lib/calculations/studyPlanAlgorithm";
+
+const DAY_START_HOUR = 7;
+
+export interface SchedulingEvent {
+  start: Date;
+  end: Date;
+  source?: "local" | "dhbw";
+  allDay?: boolean;
+  type?: string;
+  subject?: string;
+  studyPlanId?: string;
+}
 
 /** Dauer einer Lerneinheit in Stunden. */
 export const SLOT_HOURS = 2;
@@ -54,7 +60,7 @@ export interface ScheduleOptions {
   /** Erster planbarer Tag (Default: heute, falls noch ein 2-h-Slot passt, sonst morgen). */
   startDate?: Date;
   /** Für deterministische Planung (z. B. Tests/Preview). Default: aktuelle Zeit. */
-  now?: Date;
+  now: Date;
   /** Erlaubte Wochentage, 0 = So … 6 = Sa (Default: Mo–So, alle Tage). */
   allowedWeekdays?: number[];
   /** Bevorzugte Startstunde der Einheiten (Default: 16). */
@@ -165,8 +171,21 @@ function isWeekend(d: Date): boolean {
 }
 
 /** Externe Hochschul-Termine (DHBW/ICS) – erkennbar an `source: "dhbw"`. */
-function isHochschulEvent(e: CalEvent): boolean {
+function isHochschulEvent(e: SchedulingEvent): boolean {
   return e.source === "dhbw";
+}
+
+function isLernsessionEvent(event: SchedulingEvent): boolean {
+  return (
+    !!event.studyPlanId ||
+    event.type?.trim().toLocaleLowerCase("de-DE") === "lernsession"
+  );
+}
+
+function eventOverlapsDay(event: SchedulingEvent, day: Date): boolean {
+  const dayStart = startOfDay(day).getTime();
+  const dayEnd = addDays(startOfDay(day), 1).getTime();
+  return event.start.getTime() < dayEnd && event.end.getTime() > dayStart;
 }
 
 /** Zahl der zeitgebundenen Blocker, die in `day` hineinreichen (Tages-Auslastung). */
@@ -258,10 +277,32 @@ function distributeByPercentage(percentages: number[], total: number): number[] 
 export function scheduleStudyPlan(
   result: AlgorithmResult,
   options: ScheduleOptions,
-  existingEvents: CalEvent[],
+  existingEvents: readonly SchedulingEvent[],
 ): ScheduleResult {
   const warnings: string[] = [];
-  const now = options.now ?? new Date();
+  const now = new Date(options.now);
+  if (!Number.isFinite(now.getTime())) {
+    throw new TypeError("options.now muss ein gültiges Datum sein.");
+  }
+  if (!Number.isFinite(options.deadline.getTime())) {
+    throw new TypeError("options.deadline muss ein gültiges Datum sein.");
+  }
+  if (!Number.isFinite(result.totalHours) || result.totalHours <= 0) {
+    throw new TypeError("result.totalHours muss größer als 0 sein.");
+  }
+  if (!Array.isArray(result.phases) || result.phases.length === 0) {
+    throw new TypeError("result.phases darf nicht leer sein.");
+  }
+  if (
+    existingEvents.some(
+      (event) =>
+        !Number.isFinite(event.start.getTime()) ||
+        !Number.isFinite(event.end.getTime()) ||
+        event.end.getTime() <= event.start.getTime(),
+    )
+  ) {
+    throw new TypeError("existingEvents enthält einen ungültigen Termin.");
+  }
   const deadline = startOfDay(options.deadline);
   const latestEndHour = options.latestEndHour ?? LATEST_END_HOUR;
   // Startdatum: explizites startDate übernehmen; fehlt es, wird „heute“ nur
@@ -524,7 +565,7 @@ export function scheduleStudyPlan(
       end: slot.end,
       phaseName: phase.name,
       shortPhase: short,
-      tasks: PHASE_TASKS[short] ?? FALLBACK_TASKS,
+      tasks: [...(PHASE_TASKS[short] ?? FALLBACK_TASKS)],
     });
     usedInPhase++;
   }
@@ -554,7 +595,7 @@ export function scheduleStudyPlan(
  */
 export function analyzeWorkload(
   planned: { start: Date; end: Date }[],
-  existingEvents: CalEvent[],
+  existingEvents: readonly SchedulingEvent[],
   subject: string,
 ): string[] {
   const notes: string[] = [];

--- a/tests/study-plan/learningPlan.test.mjs
+++ b/tests/study-plan/learningPlan.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AlgorithmInputError,
+  calculateStudyPlan,
+} from "../../src/lib/calculations/studyPlanAlgorithm.ts";
+import { replanOpenTasks } from "../../src/lib/calculations/replanTasks.ts";
+import { scheduleStudyPlan } from "../../src/lib/study-plan/scheduler.ts";
+
+function localDate(year, month, day, hour = 0) {
+  return new Date(year, month - 1, day, hour, 0, 0, 0);
+}
+
+test("erstellt einen normalen deterministischen Plan über mehrere Wochen", () => {
+  const referenceDate = localDate(2026, 6, 1, 8);
+  const deadlineDate = localDate(2026, 7, 13);
+  const input = {
+    referenceDate,
+    deadlineDate,
+    difficulty: 3,
+    priorKnowledge: 3,
+    pages: 100,
+    credits: 6,
+  };
+
+  const firstCalculation = calculateStudyPlan(input);
+  const secondCalculation = calculateStudyPlan(input);
+  assert.deepEqual(secondCalculation, firstCalculation);
+  assert.equal(firstCalculation.planType, "normal");
+  assert.equal(firstCalculation.daysUntilDeadline, 42);
+
+  const options = {
+    deadline: deadlineDate,
+    now: referenceDate,
+    subject: "Mathematik",
+  };
+  const firstSchedule = scheduleStudyPlan(firstCalculation, options, []);
+  const secondSchedule = scheduleStudyPlan(firstCalculation, options, []);
+  assert.deepEqual(secondSchedule, firstSchedule);
+  assert.ok(firstSchedule.sessions.length > 0);
+
+  const plannedWeeks = new Set(
+    firstSchedule.sessions.map((session) => {
+      const week = new Date(session.start);
+      week.setHours(0, 0, 0, 0);
+      week.setDate(week.getDate() - ((week.getDay() + 6) % 7));
+      return week.getTime();
+    }),
+  );
+  assert.ok(plannedWeeks.size >= 4);
+});
+
+test("begrenzt den Plan kontrolliert bei sehr wenig verfügbarer Zeit", () => {
+  const referenceDate = localDate(2026, 6, 1, 8);
+  const deadlineDate = localDate(2026, 6, 3);
+  const calculation = calculateStudyPlan({
+    referenceDate,
+    deadlineDate,
+    difficulty: 5,
+    priorKnowledge: 1,
+    pages: 300,
+    credits: 10,
+  });
+
+  const schedule = scheduleStudyPlan(
+    calculation,
+    {
+      deadline: deadlineDate,
+      now: referenceDate,
+      subject: "Mathematik",
+    },
+    [],
+  );
+
+  assert.equal(calculation.planType, "kritisch");
+  assert.ok(schedule.sessionsNeeded > schedule.sessions.length);
+  assert.equal(schedule.sessions.length, 4);
+  assert.ok(schedule.warnings.some((warning) => warning.includes("höchstens 4")));
+});
+
+test("lässt erledigte Aufgaben bei der Umplanung unverändert", () => {
+  const completedDueDate = localDate(2026, 5, 20);
+  const result = replanOpenTasks({
+    referenceDate: localDate(2026, 6, 1),
+    deadlineDate: localDate(2026, 6, 15),
+    allowedWeekdays: [1, 2, 3, 4, 5],
+    tasks: [
+      {
+        id: "completed",
+        dueDate: completedDueDate,
+        estimatedMinutes: 120,
+        difficulty: 4,
+        completed: true,
+      },
+      {
+        id: "open-1",
+        dueDate: localDate(2026, 5, 22),
+        estimatedMinutes: 60,
+        difficulty: 2,
+        completed: false,
+      },
+      {
+        id: "open-2",
+        dueDate: localDate(2026, 5, 23),
+        estimatedMinutes: 180,
+        difficulty: 5,
+        completed: false,
+      },
+    ],
+  });
+
+  const completed = result.tasks.find((task) => task.id === "completed");
+  assert.equal(completed.completed, true);
+  assert.equal(completed.changed, false);
+  assert.equal(completed.dueDate.getTime(), completedDueDate.getTime());
+
+  const openTasks = result.tasks.filter((task) => !task.completed);
+  assert.ok(openTasks.every((task) => task.changed));
+  assert.ok(
+    openTasks.every(
+      (task) =>
+        task.dueDate.getTime() >= localDate(2026, 6, 1).getTime() &&
+        task.dueDate.getTime() < localDate(2026, 6, 15).getTime(),
+    ),
+  );
+});
+
+test("weist unvollständige oder unmögliche Eingaben kontrolliert zurück", () => {
+  assert.throws(
+    () =>
+      calculateStudyPlan({
+        referenceDate: localDate(2026, 6, 10),
+        deadlineDate: localDate(2026, 6, 1),
+        difficulty: 3,
+        priorKnowledge: 3,
+        pages: 100,
+        credits: 6,
+      }),
+    (error) =>
+      error instanceof AlgorithmInputError &&
+      error.field === "deadlineDate",
+  );
+
+  assert.throws(
+    () =>
+      calculateStudyPlan({
+        referenceDate: localDate(2026, 6, 1),
+        deadlineDate: localDate(2026, 6, 10),
+        difficulty: 3,
+        priorKnowledge: 3,
+        pages: 0,
+        credits: 6,
+      }),
+    (error) => error instanceof AlgorithmInputError && error.field === "pages",
+  );
+});


### PR DESCRIPTION
## What changed
- make the learning-plan calculation deterministic through an explicit reference date
- validate impossible and incomplete calculation inputs with typed errors
- decouple the scheduler from UI-specific calendar types
- add a pure task replanning function that only redistributes open tasks
- add a replanning API and UI action, including linked calendar-event updates
- add the required G2 unit tests and fix the Node test script

## Why
G2 requires the planning logic to be testable, reusable, deterministic, independent of UI/API code, and robust for incomplete or impossible input. It also requires coverage for normal multi-week plans, very limited time, and preserving completed tasks during replanning.

## Impact
Developers can call and test the calculation and replanning functions without UI or database dependencies. Users can redistribute open tasks while completed tasks remain unchanged.

## Validation
- `npm test` — 13 tests passed
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`