### PR TITLE
[codex] Add task-linked learning slots

### DIFF
--- a/src/app/api/calendar/events/[id]/route.ts
+++ b/src/app/api/calendar/events/[id]/route.ts
@@ -152,7 +152,10 @@ export async function PATCH(
         ? null
         : await tx.calendarEvent.findFirst({
             where: { id, ownerId: session.userId, source: "LOCAL" },
-            include: { task: { select: { completed: true } } },
+            include: {
+              task: { select: { completed: true } },
+              studyPlan: { select: { title: true } },
+            },
           });
 
     // Verschobene/umgeplante Lerneinheit: Fälligkeit (Startzeit) und Dauer der
@@ -218,6 +221,7 @@ export async function PATCH(
       important: row.important,
       repeat: (row.repeat as RepeatRule | null) ?? "none",
       studyPlanId: row.studyPlanId ?? undefined,
+      studyPlanTitle: row.studyPlan?.title ?? undefined,
       taskId: row.taskId ?? undefined,
       taskCompleted: row.task ? row.task.completed : undefined,
     },

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -221,7 +221,7 @@ export async function POST(req: Request) {
     }
     if (planId && task.studyPlan.id !== planId) {
       return NextResponse.json(
-        { error: "Aufgabe gehoert nicht zu diesem Lernplan." },
+        { error: "Aufgabe gehört nicht zu diesem Lernplan." },
         { status: 400 },
       );
     }

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -45,7 +45,10 @@ export async function GET() {
   const rows = await prisma.calendarEvent.findMany({
     where: { source: "LOCAL", ownerId: session.userId },
     orderBy: { startsAt: "asc" },
-    include: { task: { select: { completed: true } } },
+    include: {
+      task: { select: { completed: true } },
+      studyPlan: { select: { title: true } },
+    },
   });
 
   const events = rows.map((event) => {
@@ -66,6 +69,7 @@ export async function GET() {
       important: event.important,
       repeat: (event.repeat as RepeatRule | null) ?? "none",
       studyPlanId: event.studyPlanId ?? undefined,
+      studyPlanTitle: event.studyPlan?.title ?? undefined,
       taskId: event.taskId ?? undefined,
       taskCompleted: event.task ? event.task.completed : undefined,
     };
@@ -77,7 +81,7 @@ export async function GET() {
   // abgeleitet (siehe CLAUDE.md: read-only Events duerfen nicht editierbar sein).
   const plans = await prisma.studyPlan.findMany({
     where: { ownerId: session.userId },
-    select: { id: true, subject: true, goalType: true, targetDate: true },
+    select: { id: true, title: true, subject: true, goalType: true, targetDate: true },
   });
 
   const deadlineEvents = plans.map((plan) => {
@@ -104,6 +108,7 @@ export async function GET() {
       readOnly: true,
       repeat: "none" as const,
       studyPlanId: plan.id,
+      studyPlanTitle: plan.title,
     };
   });
 
@@ -179,15 +184,17 @@ export async function POST(req: Request) {
 
   // Optionale Lernplan-Verknüpfung: nur akzeptieren, wenn der Plan dem User gehört.
   let planId: string | null = null;
+  let planTitle: string | null = null;
   if (typeof studyPlanId === "string" && studyPlanId) {
     const plan = await prisma.studyPlan.findFirst({
       where: { id: studyPlanId, ownerId: session.userId },
-      select: { id: true },
+      select: { id: true, title: true },
     });
     if (!plan) {
       return NextResponse.json({ error: "Lernplan nicht gefunden." }, { status: 404 });
     }
     planId = plan.id;
+    planTitle = plan.title;
   }
 
   // Optionale Task-Verknüpfung (1:1): Aufgabe muss dem User gehören und darf
@@ -196,7 +203,12 @@ export async function POST(req: Request) {
   if (typeof taskId === "string" && taskId) {
     const task = await prisma.task.findFirst({
       where: { id: taskId, studyPlan: { ownerId: session.userId } },
-      select: { id: true, completed: true, calendarEvent: { select: { id: true } } },
+      select: {
+        id: true,
+        completed: true,
+        studyPlan: { select: { id: true, title: true } },
+        calendarEvent: { select: { id: true } },
+      },
     });
     if (!task) {
       return NextResponse.json({ error: "Aufgabe nicht gefunden." }, { status: 404 });
@@ -207,6 +219,14 @@ export async function POST(req: Request) {
         { status: 409 },
       );
     }
+    if (planId && task.studyPlan.id !== planId) {
+      return NextResponse.json(
+        { error: "Aufgabe gehoert nicht zu diesem Lernplan." },
+        { status: 400 },
+      );
+    }
+    planId = planId ?? task.studyPlan.id;
+    planTitle = planTitle ?? task.studyPlan.title;
     linkedTask = { id: task.id, completed: task.completed };
   }
 
@@ -250,6 +270,7 @@ export async function POST(req: Request) {
       important: row.important,
       repeat: (row.repeat as RepeatRule | null) ?? "none",
       studyPlanId: row.studyPlanId ?? undefined,
+      studyPlanTitle: planTitle ?? undefined,
       taskId: row.taskId ?? undefined,
       taskCompleted: linkedTask ? linkedTask.completed : undefined,
     },

--- a/src/app/api/study-plan/[id]/route.ts
+++ b/src/app/api/study-plan/[id]/route.ts
@@ -28,7 +28,16 @@ export async function GET(
 
   const plan = await prisma.studyPlan.findFirst({
     where: { id, ownerId: session.userId },
-    include: { tasks: { orderBy: { dueDate: "asc" } } },
+    include: {
+      tasks: {
+        orderBy: { dueDate: "asc" },
+        include: {
+          calendarEvent: {
+            select: { id: true, title: true, startsAt: true, endsAt: true },
+          },
+        },
+      },
+    },
   });
 
   if (!plan) {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -101,6 +101,7 @@ export function Calendar({
       ev.title,
       ev.type,
       ev.subject,
+      ev.studyPlanTitle,
       ev.location,
       ev.notes,
       ev.tasks,

--- a/src/components/calendar/EventDetailModal.tsx
+++ b/src/components/calendar/EventDetailModal.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import {
+  ArrowRight,
+  BookOpen,
   CalendarDays,
   CircleCheckBig,
   MapPin,
@@ -316,6 +319,27 @@ export function EventDetailModal({
                 </span>
               )}
             </div>
+
+            {event.studyPlanId && (
+              <Link
+                href={`/study-plan/${event.studyPlanId}`}
+                onClick={onClose}
+                className="flex items-center justify-between gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-left transition-colors hover:border-blue-300 hover:bg-blue-100"
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <BookOpen className="h-4 w-4 shrink-0 text-blue-700" />
+                  <span className="min-w-0">
+                    <span className="block text-xs font-semibold uppercase tracking-wider text-blue-600">
+                      Lernplan
+                    </span>
+                    <span className="block truncate text-sm font-bold text-blue-900">
+                      {event.studyPlanTitle ?? "Zum Lernplan"}
+                    </span>
+                  </span>
+                </span>
+                <ArrowRight className="h-4 w-4 shrink-0 text-blue-700" />
+              </Link>
+            )}
 
             {/* Lernsession abhaken (Events mit verknüpfter Lernplan-Aufgabe) */}
             {event.taskId && event.studyPlanId && onToggleTaskCompleted && (

--- a/src/components/calendar/events.ts
+++ b/src/components/calendar/events.ts
@@ -22,6 +22,7 @@ export type CalEvent = {
   important?: boolean;
   /** Verknüpfter Lernplan (gesetzt bei generierten Lerneinheiten). */
   studyPlanId?: string;
+  studyPlanTitle?: string;
   /** Verknüpfte Lernplan-Aufgabe (1:1, gesetzt bei generierten Lerneinheiten). */
   taskId?: string;
   /** Erledigt-Status der verknüpften Aufgabe (abhakbar im Kalender). */

--- a/src/components/study-plan/StudyPlanDetail.tsx
+++ b/src/components/study-plan/StudyPlanDetail.tsx
@@ -160,7 +160,12 @@ export function StudyPlanDetail({ planId }: StudyPlanDetailProps) {
       </div>
 
       {/* Aufgaben */}
-      <TaskList planId={plan.id} tasks={plan.tasks} onChanged={() => void refresh()} />
+      <TaskList
+        planId={plan.id}
+        subject={plan.subject}
+        tasks={plan.tasks}
+        onChanged={() => void refresh()}
+      />
 
       {/* Bearbeiten-Modal */}
       <StudyPlanForm

--- a/src/components/study-plan/TaskItem.tsx
+++ b/src/components/study-plan/TaskItem.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import { CalendarDays, Clock, Gauge, Pencil, Trash2 } from "lucide-react";
+import {
+  CalendarCheck,
+  CalendarDays,
+  CalendarPlus,
+  Clock,
+  Gauge,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
-import type { TaskDTO } from "@/lib/study-plan/types";
+import type { TaskCalendarEventDTO, TaskDTO } from "@/lib/study-plan/types";
 import { daysUntil, formatDate, formatMinutes } from "./planMeta";
 
 interface TaskItemProps {
@@ -12,9 +20,30 @@ interface TaskItemProps {
   task: TaskDTO;
   onChanged: () => void;
   onEdit: (task: TaskDTO) => void;
+  onCreateSlot: (task: TaskDTO) => void;
 }
 
-export function TaskItem({ planId, task, onChanged, onEdit }: TaskItemProps) {
+function formatSlotRange(slot: TaskCalendarEventDTO): string {
+  const start = new Date(slot.startsAt);
+  const end = new Date(slot.endsAt);
+  const date = new Intl.DateTimeFormat("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+  }).format(start);
+  const time = new Intl.DateTimeFormat("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${date}, ${time.format(start)}-${time.format(end)}`;
+}
+
+export function TaskItem({
+  planId,
+  task,
+  onChanged,
+  onEdit,
+  onCreateSlot,
+}: TaskItemProps) {
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -95,6 +124,21 @@ export function TaskItem({ planId, task, onChanged, onEdit }: TaskItemProps) {
             <Gauge className="w-3.5 h-3.5" />
             Schwierigkeit {task.difficulty}/5
           </span>
+          {task.calendarEvent ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 font-medium text-green-700">
+              <CalendarCheck className="w-3.5 h-3.5" />
+              Lernslot {formatSlotRange(task.calendarEvent)}
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onCreateSlot(task)}
+              className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-0.5 font-medium text-gray-600 transition-colors hover:border-brand-red hover:text-brand-red"
+            >
+              <CalendarPlus className="w-3.5 h-3.5" />
+              Lernslot
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/study-plan/TaskLearningSlotModal.tsx
+++ b/src/components/study-plan/TaskLearningSlotModal.tsx
@@ -207,7 +207,7 @@ export function TaskLearningSlotModal({
             onClick={onClose}
             disabled={saving}
             className="rounded-lg p-1 hover:bg-gray-100 transition-colors disabled:opacity-50"
-            aria-label="Schliessen"
+            aria-label="Schließen"
           >
             <X className="h-4 w-4 text-gray-500" />
           </button>

--- a/src/components/study-plan/TaskLearningSlotModal.tsx
+++ b/src/components/study-plan/TaskLearningSlotModal.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CalendarPlus, X } from "lucide-react";
+import {
+  DAY_START_HOUR,
+  isAllowedTimedRange,
+  type RepeatRule,
+} from "@/components/calendar/events";
+import { DateTimePicker } from "@/components/calendar/DateTimePicker";
+import type { TaskDTO } from "@/lib/study-plan/types";
+
+interface TaskLearningSlotModalProps {
+  open: boolean;
+  planId: string;
+  subject: string;
+  task: TaskDTO | null;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function toLocalInputValue(date: Date): string {
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours(),
+  )}:${pad(date.getMinutes())}`;
+}
+
+function defaultStartForTask(task: TaskDTO): Date {
+  const dueDate = new Date(task.dueDate);
+  const start = Number.isNaN(dueDate.getTime()) ? new Date() : dueDate;
+  const now = new Date();
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+
+  if (start.getTime() < today.getTime()) {
+    start.setTime(now.getTime());
+  }
+
+  start.setHours(16, 0, 0, 0);
+  if (start.getTime() <= now.getTime()) {
+    start.setTime(now.getTime());
+    start.setMinutes(Math.ceil(start.getMinutes() / 15) * 15, 0, 0);
+    if (start.getHours() < DAY_START_HOUR) {
+      start.setHours(DAY_START_HOUR, 0, 0, 0);
+    }
+    if (!isAllowedTimedRange(start, defaultEndForTask(start, 30))) {
+      start.setDate(start.getDate() + 1);
+      start.setHours(16, 0, 0, 0);
+    }
+  }
+  return start;
+}
+
+function defaultEndForTask(start: Date, estimatedMinutes: number): Date {
+  const durationMinutes = Math.max(30, Math.min(estimatedMinutes, 8 * 60));
+  const end = new Date(start.getTime() + durationMinutes * 60_000);
+  const dayEnd = new Date(start);
+  dayEnd.setDate(dayEnd.getDate() + 1);
+  dayEnd.setHours(0, 0, 0, 0);
+  return end.getTime() <= dayEnd.getTime() ? end : dayEnd;
+}
+
+function taskSlotText(task: TaskDTO): string {
+  const lines = [task.title.trim()];
+  if (task.description?.trim()) lines.push("", task.description.trim());
+  return lines.join("\n");
+}
+
+export function TaskLearningSlotModal({
+  open,
+  planId,
+  subject,
+  task,
+  onClose,
+  onCreated,
+}: TaskLearningSlotModalProps) {
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [activePicker, setActivePicker] = useState<"start" | "end" | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !task) return;
+    const initialStart = defaultStartForTask(task);
+    const initialEnd = defaultEndForTask(initialStart, task.estimatedMinutes);
+    setStart(toLocalInputValue(initialStart));
+    setEnd(toLocalInputValue(initialEnd));
+    setActivePicker(null);
+    setSaving(false);
+    setError(null);
+  }, [open, task]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape" && !saving) onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, saving]);
+
+  if (!open || !task) return null;
+  const activeTask = task;
+
+  function handleStartChange(nextStart: string) {
+    setStart(nextStart);
+    setError(null);
+    const startDate = new Date(nextStart);
+    const endDate = new Date(end);
+    if (
+      !Number.isNaN(startDate.getTime()) &&
+      !Number.isNaN(endDate.getTime()) &&
+      endDate.getTime() <= startDate.getTime()
+    ) {
+      setEnd(toLocalInputValue(defaultEndForTask(startDate, activeTask.estimatedMinutes)));
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+
+    if (
+      Number.isNaN(startDate.getTime()) ||
+      Number.isNaN(endDate.getTime()) ||
+      endDate.getTime() <= startDate.getTime()
+    ) {
+      setError("Bitte waehle einen gueltigen Zeitraum.");
+      return;
+    }
+
+    if (!isAllowedTimedRange(startDate, endDate)) {
+      setError("Lernslots muessen zwischen 07:00 und 00:00 Uhr liegen.");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/calendar/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: `Lernslot: ${activeTask.title}`,
+          start: startDate.toISOString(),
+          end: endDate.toISOString(),
+          allDay: false,
+          type: "Lernsession",
+          subject,
+          tasks: taskSlotText(activeTask),
+          repeat: "none" satisfies RepeatRule,
+          studyPlanId: planId,
+          taskId: activeTask.id,
+        }),
+      });
+
+      const data = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Lernslot konnte nicht gespeichert werden.");
+      }
+
+      onCreated();
+      onClose();
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Lernslot konnte nicht gespeichert werden.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={() => {
+        if (!saving) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="task-learning-slot-title"
+        className="max-h-[calc(100vh-2rem)] w-full max-w-md overflow-y-auto rounded-2xl border border-gray-200 bg-white shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <CalendarPlus className="h-5 w-5 shrink-0 text-brand-red" />
+            <h3
+              id="task-learning-slot-title"
+              className="truncate text-lg font-bold text-gray-900"
+            >
+              Lernslot erstellen
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-lg p-1 hover:bg-gray-100 transition-colors disabled:opacity-50"
+            aria-label="Schliessen"
+          >
+            <X className="h-4 w-4 text-gray-500" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 px-5 py-4">
+          <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+            <p className="text-sm font-semibold text-gray-900">{activeTask.title}</p>
+            {activeTask.description && (
+              <p className="mt-1 line-clamp-2 text-xs text-gray-500">
+                {activeTask.description}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <DateTimePicker
+              id="task-slot-start"
+              label="Beginn"
+              value={start}
+              open={activePicker === "start"}
+              stage="start"
+              onOpenChange={(nextOpen) => setActivePicker(nextOpen ? "start" : null)}
+              onChange={handleStartChange}
+              onComplete={() => setActivePicker("end")}
+            />
+            <DateTimePicker
+              id="task-slot-end"
+              label="Ende"
+              value={end}
+              open={activePicker === "end"}
+              align="right"
+              allowMidnight
+              stage="end"
+              onOpenChange={(nextOpen) => setActivePicker(nextOpen ? "end" : null)}
+              onChange={(nextEnd) => {
+                setEnd(nextEnd);
+                setError(null);
+              }}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2 border-t border-gray-100 pt-2">
+            {error && (
+              <p className="rounded-lg bg-red-50 px-3 py-2 text-xs font-medium text-red-600">
+                {error}
+              </p>
+            )}
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={saving}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                Abbrechen
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-bold text-white shadow-sm transition-opacity hover:opacity-90 active:scale-95 disabled:opacity-50"
+                style={{ backgroundColor: "#ef233c" }}
+              >
+                <CalendarPlus className="h-4 w-4" />
+                {saving ? "Wird gespeichert..." : "In Kalender eintragen"}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/study-plan/TaskLearningSlotModal.tsx
+++ b/src/components/study-plan/TaskLearningSlotModal.tsx
@@ -133,7 +133,7 @@ export function TaskLearningSlotModal({
     }
 
     if (!isAllowedTimedRange(startDate, endDate)) {
-      setError("Lernslots muessen zwischen 07:00 und 00:00 Uhr liegen.");
+      setError("Lernslots müssen zwischen 07:00 und 00:00 Uhr liegen.");
       return;
     }
 

--- a/src/components/study-plan/TaskLearningSlotModal.tsx
+++ b/src/components/study-plan/TaskLearningSlotModal.tsx
@@ -128,7 +128,7 @@ export function TaskLearningSlotModal({
       Number.isNaN(endDate.getTime()) ||
       endDate.getTime() <= startDate.getTime()
     ) {
-      setError("Bitte waehle einen gueltigen Zeitraum.");
+      setError("Bitte wähle einen gültigen Zeitraum.");
       return;
     }
 

--- a/src/components/study-plan/TaskList.tsx
+++ b/src/components/study-plan/TaskList.tsx
@@ -5,16 +5,19 @@ import { CircleCheckBig, Plus } from "lucide-react";
 import type { TaskDTO } from "@/lib/study-plan/types";
 import { TaskForm } from "./TaskForm";
 import { TaskItem } from "./TaskItem";
+import { TaskLearningSlotModal } from "./TaskLearningSlotModal";
 
 interface TaskListProps {
   planId: string;
+  subject: string;
   tasks: TaskDTO[];
   onChanged: () => void;
 }
 
-export function TaskList({ planId, tasks, onChanged }: TaskListProps) {
+export function TaskList({ planId, subject, tasks, onChanged }: TaskListProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [editTask, setEditTask] = useState<TaskDTO | null>(null);
+  const [slotTask, setSlotTask] = useState<TaskDTO | null>(null);
 
   const open = tasks.filter((t) => !t.completed);
   const done = tasks.filter((t) => t.completed);
@@ -62,6 +65,7 @@ export function TaskList({ planId, tasks, onChanged }: TaskListProps) {
               task={task}
               onChanged={onChanged}
               onEdit={openEdit}
+              onCreateSlot={setSlotTask}
             />
           ))}
 
@@ -79,6 +83,7 @@ export function TaskList({ planId, tasks, onChanged }: TaskListProps) {
                   task={task}
                   onChanged={onChanged}
                   onEdit={openEdit}
+                  onCreateSlot={setSlotTask}
                 />
               ))}
             </>
@@ -92,6 +97,15 @@ export function TaskList({ planId, tasks, onChanged }: TaskListProps) {
         task={editTask}
         onClose={() => setFormOpen(false)}
         onSaved={onChanged}
+      />
+
+      <TaskLearningSlotModal
+        open={slotTask !== null}
+        planId={planId}
+        subject={subject}
+        task={slotTask}
+        onClose={() => setSlotTask(null)}
+        onCreated={onChanged}
       />
     </div>
   );

--- a/src/lib/study-plan/types.ts
+++ b/src/lib/study-plan/types.ts
@@ -1,7 +1,7 @@
 // Geteilte Typen, Serializer und Validierungs-Helfer für die Lernplan-Features.
 // Siehe docs/lernplan-umsetzung.md (Phase B).
 
-import type { GoalType, StudyPlan, Task } from "@prisma/client";
+import type { CalendarEvent, GoalType, StudyPlan, Task } from "@prisma/client";
 
 export const GOAL_TYPES: GoalType[] = [
   "KLAUSUR",
@@ -22,6 +22,14 @@ export interface TaskDTO {
   dueDate: string; // ISO
   completed: boolean;
   completedAt: string | null; // ISO
+  calendarEvent: TaskCalendarEventDTO | null;
+}
+
+export interface TaskCalendarEventDTO {
+  id: string;
+  title: string;
+  startsAt: string; // ISO
+  endsAt: string; // ISO
 }
 
 export interface StudyPlanDTO {
@@ -58,7 +66,11 @@ export interface StudyPlanDetailDTO extends StudyPlanDTO {
 
 // ─── Serializer ────────────────────────────────────────────────────────────────
 
-export function serializeTask(t: Task): TaskDTO {
+type SerializableTask = Task & {
+  calendarEvent?: Pick<CalendarEvent, "id" | "title" | "startsAt" | "endsAt"> | null;
+};
+
+export function serializeTask(t: SerializableTask): TaskDTO {
   return {
     id: t.id,
     title: t.title,
@@ -68,6 +80,14 @@ export function serializeTask(t: Task): TaskDTO {
     dueDate: t.dueDate.toISOString(),
     completed: t.completed,
     completedAt: t.completedAt ? t.completedAt.toISOString() : null,
+    calendarEvent: t.calendarEvent
+      ? {
+          id: t.calendarEvent.id,
+          title: t.calendarEvent.title,
+          startsAt: t.calendarEvent.startsAt.toISOString(),
+          endsAt: t.calendarEvent.endsAt.toISOString(),
+        }
+      : null,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the S1 should-have flow for creating a calendar learning slot directly from a study-plan task.

## Changes

- Extends task DTOs and study-plan detail loading with the linked calendar event state.
- Adds a task-level learning-slot modal that creates a `Lernsession` calendar event linked to the task and study plan.
- Shows whether a task already has a linked learning slot, including completed tasks.
- Adds study-plan context to linked calendar events and exposes a direct link from the calendar event detail modal back to the study-plan detail page.

## Impact

Students can create concrete calendar learning time from a task and keep the relationship visible from both the task list and the calendar detail view.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd run build`