### PR TITLE
[codex] Add admin user management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,9 @@
 # Die Werte spiegeln POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB aus
 # docker-compose.yml wider.
 DATABASE_URL="postgresql://learnhub:learnhub_dev@localhost:5432/learnhub"
+
+# Fester Admin-Account fuer die Benutzerverwaltung.
+# Diese Werte koennen lokal ueberschrieben werden; ohne Override gelten sie als Default.
+ADMIN_EMAIL="0000@learnhub.admin"
+ADMIN_PASSWORD="0000admin"
+ADMIN_DISPLAY_NAME="LearnHub Root"

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 DATABASE_URL="postgresql://learnhub:learnhub_dev@localhost:5432/learnhub"
 
 # Fester Admin-Account fuer die Benutzerverwaltung.
-# Diese Werte koennen lokal ueberschrieben werden; ohne Override gelten sie als Default.
+# WICHTIG: Fuer produktive Umgebungen muessen diese Werte (insbesondere ADMIN_PASSWORD) ueberschrieben werden; die Defaults sind unsicher.
 ADMIN_EMAIL="0000@learnhub.admin"
 ADMIN_PASSWORD="0000admin"
 ADMIN_DISPLAY_NAME="LearnHub Root"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Anschliessend ist die App unter [http://localhost:3000](http://localhost:3000) e
 
 ### Admin-Zugang
 
-Der feste Admin-Account wird beim ersten Login automatisch angelegt. Die Defaults stehen in `.env.example` und koennen lokal ueber `ADMIN_EMAIL`, `ADMIN_PASSWORD` und `ADMIN_DISPLAY_NAME` ueberschrieben werden.
+Der feste Admin-Account wird beim ersten Login automatisch angelegt. Die Defaults stehen in `.env.example` und koennen lokal ueber `ADMIN_EMAIL`, `ADMIN_PASSWORD` und `ADMIN_DISPLAY_NAME` ueberschrieben werden (wichtig: in produktiven Umgebungen muessen diese Werte gesetzt werden; die Defaults sind unsicher).
 
 | Feld | Default |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Anschliessend ist die App unter [http://localhost:3000](http://localhost:3000) e
 | DB-Logs anschauen | `docker compose logs -f db` |
 | Build pruefen | `npm run build` |
 | Linter | `npm run lint` |
+| TypeScript pruefen | `npm run typecheck` |
+
+### Admin-Zugang
+
+Der feste Admin-Account wird beim ersten Login automatisch angelegt. Die Defaults stehen in `.env.example` und koennen lokal ueber `ADMIN_EMAIL`, `ADMIN_PASSWORD` und `ADMIN_DISPLAY_NAME` ueberschrieben werden.
+
+| Feld | Default |
+| --- | --- |
+| E-Mail | `0000@learnhub.admin` |
+| Passwort | `0000admin` |
 
 ### Nach jedem `git pull`
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types \"tests/**/*.test.mjs\"",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",

--- a/prisma/migrations/20260615213000_add_user_role/migration.sql
+++ b/prisma/migrations/20260615213000_add_user_role/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "UserRole" AS ENUM ('USER', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "role" "UserRole" NOT NULL DEFAULT 'USER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,11 +16,17 @@ datasource db {
 // Auth (siehe docs/auth-concept.md §3)
 // =====================================================================
 
+enum UserRole {
+  USER
+  ADMIN
+}
+
 model User {
   id           String   @id @default(cuid())
   email        String   @unique
   displayName  String
   passwordHash String
+  role         UserRole @default(USER)
   avatarUrl    String?
   avatarData   Bytes?
   avatarMime   String?

--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation";
+import { AdminDashboard } from "@/components/admin/AdminDashboard";
+import { getAdminUsersPayload } from "@/lib/admin/users";
+import { getAdminAuth, getAdminCredentials } from "@/lib/auth/admin";
+
+export default async function AdminPage() {
+  const auth = await getAdminAuth();
+
+  if (auth.status === "unauthenticated") {
+    redirect("/login?redirect=/admin");
+  }
+  if (auth.status === "forbidden") {
+    redirect("/dashboard");
+  }
+
+  const initialData = await getAdminUsersPayload();
+
+  return (
+    <AdminDashboard
+      initialData={initialData}
+      currentUserId={auth.user.id}
+      fixedAdminEmail={getAdminCredentials().email}
+    />
+  );
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -13,21 +13,26 @@ const updateUserSchema = z.object({
   role: z.enum(["USER", "ADMIN"]),
 });
 
-function forbidden() {
-  return NextResponse.json({ error: "Keine Admin-Berechtigung." }, { status: 403 });
+function unauthorized(status: "unauthenticated" | "forbidden") {
+  return NextResponse.json(
+    {
+      error:
+        status === "unauthenticated" ? "Nicht angemeldet." : "Keine Admin-Berechtigung.",
+    },
+    { status: status === "unauthenticated" ? 401 : 403 },
+  );
 }
 
 export async function PATCH(
   request: Request,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: { id: string } },
 ) {
   const auth = await getAdminAuth();
   if (auth.status !== "ok") {
-    return forbidden();
+    return unauthorized(auth.status);
   }
 
-  const { id } = await params;
-
+  const { id } = params;
   let body: unknown;
   try {
     body = await request.json();

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -84,7 +84,7 @@ export async function DELETE(
 ) {
   const auth = await getAdminAuth();
   if (auth.status !== "ok") {
-    return forbidden();
+    return unauthorized(auth.status);
   }
 
   const { id } = await params;

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAdminUsersPayload } from "@/lib/admin/users";
+import { getAdminAuth, isFixedAdminEmail } from "@/lib/auth/admin";
+import { prisma } from "@/lib/prisma";
+
+const updateUserSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Bitte gib einen Namen an.")
+    .max(80, "Der Name darf hoechstens 80 Zeichen lang sein."),
+  role: z.enum(["USER", "ADMIN"]),
+});
+
+function forbidden() {
+  return NextResponse.json({ error: "Keine Admin-Berechtigung." }, { status: 403 });
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await getAdminAuth();
+  if (auth.status !== "ok") {
+    return forbidden();
+  }
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Ungueltiger Anfrage-Body." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = updateUserSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ungueltige Eingabe." },
+      { status: 400 },
+    );
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: { email: true },
+  });
+  if (!target) {
+    return NextResponse.json({ error: "Nutzer nicht gefunden." }, { status: 404 });
+  }
+
+  const fixedAdmin = isFixedAdminEmail(target.email);
+  if ((id === auth.user.id || fixedAdmin) && parsed.data.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "Dieser Admin-Account kann nicht zur Nutzerrolle geändert werden." },
+      { status: 400 },
+    );
+  }
+
+  await prisma.user.update({
+    where: { id },
+    data: {
+      displayName: parsed.data.displayName,
+      role: parsed.data.role,
+    },
+  });
+
+  return NextResponse.json(await getAdminUsersPayload());
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await getAdminAuth();
+  if (auth.status !== "ok") {
+    return forbidden();
+  }
+
+  const { id } = await params;
+
+  if (id === auth.user.id) {
+    return NextResponse.json(
+      { error: "Der aktuell angemeldete Admin kann nicht gelöscht werden." },
+      { status: 400 },
+    );
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: { email: true },
+  });
+  if (!target) {
+    return NextResponse.json({ error: "Nutzer nicht gefunden." }, { status: 404 });
+  }
+  if (isFixedAdminEmail(target.email)) {
+    return NextResponse.json(
+      { error: "Der feste Admin-Account kann nicht gelöscht werden." },
+      { status: 400 },
+    );
+  }
+
+  await prisma.user.delete({ where: { id } });
+
+  return NextResponse.json(await getAdminUsersPayload());
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -25,14 +25,14 @@ function unauthorized(status: "unauthenticated" | "forbidden") {
 
 export async function PATCH(
   request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await getAdminAuth();
   if (auth.status !== "ok") {
     return unauthorized(auth.status);
   }
 
-  const { id } = params;
+  const { id } = await params;
   let body: unknown;
   try {
     body = await request.json();

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getAdminAuth, isFixedAdminEmail } from "@/lib/auth/admin";
+import { hashPassword } from "@/lib/auth/password";
+import { getAdminUsersPayload } from "@/lib/admin/users";
+import { prisma } from "@/lib/prisma";
+
+const createUserSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Bitte gib einen Namen an.")
+    .max(80, "Der Name darf hoechstens 80 Zeichen lang sein."),
+  email: z.string().trim().email("Bitte gib eine gueltige E-Mail-Adresse an."),
+  password: z
+    .string()
+    .min(8, "Das Passwort muss mindestens 8 Zeichen lang sein."),
+  role: z.enum(["USER", "ADMIN"]).default("USER"),
+});
+
+function forbidden() {
+  return NextResponse.json({ error: "Keine Admin-Berechtigung." }, { status: 403 });
+}
+
+export async function GET() {
+  const auth = await getAdminAuth();
+  if (auth.status !== "ok") {
+    return forbidden();
+  }
+
+  return NextResponse.json(await getAdminUsersPayload());
+}
+
+export async function POST(request: Request) {
+  const auth = await getAdminAuth();
+  if (auth.status !== "ok") {
+    return forbidden();
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Ungueltiger Anfrage-Body." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createUserSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ungueltige Eingabe." },
+      { status: 400 },
+    );
+  }
+
+  const { displayName, password, role } = parsed.data;
+  const email = parsed.data.email.toLowerCase();
+
+  if (isFixedAdminEmail(email)) {
+    return NextResponse.json(
+      { error: "Diese E-Mail-Adresse ist fuer den festen Admin reserviert." },
+      { status: 409 },
+    );
+  }
+
+  const existing = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "Diese E-Mail-Adresse ist bereits registriert." },
+      { status: 409 },
+    );
+  }
+
+  await prisma.user.create({
+    data: {
+      displayName,
+      email,
+      passwordHash: await hashPassword(password),
+      role,
+    },
+  });
+
+  return NextResponse.json(await getAdminUsersPayload(), { status: 201 });
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -18,14 +18,20 @@ const createUserSchema = z.object({
   role: z.enum(["USER", "ADMIN"]).default("USER"),
 });
 
-function forbidden() {
-  return NextResponse.json({ error: "Keine Admin-Berechtigung." }, { status: 403 });
+function unauthorized(status: "unauthenticated" | "forbidden") {
+  return NextResponse.json(
+    {
+      error:
+        status === "unauthenticated" ? "Nicht angemeldet." : "Keine Admin-Berechtigung.",
+    },
+    { status: status === "unauthenticated" ? 401 : 403 },
+  );
 }
 
 export async function GET() {
   const auth = await getAdminAuth();
   if (auth.status !== "ok") {
-    return forbidden();
+    return unauthorized(auth.status);
   }
 
   return NextResponse.json(await getAdminUsersPayload());
@@ -34,7 +40,7 @@ export async function GET() {
 export async function POST(request: Request) {
   const auth = await getAdminAuth();
   if (auth.status !== "ok") {
-    return forbidden();
+    return unauthorized(auth.status);
   }
 
   let body: unknown;

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -39,7 +39,10 @@ export async function POST(request: Request) {
   const normalizedEmail = email.toLowerCase();
   const adminCredentials = getAdminCredentials();
 
-  if (normalizedEmail === adminCredentials.email) {
+  if (
+    normalizedEmail === adminCredentials.email &&
+    password === adminCredentials.password
+  ) {
     await ensureFixedAdminAccount();
   }
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { ensureFixedAdminAccount, getAdminCredentials } from "@/lib/auth/admin";
 import { verifyPassword } from "@/lib/auth/password";
 import { createSession } from "@/lib/auth/session";
 
@@ -36,10 +37,15 @@ export async function POST(request: Request) {
 
   const { email, password, rememberMe } = parsed.data;
   const normalizedEmail = email.toLowerCase();
+  const adminCredentials = getAdminCredentials();
+
+  if (normalizedEmail === adminCredentials.email) {
+    await ensureFixedAdminAccount();
+  }
 
   const user = await prisma.user.findUnique({
     where: { email: normalizedEmail },
-    select: { id: true, passwordHash: true },
+    select: { id: true, passwordHash: true, role: true },
   });
 
   // Immer bcrypt ausführen – auch bei unbekannter E-Mail (Dummy-Hash).
@@ -54,7 +60,7 @@ export async function POST(request: Request) {
     );
   }
 
-  await createSession(user.id, rememberMe);
+  await createSession(user.id, rememberMe, user.role);
 
-  return NextResponse.json({ ok: true }, { status: 200 });
+  return NextResponse.json({ ok: true, role: user.role }, { status: 200 });
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { isFixedAdminEmail } from "@/lib/auth/admin";
 import { hashPassword } from "@/lib/auth/password";
 import { createSession } from "@/lib/auth/session";
 
@@ -39,6 +40,13 @@ export async function POST(request: Request) {
   const { email, displayName, password, rememberMe } = parsed.data;
   const normalizedEmail = email.toLowerCase();
 
+  if (isFixedAdminEmail(normalizedEmail)) {
+    return NextResponse.json(
+      { error: "Diese E-Mail-Adresse ist fuer den Admin-Account reserviert." },
+      { status: 409 },
+    );
+  }
+
   const existing = await prisma.user.findUnique({
     where: { email: normalizedEmail },
   });
@@ -60,7 +68,7 @@ export async function POST(request: Request) {
       },
     });
 
-    await createSession(user.id, rememberMe);
+    await createSession(user.id, rememberMe, user.role);
 
     return NextResponse.json({ ok: true }, { status: 201 });
   } catch (err) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -150,4 +150,28 @@
   .dark .bg-white {
     background-color: var(--card);
   }
+
+  .admin-role-select {
+    color-scheme: light;
+    background-color: white;
+    color: oklch(0.145 0 0);
+  }
+
+  .admin-role-select-option,
+  .admin-role-select option {
+    background-color: white;
+    color: oklch(0.145 0 0);
+  }
+
+  .dark .admin-role-select {
+    color-scheme: dark;
+    background-color: oklch(0.24 0.006 250);
+    color: oklch(0.985 0 0);
+  }
+
+  .dark .admin-role-select-option,
+  .dark .admin-role-select option {
+    background-color: oklch(0.24 0.006 250);
+    color: oklch(0.985 0 0);
+  }
 }

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Pencil,
+  RefreshCw,
+  Save,
+  ShieldCheck,
+  Trash2,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { AdminUserListItem, AdminUsersPayload } from "@/lib/admin/users";
+import { cn } from "@/lib/utils";
+
+type FormState = {
+  displayName: string;
+  email: string;
+  password: string;
+  role: "USER" | "ADMIN";
+};
+
+type EditState = Pick<FormState, "displayName" | "role">;
+
+const emptyForm: FormState = {
+  displayName: "",
+  email: "",
+  password: "",
+  role: "USER",
+};
+
+const roleLabels: Record<FormState["role"], string> = {
+  USER: "Nutzer",
+  ADMIN: "Admin",
+};
+
+const SELECT_CLASSES =
+  "admin-role-select h-8 w-full rounded-lg border border-input px-2.5 text-sm outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50";
+
+const OPTION_CLASSES = "admin-role-select-option";
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function roleBadgeClass(role: FormState["role"]) {
+  return role === "ADMIN"
+    ? "border-red-200 bg-red-50 text-red-700"
+    : "border-gray-200 bg-gray-50 text-gray-700";
+}
+
+interface AdminDashboardProps {
+  initialData: AdminUsersPayload;
+  currentUserId: string;
+  fixedAdminEmail: string;
+}
+
+export function AdminDashboard({
+  initialData,
+  currentUserId,
+  fixedAdminEmail,
+}: AdminDashboardProps) {
+  const [users, setUsers] = useState<AdminUserListItem[]>(initialData.users);
+  const [total, setTotal] = useState(initialData.total);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<EditState>({ displayName: "", role: "USER" });
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(
+    null,
+  );
+
+  const adminCount = useMemo(
+    () => users.filter((user) => user.role === "ADMIN").length,
+    [users],
+  );
+
+  async function applyResponse(response: Response) {
+    const data = (await response.json().catch(() => null)) as
+      | (Partial<AdminUsersPayload> & { error?: string })
+      | null;
+
+    if (!response.ok) {
+      throw new Error(data?.error ?? "Admin-Aktion fehlgeschlagen.");
+    }
+
+    if (Array.isArray(data?.users) && typeof data.total === "number") {
+      setUsers(data.users);
+      setTotal(data.total);
+    }
+  }
+
+  async function reloadUsers() {
+    setLoading(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/admin/users");
+      await applyResponse(response);
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Nutzerliste konnte nicht geladen werden.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleCreate(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      await applyResponse(response);
+      setForm(emptyForm);
+      setMessage({ type: "success", text: "Nutzer wurde angelegt." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Nutzer konnte nicht angelegt werden.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDelete(user: AdminUserListItem) {
+    if (!window.confirm(`${user.displayName} wirklich dauerhaft löschen?`)) {
+      return;
+    }
+
+    setDeletingId(user.id);
+    setMessage(null);
+    try {
+      const response = await fetch(`/api/admin/users/${user.id}`, { method: "DELETE" });
+      await applyResponse(response);
+      setMessage({ type: "success", text: "Nutzer wurde gelöscht." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Nutzer konnte nicht gelöscht werden.",
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  function startEditing(user: AdminUserListItem) {
+    setEditingId(user.id);
+    setEditForm({ displayName: user.displayName, role: user.role });
+    setMessage(null);
+  }
+
+  function cancelEditing() {
+    setEditingId(null);
+    setEditForm({ displayName: "", role: "USER" });
+  }
+
+  async function handleSaveEdit(user: AdminUserListItem) {
+    setSavingId(user.id);
+    setMessage(null);
+
+    try {
+      const response = await fetch(`/api/admin/users/${user.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(editForm),
+      });
+      await applyResponse(response);
+      cancelEditing();
+      setMessage({ type: "success", text: "Nutzer wurde aktualisiert." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Nutzer konnte nicht aktualisiert werden.",
+      });
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  return (
+    <main className="flex h-full flex-col gap-5 overflow-auto p-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-500">Administration</p>
+          <h1 className="mt-1 text-3xl font-bold text-gray-950">Benutzerverwaltung</h1>
+        </div>
+        <Button type="button" variant="outline" onClick={reloadUsers} disabled={loading}>
+          <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
+          Aktualisieren
+        </Button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-gray-100 text-gray-700">
+              <Users className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-950">{total}</p>
+              <p className="text-sm text-gray-500">Registrierte Accounts</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-red-50 text-red-700">
+              <ShieldCheck className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-2xl font-bold text-gray-950">{adminCount}</p>
+              <p className="text-sm text-gray-500">Admin-Accounts</p>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm sm:col-span-2 xl:col-span-1">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Fester Admin
+          </p>
+          <p className="mt-2 truncate text-sm font-semibold text-gray-950">
+            {fixedAdminEmail}
+          </p>
+        </div>
+      </div>
+
+      {message && (
+        <p
+          role="status"
+          className={cn(
+            "rounded-lg border px-4 py-3 text-sm font-medium",
+            message.type === "success"
+              ? "border-green-200 bg-green-50 text-green-700"
+              : "border-red-200 bg-red-50 text-red-700",
+          )}
+        >
+          {message.text}
+        </p>
+      )}
+
+      <section className="grid gap-5 xl:grid-cols-[380px_1fr]">
+        <form
+          onSubmit={handleCreate}
+          className="h-fit rounded-lg border border-gray-200 bg-white p-5 shadow-sm"
+        >
+          <div className="flex items-center gap-3 border-b border-gray-100 pb-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-gray-700">
+              <UserPlus className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-gray-950">Neuen Nutzer anlegen</h2>
+              <p className="text-sm text-gray-500">Name, Login und Rolle vergeben.</p>
+            </div>
+          </div>
+
+          <div className="mt-5 grid gap-4">
+            <Field label="Name" htmlFor="admin-display-name">
+              <Input
+                id="admin-display-name"
+                value={form.displayName}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, displayName: event.target.value }))
+                }
+                required
+                maxLength={80}
+                autoComplete="name"
+              />
+            </Field>
+            <Field label="E-Mail" htmlFor="admin-email">
+              <Input
+                id="admin-email"
+                type="email"
+                value={form.email}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, email: event.target.value }))
+                }
+                required
+                autoComplete="email"
+              />
+            </Field>
+            <Field label="Passwort" htmlFor="admin-password">
+              <Input
+                id="admin-password"
+                type="password"
+                value={form.password}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, password: event.target.value }))
+                }
+                required
+                minLength={8}
+                autoComplete="new-password"
+              />
+            </Field>
+            <Field label="Rolle" htmlFor="admin-role">
+              <select
+                id="admin-role"
+                value={form.role}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    role: event.target.value as FormState["role"],
+                  }))
+                }
+                className={SELECT_CLASSES}
+              >
+                <option value="USER" className={OPTION_CLASSES}>
+                  Nutzer
+                </option>
+                <option value="ADMIN" className={OPTION_CLASSES}>
+                  Admin
+                </option>
+              </select>
+            </Field>
+          </div>
+
+          <div className="mt-5 flex justify-end border-t border-gray-100 pt-4">
+            <Button type="submit" disabled={submitting}>
+              <UserPlus className="h-4 w-4" />
+              {submitting ? "Wird angelegt..." : "Anlegen"}
+            </Button>
+          </div>
+        </form>
+
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+            <div>
+              <h2 className="text-base font-semibold text-gray-950">Alle Accounts</h2>
+              <p className="text-sm text-gray-500">Name, E-Mail, Registrierung und Rolle.</p>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[760px] text-left text-sm">
+              <thead className="bg-gray-50 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                <tr>
+                  <th className="px-5 py-3">Name</th>
+                  <th className="px-5 py-3">E-Mail</th>
+                  <th className="px-5 py-3">Registriert</th>
+                  <th className="px-5 py-3">Rolle</th>
+                  <th className="px-5 py-3 text-right">Aktion</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {users.map((user) => {
+                  const isSelf = user.id === currentUserId;
+                  const deleteDisabled = isSelf || user.isFixedAdmin || deletingId === user.id;
+                  const isEditing = editingId === user.id;
+                  const roleChangeDisabled = isSelf || user.isFixedAdmin;
+
+                  return (
+                    <tr key={user.id} className="align-middle">
+                      <td className="px-5 py-4">
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-700">
+                            {user.displayName
+                              .split(/\s+/)
+                              .slice(0, 2)
+                              .map((part) => part[0]?.toUpperCase())
+                              .join("") || "LH"}
+                          </div>
+                          <div className="min-w-0">
+                            {isEditing ? (
+                              <Input
+                                value={editForm.displayName}
+                                onChange={(event) =>
+                                  setEditForm((current) => ({
+                                    ...current,
+                                    displayName: event.target.value,
+                                  }))
+                                }
+                                maxLength={80}
+                                className="h-8 min-w-[180px]"
+                              />
+                            ) : (
+                              <p className="truncate font-semibold text-gray-950">
+                                {user.displayName}
+                              </p>
+                            )}
+                            {isSelf && (
+                              <p className="text-xs text-gray-500">Aktuelle Session</p>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-5 py-4 text-gray-600">{user.email}</td>
+                      <td className="px-5 py-4 text-gray-600">{formatDate(user.createdAt)}</td>
+                      <td className="px-5 py-4">
+                        {isEditing ? (
+                          <select
+                            value={editForm.role}
+                            disabled={roleChangeDisabled}
+                            onChange={(event) =>
+                              setEditForm((current) => ({
+                                ...current,
+                                role: event.target.value as FormState["role"],
+                              }))
+                            }
+                            className={cn(SELECT_CLASSES, "min-w-[120px]")}
+                          >
+                            <option value="USER" className={OPTION_CLASSES}>
+                              Nutzer
+                            </option>
+                            <option value="ADMIN" className={OPTION_CLASSES}>
+                              Admin
+                            </option>
+                          </select>
+                        ) : (
+                          <span
+                            className={cn(
+                              "inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold",
+                              roleBadgeClass(user.role),
+                            )}
+                          >
+                            {roleLabels[user.role]}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-5 py-4">
+                        <div className="flex justify-end gap-2">
+                          {isEditing ? (
+                            <>
+                              <Button
+                                type="button"
+                                size="sm"
+                                disabled={savingId === user.id}
+                                onClick={() => handleSaveEdit(user)}
+                              >
+                                <Save className="h-4 w-4" />
+                                {savingId === user.id ? "Speichert..." : "Speichern"}
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                disabled={savingId === user.id}
+                                onClick={cancelEditing}
+                              >
+                                <X className="h-4 w-4" />
+                                Abbrechen
+                              </Button>
+                            </>
+                          ) : (
+                            <>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => startEditing(user)}
+                              >
+                                <Pencil className="h-4 w-4" />
+                                Bearbeiten
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="destructive"
+                                size="sm"
+                                disabled={deleteDisabled}
+                                title={
+                                  isSelf || user.isFixedAdmin
+                                    ? "Dieser Admin-Account kann nicht gelöscht werden"
+                                    : "Nutzer löschen"
+                                }
+                                onClick={() => handleDelete(user)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                                {deletingId === user.id ? "Löscht..." : "Löschen"}
+                              </Button>
+                            </>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}
+
+function Field({ label, htmlFor, children }: FieldProps) {
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={htmlFor} className="text-gray-700">
+        {label}
+      </Label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { LayoutDashboard, Calendar, BookOpen, MessageSquare, Settings } from "lucide-react";
+import {
+  LayoutDashboard,
+  Calendar,
+  BookOpen,
+  MessageSquare,
+  Settings,
+  ShieldCheck,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
 import type { CurrentUser } from "@/lib/auth/session";
 import { cn } from "@/lib/utils";
 
-const navItems = [
+function getNavItems(isAdmin: boolean) {
+  return [
   {
     section: "Learning",
     items: [
@@ -23,7 +31,16 @@ const navItems = [
       { label: "Einstellungen", href: "/settings?tab=profile", icon: Settings },
     ],
   },
-];
+  ...(isAdmin
+    ? [
+        {
+          section: "Admin",
+          items: [{ label: "Benutzer", href: "/admin", icon: ShieldCheck }],
+        },
+      ]
+    : []),
+  ];
+}
 
 interface SidebarProps {
   currentUser?: CurrentUser;
@@ -52,6 +69,7 @@ export function Sidebar({ currentUser }: SidebarProps) {
   const pathname = usePathname() ?? "";
   const displayName = currentUser?.displayName ?? "LearnHub";
   const email = currentUser?.email ?? "";
+  const navItems = getNavItems(currentUser?.role === "ADMIN");
 
   return (
     <div className="flex h-full w-full flex-col border-r border-sidebar-border bg-sidebar px-5 py-6 text-sidebar-foreground transition-colors duration-300">

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -37,11 +37,19 @@ export function LoginForm() {
         return;
       }
 
+      const data = (await res.json().catch(() => ({}))) as { role?: "USER" | "ADMIN" };
       const redirect = searchParams.get("redirect");
-      const target =
+      const safeRedirect =
         redirect && redirect.startsWith("/") && !redirect.startsWith("//")
           ? redirect
-          : "/dashboard";
+          : null;
+      const isAdmin = data.role === "ADMIN";
+      const target =
+        safeRedirect && (isAdmin || !safeRedirect.startsWith("/admin"))
+          ? safeRedirect
+          : isAdmin
+            ? "/admin"
+            : "/dashboard";
 
       router.push(target);
       router.refresh();

--- a/src/lib/admin/users.ts
+++ b/src/lib/admin/users.ts
@@ -1,0 +1,57 @@
+import type { UserRole } from "@prisma/client";
+import { isFixedAdminEmail } from "@/lib/auth/admin";
+import { prisma } from "@/lib/prisma";
+
+export interface AdminUserListItem {
+  id: string;
+  displayName: string;
+  email: string;
+  createdAt: string;
+  role: UserRole;
+  isFixedAdmin: boolean;
+}
+
+export interface AdminUsersPayload {
+  total: number;
+  users: AdminUserListItem[];
+}
+
+interface UserRow {
+  id: string;
+  displayName: string;
+  email: string;
+  createdAt: Date;
+  role: UserRole;
+}
+
+export function serializeAdminUser(user: UserRow): AdminUserListItem {
+  return {
+    id: user.id,
+    displayName: user.displayName,
+    email: user.email,
+    createdAt: user.createdAt.toISOString(),
+    role: user.role,
+    isFixedAdmin: isFixedAdminEmail(user.email),
+  };
+}
+
+export async function getAdminUsersPayload(): Promise<AdminUsersPayload> {
+  const [total, users] = await prisma.$transaction([
+    prisma.user.count(),
+    prisma.user.findMany({
+      select: {
+        id: true,
+        displayName: true,
+        email: true,
+        createdAt: true,
+        role: true,
+      },
+      orderBy: [{ role: "asc" }, { createdAt: "desc" }],
+    }),
+  ]);
+
+  return {
+    total,
+    users: users.map(serializeAdminUser),
+  };
+}

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -1,0 +1,87 @@
+import type { UserRole } from "@prisma/client";
+import { getCurrentUser, type CurrentUser } from "@/lib/auth/session";
+import { hashPassword, verifyPassword } from "@/lib/auth/password";
+import { prisma } from "@/lib/prisma";
+
+const DEFAULT_ADMIN_EMAIL = "0000@learnhub.admin";
+const DEFAULT_ADMIN_PASSWORD = "0000admin";
+const DEFAULT_ADMIN_DISPLAY_NAME = "LearnHub Root";
+
+export interface AdminCredentials {
+  email: string;
+  password: string;
+  displayName: string;
+}
+
+export type AdminAuthResult =
+  | { status: "ok"; user: CurrentUser }
+  | { status: "unauthenticated" }
+  | { status: "forbidden" };
+
+export function getAdminCredentials(): AdminCredentials {
+  return {
+    email: (process.env.ADMIN_EMAIL ?? DEFAULT_ADMIN_EMAIL).trim().toLowerCase(),
+    password: process.env.ADMIN_PASSWORD ?? DEFAULT_ADMIN_PASSWORD,
+    displayName:
+      (process.env.ADMIN_DISPLAY_NAME ?? DEFAULT_ADMIN_DISPLAY_NAME).trim() ||
+      DEFAULT_ADMIN_DISPLAY_NAME,
+  };
+}
+
+export function isFixedAdminEmail(email: string): boolean {
+  return email.trim().toLowerCase() === getAdminCredentials().email;
+}
+
+export async function ensureFixedAdminAccount() {
+  const credentials = getAdminCredentials();
+  const existing = await prisma.user.findUnique({
+    where: { email: credentials.email },
+    select: { id: true, passwordHash: true, role: true },
+  });
+
+  if (!existing) {
+    return prisma.user.create({
+      data: {
+        email: credentials.email,
+        displayName: credentials.displayName,
+        passwordHash: await hashPassword(credentials.password),
+        role: "ADMIN",
+      },
+      select: { id: true },
+    });
+  }
+
+  const hasConfiguredPassword = await verifyPassword(
+    credentials.password,
+    existing.passwordHash,
+  );
+  const data: { passwordHash?: string; role?: UserRole } = {};
+
+  if (!hasConfiguredPassword) {
+    data.passwordHash = await hashPassword(credentials.password);
+  }
+  if (existing.role !== "ADMIN") {
+    data.role = "ADMIN";
+  }
+
+  if (Object.keys(data).length > 0) {
+    await prisma.user.update({
+      where: { id: existing.id },
+      data,
+      select: { id: true },
+    });
+  }
+
+  return { id: existing.id };
+}
+
+export async function getAdminAuth(): Promise<AdminAuthResult> {
+  const user = await getCurrentUser();
+  if (!user) {
+    return { status: "unauthenticated" };
+  }
+  if (user.role !== "ADMIN") {
+    return { status: "forbidden" };
+  }
+  return { status: "ok", user };
+}

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -51,27 +51,8 @@ export async function ensureFixedAdminAccount() {
     });
   }
 
-  const hasConfiguredPassword = await verifyPassword(
-    credentials.password,
-    existing.passwordHash,
-  );
-  const data: { passwordHash?: string; role?: UserRole } = {};
-
-  if (!hasConfiguredPassword) {
-    data.passwordHash = await hashPassword(credentials.password);
-  }
-  if (existing.role !== "ADMIN") {
-    data.role = "ADMIN";
-  }
-
-  if (Object.keys(data).length > 0) {
-    await prisma.user.update({
-      where: { id: existing.id },
-      data,
-      select: { id: true },
-    });
-  }
-
+  // If the fixed admin already exists, don't mutate password/role based on an unauthenticated request.
+  // Account changes should happen via authenticated admin flows.
   return { id: existing.id };
 }
 

--- a/src/lib/auth/cookie.ts
+++ b/src/lib/auth/cookie.ts
@@ -1,6 +1,7 @@
 // Auth-Cookie-Konstanten gemaess docs/auth-concept.md §5.2 und §5.3.
 
 export const SESSION_COOKIE = "lh_session";
+export const SESSION_ROLE_COOKIE = "lh_role";
 
 export const SESSION_TTL_DEFAULT_SECONDS = 24 * 60 * 60;        // 24 Stunden
 export const SESSION_TTL_REMEMBER_SECONDS = 30 * 24 * 60 * 60;  // 30 Tage

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from "crypto";
+import type { UserRole } from "@prisma/client";
 import { cookies } from "next/headers";
 import { prisma } from "@/lib/prisma";
 import {
   SESSION_COOKIE,
+  SESSION_ROLE_COOKIE,
   SESSION_TTL_DEFAULT_SECONDS,
   SESSION_TTL_REMEMBER_SECONDS,
   sessionCookieOptions,
@@ -12,6 +14,7 @@ export interface CurrentUser {
   id: string;
   email: string;
   displayName: string;
+  role: UserRole;
   avatarUrl?: string | null;
 }
 
@@ -57,7 +60,7 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
     where: { id: token },
     include: {
       user: {
-        select: { id: true, email: true, displayName: true, avatarUrl: true },
+        select: { id: true, email: true, displayName: true, role: true, avatarUrl: true },
       },
     },
   });
@@ -84,6 +87,7 @@ export async function destroyCurrentSession(): Promise<void> {
   }
 
   cookieStore.set(SESSION_COOKIE, "", sessionCookieOptions(0));
+  cookieStore.set(SESSION_ROLE_COOKIE, "", sessionCookieOptions(0));
 }
 
 /**
@@ -92,6 +96,7 @@ export async function destroyCurrentSession(): Promise<void> {
 export async function createSession(
   userId: string,
   rememberMe: boolean,
+  role: UserRole = "USER",
 ): Promise<void> {
   const token = generateSessionToken();
   const ttlSeconds = rememberMe
@@ -105,4 +110,5 @@ export async function createSession(
 
   const cookieStore = await cookies();
   cookieStore.set(SESSION_COOKIE, token, sessionCookieOptions(ttlSeconds));
+  cookieStore.set(SESSION_ROLE_COOKIE, role, sessionCookieOptions(ttlSeconds));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,10 +46,7 @@ export function middleware(request: NextRequest) {
     if (isAdmin) {
       if (!hasSessionCookie) {
         if (pathname.startsWith("/api/")) {
-          return NextResponse.json(
-            { error: "Keine Admin-Berechtigung." },
-            { status: 403 },
-          );
+          return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
         }
 
         const loginUrl = new URL("/login", request.url);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { SESSION_COOKIE } from "@/lib/auth/cookie";
+import { SESSION_COOKIE, SESSION_ROLE_COOKIE } from "@/lib/auth/cookie";
 
 /**
  * Middleware für LearnHub — Auth-Schutz (C3).
@@ -15,6 +15,7 @@ import { SESSION_COOKIE } from "@/lib/auth/cookie";
  * Siehe docs/auth-concept.md §6.3.
  */
 const AUTH_ENABLED = true;
+const ADMIN_ROLE = "ADMIN";
 
 const PUBLIC_PATHS = ["/login", "/register", "/forgot-password", "/api/auth"];
 
@@ -24,14 +25,50 @@ function isPublicPath(pathname: string) {
   );
 }
 
+function isAdminPath(pathname: string) {
+  return (
+    pathname === "/admin" ||
+    pathname.startsWith("/admin/") ||
+    pathname === "/api/admin" ||
+    pathname.startsWith("/api/admin/")
+  );
+}
+
 export function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
   // Nur Cookie-Existenz prüfen – keine DB-Validierung (Edge-Runtime hat kein Prisma).
   // Echte Session-Gültigkeit wird in Server Components / Route Handlern via getSession() geprüft.
   const hasSessionCookie = request.cookies.has(SESSION_COOKIE);
   const isPublic = isPublicPath(pathname);
+  const isAdmin = isAdminPath(pathname);
 
   if (AUTH_ENABLED) {
+    if (isAdmin) {
+      if (!hasSessionCookie) {
+        if (pathname.startsWith("/api/")) {
+          return NextResponse.json(
+            { error: "Keine Admin-Berechtigung." },
+            { status: 403 },
+          );
+        }
+
+        const loginUrl = new URL("/login", request.url);
+        loginUrl.searchParams.set("redirect", `${pathname}${search}`);
+        return NextResponse.redirect(loginUrl);
+      }
+
+      if (request.cookies.get(SESSION_ROLE_COOKIE)?.value !== ADMIN_ROLE) {
+        if (pathname.startsWith("/api/")) {
+          return NextResponse.json(
+            { error: "Keine Admin-Berechtigung." },
+            { status: 403 },
+          );
+        }
+
+        return NextResponse.redirect(new URL("/dashboard", request.url));
+      }
+    }
+
     if (!hasSessionCookie && !isPublic) {
       // API-Routen: 401 JSON statt Redirect
       if (pathname.startsWith("/api/")) {


### PR DESCRIPTION
## Summary
- Add `ADMIN` user role support in Prisma, sessions, login redirects, middleware, and auth helpers.
- Add protected `/admin` dashboard with user counts, account list, create, edit role/name, and delete flows.
- Add protected admin user APIs plus fixed admin bootstrap credentials via env defaults.
- Document admin defaults and add a `typecheck` npm script.

## Validation
- `npm.cmd run prisma:migrate`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `npm.cmd test`
- Manual API check: admin login, create test user, update name/role, delete test user.