### PR TITLE
K1: Verpasste Lernsessions benachrichtigen

### DIFF
--- a/prisma/migrations/20260617170000_add_missed_session_notifications/migration.sql
+++ b/prisma/migrations/20260617170000_add_missed_session_notifications/migration.sql
@@ -1,0 +1,21 @@
+-- Extend notifications for missed learning sessions.
+ALTER TYPE "NotificationType" ADD VALUE 'MISSED_SESSION';
+
+ALTER TABLE "Notification" ADD COLUMN "triggerKey" TEXT;
+
+CREATE UNIQUE INDEX "Notification_ownerId_triggerKey_key" ON "Notification"("ownerId", "triggerKey");
+
+CREATE TABLE "NotificationSettings" (
+    "id" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "missedSessionRescheduleEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "missedSessionReplanWarningEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationSettings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "NotificationSettings_ownerId_key" ON "NotificationSettings"("ownerId");
+
+ALTER TABLE "NotificationSettings" ADD CONSTRAINT "NotificationSettings_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,7 @@ model User {
   calendarEvents  CalendarEvent[]
   calendarSources CalendarSource[]
   notifications   Notification[]
+  notificationSettings NotificationSettings?
   feedbacks       Feedback[]
 }
 
@@ -205,6 +206,7 @@ model CalendarSource {
 enum NotificationType {
   ASSIGNMENT
   EXAM
+  MISSED_SESSION
 }
 
 model Notification {
@@ -217,6 +219,7 @@ model Notification {
   isUrgent    Boolean          @default(false)
   isDone      Boolean          @default(false)
   isArchived  Boolean          @default(false)
+  triggerKey  String?
   ownerId     String
   createdAt   DateTime         @default(now())
   updatedAt   DateTime         @updatedAt
@@ -224,8 +227,20 @@ model Notification {
 
   owner User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
 
+  @@unique([ownerId, triggerKey])
   @@index([ownerId])
   @@index([expiresAt])
+}
+
+model NotificationSettings {
+  id                                String   @id @default(cuid())
+  ownerId                           String   @unique
+  missedSessionRescheduleEnabled    Boolean  @default(true)
+  missedSessionReplanWarningEnabled Boolean  @default(true)
+  createdAt                         DateTime @default(now())
+  updatedAt                         DateTime @updatedAt
+
+  owner User @relation(fields: [ownerId], references: [id], onDelete: Cascade)
 }
 
 // =====================================================================

--- a/src/app/api/notifications/check/route.ts
+++ b/src/app/api/notifications/check/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { checkMissedSessionNotifications } from "@/lib/notifications/missedSessions";
+
+async function handleCheck() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const result = await checkMissedSessionNotifications(session.userId);
+  return NextResponse.json(result);
+}
+
+/** GET /api/notifications/check - verpasste Lernsessions prüfen. */
+export async function GET() {
+  return handleCheck();
+}
+
+/** POST /api/notifications/check - verpasste Lernsessions prüfen. */
+export async function POST() {
+  return handleCheck();
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
+import { checkMissedSessionNotifications } from "@/lib/notifications/missedSessions";
 import {
   isNotificationType,
   serializeNotification,
@@ -9,58 +10,6 @@ import { prisma } from "@/lib/prisma";
 
 const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
-const MISSED_SESSION_SUBJECT = "Lernsession nicht abgehakt";
-
-/**
- * Erzeugt Benachrichtigungen für vergangene, nicht abgehakte Lernsessions
- * (Kalender-Lerneinheiten mit verknüpfter, offener Lernplan-Aufgabe).
- * Idempotent: pro Session entsteht höchstens eine Benachrichtigung
- * (Dedupe über Fach + Endzeitpunkt).
- */
-async function createMissedSessionNotifications(userId: string, now: Date) {
-  const since = new Date(now.getTime() - RETENTION_MS);
-  const missed = await prisma.calendarEvent.findMany({
-    where: {
-      ownerId: userId,
-      source: "LOCAL",
-      type: "LERNEINHEIT",
-      taskId: { not: null },
-      endsAt: { lt: now, gt: since },
-      task: { is: { completed: false } },
-    },
-    select: { title: true, subject: true, endsAt: true },
-  });
-  if (missed.length === 0) return;
-
-  const existing = await prisma.notification.findMany({
-    where: { ownerId: userId, subject: MISSED_SESSION_SUBJECT, expiresAt: { gt: now } },
-    select: { course: true, dueDate: true },
-  });
-  const seen = new Set(existing.map((n) => `${n.course}|${n.dueDate.getTime()}`));
-
-  const pad = (n: number) => n.toString().padStart(2, "0");
-  const toCreate = missed
-    .filter((e) => !seen.has(`${e.subject ?? e.title}|${e.endsAt.getTime()}`))
-    .map((e) => {
-      const d = e.endsAt;
-      const when = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} um ${pad(d.getHours())}:${pad(d.getMinutes())} Uhr`;
-      return {
-        type: "ASSIGNMENT" as const,
-        subject: MISSED_SESSION_SUBJECT,
-        course: e.subject ?? e.title,
-        dueDate: e.endsAt,
-        description:
-          `Deine Lernsession „${e.title}“ (geplant bis ${when}) wurde noch nicht abgehakt. ` +
-          "Hake sie im Kalender ab oder verschiebe sie – der Lernplan ist eine Basis, kein Pflichtprogramm.",
-        ownerId: userId,
-        expiresAt: new Date(e.endsAt.getTime() + RETENTION_MS),
-      };
-    });
-  if (toCreate.length > 0) {
-    await prisma.notification.createMany({ data: toCreate });
-  }
-}
-
 /** GET /api/notifications - aktive Benachrichtigungen des angemeldeten Users. */
 export async function GET() {
   const session = await getSession();
@@ -69,9 +18,8 @@ export async function GET() {
   }
 
   const now = new Date();
-  // Erst fehlende Hinweise zu nicht abgehakten Lernsessions erzeugen,
-  // damit sie direkt in der Antwort enthalten sind.
-  await createMissedSessionNotifications(session.userId, now);
+  await checkMissedSessionNotifications(session.userId, now);
+
   const [, notifications] = await prisma.$transaction([
     prisma.notification.deleteMany({
       where: { ownerId: session.userId, expiresAt: { lte: now } },

--- a/src/app/api/settings/notifications/route.ts
+++ b/src/app/api/settings/notifications/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import {
+  getNotificationSettings,
+  updateNotificationSettings,
+  type NotificationSettingsDTO,
+} from "@/lib/notifications/settings";
+
+function parseSettingsInput(body: unknown): NotificationSettingsDTO | null {
+  const input = (body ?? {}) as Record<string, unknown>;
+
+  if (
+    typeof input.missedSessionRescheduleEnabled !== "boolean" ||
+    typeof input.missedSessionReplanWarningEnabled !== "boolean"
+  ) {
+    return null;
+  }
+
+  return {
+    missedSessionRescheduleEnabled: input.missedSessionRescheduleEnabled,
+    missedSessionReplanWarningEnabled: input.missedSessionReplanWarningEnabled,
+  };
+}
+
+/** GET /api/settings/notifications - Benachrichtigungseinstellungen laden. */
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  const settings = await getNotificationSettings(session.userId);
+  return NextResponse.json({ settings });
+}
+
+/** PUT /api/settings/notifications - Benachrichtigungseinstellungen speichern. */
+export async function PUT(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const settings = parseSettingsInput(body);
+  if (!settings) {
+    return NextResponse.json({ error: "Ungültige Einstellungen." }, { status: 400 });
+  }
+
+  const savedSettings = await updateNotificationSettings(session.userId, settings);
+  return NextResponse.json({ settings: savedSettings });
+}

--- a/src/components/layout/DashboardShell.tsx
+++ b/src/components/layout/DashboardShell.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { CurrentUser } from "@/lib/auth/session";
+import {
+  EMPTY_NOTIFICATION_SUMMARY,
+  summarizeNotifications,
+  type NotificationSummary,
+} from "@/lib/notifications/summary";
+import type { NotificationDTO } from "@/lib/notifications/types";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 
@@ -12,7 +18,34 @@ interface DashboardShellProps {
 
 export function DashboardShell({ children, currentUser }: DashboardShellProps) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [notificationSummary, setNotificationSummary] =
+    useState<NotificationSummary>(EMPTY_NOTIFICATION_SUMMARY);
   const sidebarWidth = 260;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadNotificationSummary() {
+      try {
+        const response = await fetch("/api/notifications", { cache: "no-store" });
+        const data = (await response.json().catch(() => ({}))) as {
+          notifications?: NotificationDTO[];
+        };
+
+        if (!response.ok || cancelled) return;
+        setNotificationSummary(
+          summarizeNotifications(data.notifications ?? []),
+        );
+      } catch {
+        if (!cancelled) setNotificationSummary(EMPTY_NOTIFICATION_SUMMARY);
+      }
+    }
+
+    loadNotificationSummary();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="flex min-h-screen bg-background text-foreground transition-colors duration-300">
@@ -21,7 +54,10 @@ export function DashboardShell({ children, currentUser }: DashboardShellProps) {
         className="fixed top-0 left-0 h-screen z-40 transition-all duration-300"
         style={{ width: sidebarOpen ? sidebarWidth : 0, overflow: "hidden" }}
       >
-        <Sidebar currentUser={currentUser} />
+        <Sidebar
+          currentUser={currentUser}
+          notificationSummary={notificationSummary}
+        />
       </div>
 
       {/* Rechter Hauptbereich */}
@@ -32,6 +68,7 @@ export function DashboardShell({ children, currentUser }: DashboardShellProps) {
         <Topbar
           sidebarOpen={sidebarOpen}
           onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
+          notificationSummary={notificationSummary}
         />
         <div className="flex-1">{children}</div>
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
 import type { CurrentUser } from "@/lib/auth/session";
+import type { NotificationSummary } from "@/lib/notifications/summary";
 import { cn } from "@/lib/utils";
 
 function getNavItems(canOpenManagement: boolean) {
@@ -46,6 +47,7 @@ function getNavItems(canOpenManagement: boolean) {
 
 interface SidebarProps {
   currentUser?: CurrentUser;
+  notificationSummary?: NotificationSummary;
 }
 
 function getInitials(displayName?: string): string {
@@ -67,11 +69,12 @@ function isActiveLink(currentPath: string, href: string) {
   return currentPath === target || currentPath.startsWith(`${target}/`);
 }
 
-export function Sidebar({ currentUser }: SidebarProps) {
+export function Sidebar({ currentUser, notificationSummary }: SidebarProps) {
   const pathname = usePathname() ?? "";
   const displayName = currentUser?.displayName ?? "LearnHub";
   const email = currentUser?.email ?? "";
   const navItems = getNavItems(currentUser?.role === "ADMIN" || currentUser?.role === "DEV");
+  const openNotificationCount = notificationSummary?.openCount ?? 0;
 
   return (
     <div className="flex h-full w-full flex-col border-r border-sidebar-border bg-sidebar px-5 py-6 text-sidebar-foreground transition-colors duration-300">
@@ -105,12 +108,22 @@ export function Sidebar({ currentUser }: SidebarProps) {
                       href={href}
                       aria-current={active ? "page" : undefined}
                       className={cn(
-                        "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-semibold transition-colors",
+                        "flex items-center justify-between gap-3 rounded-xl px-3 py-2 text-sm font-semibold transition-colors",
                         active ? "bg-white/15 text-white" : "text-white hover:bg-white/10",
                       )}
                     >
-                      <Icon className="h-4 w-4 opacity-80" />
-                      {label}
+                      <span className="flex min-w-0 items-center gap-3">
+                        <Icon className="h-4 w-4 shrink-0 opacity-80" />
+                        <span className="truncate">{label}</span>
+                      </span>
+                      {label === "Benachrichtigungen" && openNotificationCount > 0 && (
+                        <span
+                          aria-label={`${openNotificationCount} offene Benachrichtigungen`}
+                          className="ml-auto inline-flex min-w-5 shrink-0 items-center justify-center rounded-full bg-[#ef233c] px-1.5 py-0.5 text-[11px] font-bold leading-none text-white shadow-sm ring-1 ring-white/20"
+                        >
+                          {openNotificationCount > 99 ? "99+" : openNotificationCount}
+                        </span>
+                      )}
                     </Link>
                   </li>
                 );

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,20 +1,80 @@
 "use client";
 
-import { LogOut, Moon, PanelLeftClose, PanelLeftOpen, Search, Sun } from "lucide-react";
+import Link from "next/link";
+import {
+  BellRing,
+  LogOut,
+  Moon,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Search,
+  Sun,
+  X,
+} from "lucide-react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import type { NotificationSummary } from "@/lib/notifications/summary";
 import { useTheme } from "@/lib/useTheme";
 
 interface TopbarProps {
   sidebarOpen: boolean;
   onToggleSidebar: () => void;
+  notificationSummary?: NotificationSummary;
 }
 
-export function Topbar({ sidebarOpen, onToggleSidebar }: TopbarProps) {
+function getNotificationTitle(summary: NotificationSummary) {
+  if (summary.missedSessionCount > 0) return "Lernsessions verpasst";
+  if (summary.urgentCount > 0) return "Wichtige Benachrichtigungen";
+  return "Neue Benachrichtigungen";
+}
+
+function getNotificationMessage(summary: NotificationSummary) {
+  if (summary.missedSessionCount > 0) {
+    return `Du hast ${summary.missedSessionCount} Hinweis${
+      summary.missedSessionCount === 1 ? "" : "e"
+    } zu verpassten Lernsessions. Schau in die Benachrichtigungen, um deinen Lernplan anzupassen.`;
+  }
+
+  if (summary.urgentCount > 0) {
+    return `Du hast ${summary.urgentCount} wichtige Benachrichtigung${
+      summary.urgentCount === 1 ? "" : "en"
+    }. Schau sie dir an.`;
+  }
+
+  return `Du hast ${summary.openCount} offene Benachrichtigung${
+    summary.openCount === 1 ? "" : "en"
+  }.`;
+}
+
+export function Topbar({
+  sidebarOpen,
+  onToggleSidebar,
+  notificationSummary,
+}: TopbarProps) {
   const router = useRouter();
+  const pathname = usePathname() ?? "";
   const { isDark, toggleTheme } = useTheme();
   const [logoutError, setLogoutError] = useState<string | null>(null);
+  const [notificationPopupDismissed, setNotificationPopupDismissed] =
+    useState(false);
+  const [mounted, setMounted] = useState(false);
+  const openNotificationCount = notificationSummary?.openCount ?? 0;
+  const showNotificationPopup =
+    openNotificationCount > 0 &&
+    !notificationPopupDismissed &&
+    pathname !== "/notifications";
+  const notificationTitle = notificationSummary
+    ? getNotificationTitle(notificationSummary)
+    : "";
+  const notificationMessage = notificationSummary
+    ? getNotificationMessage(notificationSummary)
+    : "";
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   async function handleLogout() {
     try {
@@ -31,66 +91,120 @@ export function Topbar({ sidebarOpen, onToggleSidebar }: TopbarProps) {
   }
 
   return (
-    <div className="flex flex-col border-b border-border bg-background/85 backdrop-blur-sm">
-      <div className="flex items-center justify-between px-6 py-4">
-        <button
-          type="button"
-          onClick={onToggleSidebar}
-          className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
-          aria-label={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
-        >
-          {sidebarOpen ? (
-            <PanelLeftClose className="h-5 w-5" />
-          ) : (
-            <PanelLeftOpen className="h-5 w-5" />
-          )}
-        </button>
-
-        <div className="flex w-[280px] items-center gap-2 rounded-2xl bg-muted px-4 py-2 text-muted-foreground">
-          <Search className="h-4 w-4" />
-          <span className="text-sm">Suchen</span>
-        </div>
-
-        <div className="flex items-center gap-3">
+    <>
+      <div className="flex flex-col border-b border-border bg-background/85 backdrop-blur-sm">
+        <div className="flex items-center justify-between px-6 py-4">
           <button
             type="button"
-            onClick={toggleTheme}
+            onClick={onToggleSidebar}
             className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title={isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
-            aria-label={isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
-            aria-pressed={isDark}
+            title={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
+            aria-label={sidebarOpen ? "Sidebar einklappen" : "Sidebar ausklappen"}
           >
-            {isDark ? (
-              <Sun className="h-5 w-5 text-amber-400" />
+            {sidebarOpen ? (
+              <PanelLeftClose className="h-5 w-5" />
             ) : (
-              <Moon className="h-5 w-5" />
+              <PanelLeftOpen className="h-5 w-5" />
             )}
           </button>
-          <button
-            type="button"
-            onClick={handleLogout}
-            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Abmelden"
-            aria-label="Abmelden"
-          >
-            <LogOut className="h-5 w-5" />
-          </button>
-          <Image
-            src="/images/Dhbw_Icon.png"
-            alt="DHBW Logo"
-            width={48}
-            height={48}
-            className="object-contain"
-          />
+
+          <div className="flex w-[280px] items-center gap-2 rounded-2xl bg-muted px-4 py-2 text-muted-foreground">
+            <Search className="h-4 w-4" />
+            <span className="text-sm">Suchen</span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title={isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"}
+              aria-label={
+                isDark ? "Light Mode aktivieren" : "Dark Mode aktivieren"
+              }
+              aria-pressed={isDark}
+            >
+              {isDark ? (
+                <Sun className="h-5 w-5 text-amber-400" />
+              ) : (
+                <Moon className="h-5 w-5" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title="Abmelden"
+              aria-label="Abmelden"
+            >
+              <LogOut className="h-5 w-5" />
+            </button>
+            <Image
+              src="/images/Dhbw_Icon.png"
+              alt="DHBW Logo"
+              width={48}
+              height={48}
+              className="object-contain"
+            />
+          </div>
         </div>
+
+        {logoutError && (
+          <div className="border-t border-red-200 bg-red-50 px-6 py-2 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
+            {logoutError}
+          </div>
+        )}
       </div>
 
-      {logoutError && (
-        <div className="border-t border-red-200 bg-red-50 px-6 py-2 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300">
-          {logoutError}
-        </div>
-      )}
-    </div>
+      {mounted &&
+        showNotificationPopup &&
+        notificationSummary &&
+        createPortal(
+          <div className="fixed bottom-4 left-4 z-[9999] w-[min(430px,calc(100vw-2rem))] sm:bottom-6 sm:left-6">
+            <div
+              role="alert"
+              aria-labelledby="notification-popup-title"
+              className="w-full rounded-xl border border-border bg-card p-4 text-card-foreground shadow-2xl ring-1 ring-black/10 dark:border-white/10 dark:bg-[#242629] dark:text-white dark:ring-white/10"
+            >
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[#ef233c] text-white shadow-sm">
+                  <BellRing className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h2
+                    id="notification-popup-title"
+                    className="text-base font-bold leading-6 text-foreground dark:text-white"
+                  >
+                    {notificationTitle}
+                  </h2>
+                  <p className="mt-1 text-sm leading-5 text-muted-foreground dark:text-white/75">
+                    {notificationMessage}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setNotificationPopupDismissed(true)}
+                  className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white"
+                  aria-label="Popup schließen"
+                  title="Popup schließen"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="mt-4 flex justify-end">
+                <Link
+                  href="/notifications"
+                  onClick={() => setNotificationPopupDismissed(true)}
+                  className="rounded-lg bg-[#ef233c] px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#d11f35]"
+                >
+                  Benachrichtigungen öffnen
+                </Link>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }

--- a/src/components/notifications/NotificationsPage.tsx
+++ b/src/components/notifications/NotificationsPage.tsx
@@ -6,6 +6,7 @@ import {
   Archive,
   ArchiveRestore,
   BookOpen,
+  CalendarClock,
   CheckCircle,
   Search,
   Trash2,
@@ -16,7 +17,7 @@ import type {
 } from "@/lib/notifications/types";
 import { cn } from "@/lib/utils";
 
-const filters = ["Alle", "Offen", "Abgaben", "Klausuren", "Archiviert"] as const;
+const filters = ["Alle", "Offen", "Abgaben", "Klausuren", "Lernsessions", "Archiviert"] as const;
 type Filter = (typeof filters)[number];
 
 const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
@@ -85,6 +86,8 @@ export function NotificationsPage() {
             return notification.type === "assignment" && !notification.isArchived;
           case "Klausuren":
             return notification.type === "exam" && !notification.isArchived;
+          case "Lernsessions":
+            return notification.type === "missed-session" && !notification.isArchived;
           case "Offen":
             return !notification.isDone && !notification.isArchived;
           case "Archiviert":
@@ -182,15 +185,18 @@ export function NotificationsPage() {
     }
   };
 
-  const getTypeIcon = (type: NotificationType) =>
-    type === "exam" ? (
-      <AlertCircle className="h-5 w-5" />
-    ) : (
-      <BookOpen className="h-5 w-5" />
-    );
+  const getTypeIcon = (type: NotificationType) => {
+    if (type === "exam") return <AlertCircle className="h-5 w-5" />;
+    if (type === "missed-session") return <CalendarClock className="h-5 w-5" />;
+    return <BookOpen className="h-5 w-5" />;
+  };
 
   const getTypeLabel = (type: NotificationType) =>
-    type === "exam" ? "Klausur" : "Abgabe";
+    type === "exam"
+      ? "Klausur"
+      : type === "missed-session"
+        ? "Lernsession"
+        : "Abgabe";
 
   return (
     <div className="flex h-full min-h-[calc(100vh-116px)] flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white">
@@ -219,7 +225,7 @@ export function NotificationsPage() {
             <div
               role="tablist"
               aria-label="Filter"
-              className="flex gap-1 rounded-xl bg-gray-100 p-1"
+              className="flex gap-1 overflow-x-auto rounded-xl bg-gray-100 p-1 dark:bg-white/5"
             >
               {filters.map((filter) => {
                 const isActive = activeFilter === filter;
@@ -231,10 +237,10 @@ export function NotificationsPage() {
                     aria-selected={isActive}
                     onClick={() => setActiveFilter(filter)}
                     className={cn(
-                      "flex-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+                      "shrink-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
                       isActive
-                        ? "bg-white text-gray-900 shadow-sm"
-                        : "text-gray-500 hover:text-gray-700",
+                        ? "bg-white text-gray-900 shadow-sm dark:bg-white/10 dark:text-white"
+                        : "text-gray-500 hover:text-gray-700 dark:text-white/65 dark:hover:text-white",
                     )}
                   >
                     {filter}
@@ -265,8 +271,13 @@ export function NotificationsPage() {
                     aria-current={isSelected ? "true" : undefined}
                     onClick={() => setSelectedId(notification.id)}
                     className={cn(
-                      "flex w-full gap-3 border-b border-gray-100 px-4 py-4 text-left transition-colors hover:bg-gray-50",
-                      isSelected && "bg-gray-50",
+                      "flex w-full gap-3 border-b border-gray-100 px-4 py-4 text-left transition-colors hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5",
+                      notification.isUrgent &&
+                        "border-l-4 border-l-[#ef233c] bg-red-50/70 hover:bg-red-50 dark:bg-[#351316] dark:hover:bg-[#43171b]",
+                      isSelected &&
+                        (notification.isUrgent
+                          ? "bg-red-50 dark:bg-[#43171b]"
+                          : "bg-gray-50 dark:bg-white/5"),
                     )}
                   >
                     <div
@@ -281,10 +292,17 @@ export function NotificationsPage() {
                     <div className="min-w-0 flex-1">
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold text-gray-900">
-                            {notification.subject}
-                          </p>
-                          <p className="truncate text-xs text-gray-500">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                              {notification.subject}
+                            </p>
+                            {notification.isUrgent && (
+                              <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold text-red-700 ring-1 ring-red-200 dark:bg-[#ef233c]/20 dark:text-white dark:ring-[#ef233c]/45">
+                                Dringend
+                              </span>
+                            )}
+                          </div>
+                          <p className="truncate text-xs text-gray-500 dark:text-white/65">
                             {notification.course}
                           </p>
                         </div>
@@ -292,7 +310,7 @@ export function NotificationsPage() {
                           <CheckCircle className="h-4 w-4 shrink-0 text-green-600" />
                         )}
                       </div>
-                      <p className="mt-2 truncate text-sm font-semibold text-gray-800">
+                      <p className="mt-2 truncate text-sm font-semibold text-gray-800 dark:text-white/75">
                         Fällig: {formatDate(notification.dueDate)}
                       </p>
                     </div>
@@ -306,7 +324,14 @@ export function NotificationsPage() {
         <section className="flex min-h-0 flex-col bg-gray-50">
           {selectedNotification ? (
             <>
-              <div className="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-4">
+              <div
+                className={cn(
+                  "flex items-center justify-between border-b px-6 py-4",
+                  selectedNotification.isUrgent
+                    ? "border-red-200 bg-red-50 dark:border-[#ef233c]/45 dark:bg-[#2a1114]"
+                    : "border-gray-200 bg-white dark:border-white/10 dark:bg-card",
+                )}
+              >
                 <div className="flex min-w-0 items-center gap-3">
                   <div
                     className={cn(
@@ -317,10 +342,17 @@ export function NotificationsPage() {
                     {getTypeIcon(selectedNotification.type)}
                   </div>
                   <div className="min-w-0">
-                    <h2 className="truncate text-lg font-bold text-gray-900">
-                      {selectedNotification.subject}
-                    </h2>
-                    <p className="truncate text-sm text-gray-500">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <h2 className="truncate text-lg font-bold text-gray-900 dark:text-white">
+                        {selectedNotification.subject}
+                      </h2>
+                      {selectedNotification.isUrgent && (
+                        <span className="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-xs font-semibold text-red-700 ring-1 ring-red-200 dark:bg-[#ef233c]/20 dark:text-white dark:ring-[#ef233c]/45">
+                          Dringend
+                        </span>
+                      )}
+                    </div>
+                    <p className="truncate text-sm text-gray-500 dark:text-white/65">
                       {selectedNotification.course} ·{" "}
                       {getTypeLabel(selectedNotification.type)}
                     </p>
@@ -389,29 +421,36 @@ export function NotificationsPage() {
                     {error}
                   </p>
                 )}
-                <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+                <div
+                  className={cn(
+                    "rounded-lg border bg-white p-6 shadow-sm dark:bg-card",
+                    selectedNotification.isUrgent
+                      ? "border-red-200 dark:border-[#ef233c]/45"
+                      : "border-gray-200 dark:border-white/10",
+                  )}
+                >
                   <div className="space-y-4">
                     <div>
-                      <h3 className="mb-2 text-sm font-semibold text-gray-600">
+                      <h3 className="mb-2 text-sm font-semibold text-gray-600 dark:text-white/75">
                         Beschreibung
                       </h3>
-                      <p className="text-gray-800">
+                      <p className="text-gray-800 dark:text-white">
                         {selectedNotification.description}
                       </p>
                     </div>
 
-                    <div className="border-t border-gray-200 pt-4">
+                    <div className="border-t border-gray-200 pt-4 dark:border-white/15">
                       <div className="grid grid-cols-2 gap-4">
                         <div>
-                          <p className="text-xs font-medium uppercase text-gray-500">
+                          <p className="text-xs font-medium uppercase text-gray-500 dark:text-white/60">
                             Fällig am
                           </p>
-                          <p className="mt-1 text-lg font-bold text-gray-900">
+                          <p className="mt-1 text-lg font-bold text-gray-900 dark:text-white">
                             {formatDate(selectedNotification.dueDate)}
                           </p>
                         </div>
                         <div>
-                          <p className="text-xs font-medium uppercase text-gray-500">
+                          <p className="text-xs font-medium uppercase text-gray-500 dark:text-white/60">
                             Status
                           </p>
                           <p

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -46,6 +46,16 @@ const SELECT_CLASSES =
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024; // 5 MB
 const ALLOWED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp"];
 
+interface NotificationSettingsState {
+  missedSessionRescheduleEnabled: boolean;
+  missedSessionReplanWarningEnabled: boolean;
+}
+
+const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsState = {
+  missedSessionRescheduleEnabled: true,
+  missedSessionReplanWarningEnabled: true,
+};
+
 export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -341,10 +351,96 @@ function ProfileSettings({
 }
 
 function NotificationSettings() {
-  // S-5 Fix: Submit-Handler.
-  function handleNotificationSubmit(event: React.FormEvent<HTMLFormElement>) {
+  const [settings, setSettings] = useState<NotificationSettingsState>(
+    DEFAULT_NOTIFICATION_SETTINGS,
+  );
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSettings() {
+      try {
+        const response = await fetch("/api/settings/notifications", {
+          cache: "no-store",
+        });
+        const data = (await response.json().catch(() => ({}))) as {
+          settings?: NotificationSettingsState;
+          error?: string;
+        };
+
+        if (!response.ok || !data.settings) {
+          throw new Error(data.error ?? "Einstellungen konnten nicht geladen werden.");
+        }
+
+        if (!cancelled) {
+          setSettings(data.settings);
+          setFeedback(null);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setFeedback({
+            type: "error",
+            message:
+              loadError instanceof Error
+                ? loadError.message
+                : "Einstellungen konnten nicht geladen werden.",
+          });
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    loadSettings();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleNotificationSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    // TODO: An /api/settings/notifications anbinden.
+    if (isSaving) return;
+
+    setIsSaving(true);
+    setFeedback(null);
+
+    try {
+      const response = await fetch("/api/settings/notifications", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        settings?: NotificationSettingsState;
+        error?: string;
+      };
+
+      if (!response.ok || !data.settings) {
+        throw new Error(data.error ?? "Einstellungen konnten nicht gespeichert werden.");
+      }
+
+      setSettings(data.settings);
+      setFeedback({
+        type: "success",
+        message: "Benachrichtigungseinstellungen gespeichert.",
+      });
+    } catch (saveError) {
+      setFeedback({
+        type: "error",
+        message:
+          saveError instanceof Error
+            ? saveError.message
+            : "Einstellungen konnten nicht gespeichert werden.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
   }
 
   return (
@@ -357,6 +453,39 @@ function NotificationSettings() {
       </div>
 
       <form className="mt-5 grid gap-5" onSubmit={handleNotificationSubmit}>
+        <SettingsBlock
+          icon={Bell}
+          title="Verpasste Lernsessions"
+          description="Steuert Hinweise, wenn geplante Lerneinheiten abgelaufen und die verknüpften Aufgaben noch offen sind."
+        >
+          <CheckboxField
+            id="missed-session-reschedule"
+            name="missedSessionRescheduleEnabled"
+            label="Bei 1 bis 2 verpassten Sessions einen Hinweis zum Verschieben anzeigen"
+            checked={settings.missedSessionRescheduleEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                missedSessionRescheduleEnabled: checked,
+              }))
+            }
+          />
+          <CheckboxField
+            id="missed-session-replan"
+            name="missedSessionReplanWarningEnabled"
+            label="Ab 3 verpassten Sessions eine Warnung zum Neuplanen anzeigen"
+            checked={settings.missedSessionReplanWarningEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                missedSessionReplanWarningEnabled: checked,
+              }))
+            }
+          />
+        </SettingsBlock>
+
         <SettingsBlock
           icon={CalendarClock}
           title="Deadline-Erinnerungen"
@@ -430,9 +559,19 @@ function NotificationSettings() {
         </SettingsBlock>
 
         <div className="flex justify-end border-t border-gray-100 pt-4">
-          <Button type="submit">
+          {feedback && (
+            <p
+              className={cn(
+                "mr-auto text-sm font-medium",
+                feedback.type === "success" ? "text-green-600" : "text-red-600",
+              )}
+            >
+              {feedback.message}
+            </p>
+          )}
+          <Button type="submit" disabled={isLoading || isSaving}>
             <Save className="h-4 w-4" />
-            Einstellungen speichern
+            {isSaving ? "Wird gespeichert" : "Einstellungen speichern"}
           </Button>
         </div>
       </form>
@@ -565,14 +704,35 @@ interface CheckboxFieldProps {
   id: string;
   label: string;
   name?: string;
+  checked?: boolean;
   defaultChecked?: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
 }
 
-function CheckboxField({ id, label, name, defaultChecked }: CheckboxFieldProps) {
+function CheckboxField({
+  id,
+  label,
+  name,
+  checked,
+  defaultChecked,
+  disabled,
+  onCheckedChange,
+}: CheckboxFieldProps) {
   return (
     <div className="flex items-center gap-3">
-      <Checkbox id={id} name={name} defaultChecked={defaultChecked} />
-      <Label htmlFor={id} className="text-gray-700">
+      <Checkbox
+        id={id}
+        name={name}
+        checked={checked}
+        defaultChecked={defaultChecked}
+        disabled={disabled}
+        onCheckedChange={(nextChecked) => onCheckedChange?.(nextChecked)}
+      />
+      <Label
+        htmlFor={id}
+        className={cn("text-gray-700", disabled && "text-gray-400")}
+      >
         {label}
       </Label>
     </div>

--- a/src/lib/notifications/missedSessions.ts
+++ b/src/lib/notifications/missedSessions.ts
@@ -107,7 +107,7 @@ export async function checkMissedSessionNotifications(
       source: "LOCAL",
       type: "LERNEINHEIT",
       taskId: { not: null },
-      endsAt: { lt: now },
+      endsAt: { lt: now, gte: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000) },
       task: { is: { completed: false } },
     },
     orderBy: { endsAt: "asc" },

--- a/src/lib/notifications/missedSessions.ts
+++ b/src/lib/notifications/missedSessions.ts
@@ -1,0 +1,173 @@
+import type { Prisma } from "@prisma/client";
+import { getNotificationSettings } from "@/lib/notifications/settings";
+import { prisma } from "@/lib/prisma";
+
+const AUTO_NOTIFICATION_EXPIRES_AT = new Date("2099-12-31T23:59:59.000Z");
+const MISSED_SESSION_RESCHEDULE_SUBJECT = "Lernsession verpasst";
+const MISSED_SESSION_REPLAN_SUBJECT = "Lernplan neu planen";
+
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+export interface MissedSessionCheckResult {
+  missedSessionCount: number;
+  createdNotificationCount: number;
+}
+
+type MissedSession = {
+  id: string;
+  title: string;
+  subject: string | null;
+  endsAt: Date;
+  task: {
+    title: string;
+    studyPlan: {
+      title: string;
+      subject: string;
+    };
+  } | null;
+};
+
+function getCourseLabel(session: MissedSession) {
+  return (
+    session.subject?.trim() ||
+    session.task?.studyPlan.subject?.trim() ||
+    session.task?.studyPlan.title?.trim() ||
+    "Lernplan"
+  );
+}
+
+function getSessionLabel(session: MissedSession) {
+  return session.task?.title?.trim() || session.title;
+}
+
+function createRescheduleNotification(
+  ownerId: string,
+  session: MissedSession,
+): Prisma.NotificationCreateManyInput {
+  const sessionLabel = getSessionLabel(session);
+  const course = getCourseLabel(session);
+
+  return {
+    type: "MISSED_SESSION",
+    subject: MISSED_SESSION_RESCHEDULE_SUBJECT,
+    course,
+    dueDate: session.endsAt,
+    description:
+      `Du hast die Lernsession "${sessionLabel}" verpasst. ` +
+      "Verschiebe sie auf einen anderen Tag, damit dein Lernplan realistisch bleibt.",
+    isUrgent: false,
+    ownerId,
+    expiresAt: AUTO_NOTIFICATION_EXPIRES_AT,
+    triggerKey: `missed-session:reschedule:${session.id}`,
+  };
+}
+
+function createReplanNotification(
+  ownerId: string,
+  missedSessions: MissedSession[],
+): Prisma.NotificationCreateManyInput {
+  const firstMissedSession = missedSessions[0];
+  const lastMissedSession = missedSessions[missedSessions.length - 1];
+  const affectedCourses = Array.from(new Set(missedSessions.map(getCourseLabel)));
+  const course =
+    affectedCourses.length === 1
+      ? affectedCourses[0]
+      : `${affectedCourses.length} Lernbereiche`;
+
+  return {
+    type: "MISSED_SESSION",
+    subject: MISSED_SESSION_REPLAN_SUBJECT,
+    course,
+    dueDate: lastMissedSession.endsAt,
+    description:
+      `Du hast ${missedSessions.length} Lernsessions verpasst. ` +
+      `Die älteste offene Session endete am ${DATE_TIME_FORMATTER.format(firstMissedSession.endsAt)}. ` +
+      "Erstelle deinen Lernplan neu, damit die verbleibenden Aufgaben wieder realistisch verteilt sind.",
+    isUrgent: true,
+    ownerId,
+    expiresAt: AUTO_NOTIFICATION_EXPIRES_AT,
+    triggerKey: "missed-session:replan",
+  };
+}
+
+export async function checkMissedSessionNotifications(
+  ownerId: string,
+  now = new Date(),
+): Promise<MissedSessionCheckResult> {
+  const settings = await getNotificationSettings(ownerId);
+  const missedSessions = await prisma.calendarEvent.findMany({
+    where: {
+      ownerId,
+      source: "LOCAL",
+      type: "LERNEINHEIT",
+      taskId: { not: null },
+      endsAt: { lt: now },
+      task: { is: { completed: false } },
+    },
+    orderBy: { endsAt: "asc" },
+    select: {
+      id: true,
+      title: true,
+      subject: true,
+      endsAt: true,
+      task: {
+        select: {
+          title: true,
+          studyPlan: {
+            select: {
+              title: true,
+              subject: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (missedSessions.length === 0) {
+    return { missedSessionCount: 0, createdNotificationCount: 0 };
+  }
+
+  const notifications: Prisma.NotificationCreateManyInput[] = [];
+
+  if (
+    missedSessions.length <= 2 &&
+    settings.missedSessionRescheduleEnabled
+  ) {
+    notifications.push(
+      ...missedSessions.map((missedSession) =>
+        createRescheduleNotification(ownerId, missedSession),
+      ),
+    );
+  }
+
+  if (
+    missedSessions.length >= 3 &&
+    settings.missedSessionReplanWarningEnabled
+  ) {
+    notifications.push(createReplanNotification(ownerId, missedSessions));
+  }
+
+  if (notifications.length === 0) {
+    return {
+      missedSessionCount: missedSessions.length,
+      createdNotificationCount: 0,
+    };
+  }
+
+  const result = await prisma.notification.createMany({
+    data: notifications,
+    skipDuplicates: true,
+  });
+
+  return {
+    missedSessionCount: missedSessions.length,
+    createdNotificationCount: result.count,
+  };
+}

--- a/src/lib/notifications/settings.ts
+++ b/src/lib/notifications/settings.ts
@@ -1,0 +1,55 @@
+import type { NotificationSettings as DbNotificationSettings } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface NotificationSettingsDTO {
+  missedSessionRescheduleEnabled: boolean;
+  missedSessionReplanWarningEnabled: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsDTO = {
+  missedSessionRescheduleEnabled: true,
+  missedSessionReplanWarningEnabled: true,
+};
+
+export function serializeNotificationSettings(
+  settings: Pick<
+    DbNotificationSettings,
+    "missedSessionRescheduleEnabled" | "missedSessionReplanWarningEnabled"
+  >,
+): NotificationSettingsDTO {
+  return {
+    missedSessionRescheduleEnabled: settings.missedSessionRescheduleEnabled,
+    missedSessionReplanWarningEnabled: settings.missedSessionReplanWarningEnabled,
+  };
+}
+
+export async function getNotificationSettings(
+  ownerId: string,
+): Promise<NotificationSettingsDTO> {
+  const settings = await prisma.notificationSettings.upsert({
+    where: { ownerId },
+    update: {},
+    create: {
+      ownerId,
+      ...DEFAULT_NOTIFICATION_SETTINGS,
+    },
+  });
+
+  return serializeNotificationSettings(settings);
+}
+
+export async function updateNotificationSettings(
+  ownerId: string,
+  settings: NotificationSettingsDTO,
+): Promise<NotificationSettingsDTO> {
+  const savedSettings = await prisma.notificationSettings.upsert({
+    where: { ownerId },
+    update: settings,
+    create: {
+      ownerId,
+      ...settings,
+    },
+  });
+
+  return serializeNotificationSettings(savedSettings);
+}

--- a/src/lib/notifications/summary.ts
+++ b/src/lib/notifications/summary.ts
@@ -1,0 +1,33 @@
+import type { NotificationDTO } from "@/lib/notifications/types";
+
+export interface NotificationSummary {
+  openCount: number;
+  urgentCount: number;
+  missedSessionCount: number;
+}
+
+export const EMPTY_NOTIFICATION_SUMMARY: NotificationSummary = {
+  openCount: 0,
+  urgentCount: 0,
+  missedSessionCount: 0,
+};
+
+export function summarizeNotifications(
+  notifications: Pick<
+    NotificationDTO,
+    "type" | "isDone" | "isArchived" | "isUrgent"
+  >[],
+): NotificationSummary {
+  const openNotifications = notifications.filter(
+    (notification) => !notification.isDone && !notification.isArchived,
+  );
+
+  return {
+    openCount: openNotifications.length,
+    urgentCount: openNotifications.filter((notification) => notification.isUrgent)
+      .length,
+    missedSessionCount: openNotifications.filter(
+      (notification) => notification.type === "missed-session",
+    ).length,
+  };
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -3,7 +3,7 @@ import type {
   NotificationType as DbNotificationType,
 } from "@prisma/client";
 
-export type NotificationType = "assignment" | "exam";
+export type NotificationType = "assignment" | "exam" | "missed-session";
 
 export interface NotificationDTO {
   id: string;
@@ -20,17 +20,29 @@ export interface NotificationDTO {
 }
 
 export function toDbNotificationType(type: NotificationType): DbNotificationType {
-  return type === "exam" ? "EXAM" : "ASSIGNMENT";
+  switch (type) {
+    case "exam":
+      return "EXAM";
+    case "missed-session":
+      return "MISSED_SESSION";
+    default:
+      return "ASSIGNMENT";
+  }
 }
 
 export function isNotificationType(value: unknown): value is NotificationType {
-  return value === "assignment" || value === "exam";
+  return value === "assignment" || value === "exam" || value === "missed-session";
 }
 
 export function serializeNotification(notification: DbNotification): NotificationDTO {
   return {
     id: notification.id,
-    type: notification.type === "EXAM" ? "exam" : "assignment",
+    type:
+      notification.type === "EXAM"
+        ? "exam"
+        : notification.type === "MISSED_SESSION"
+          ? "missed-session"
+          : "assignment",
     subject: notification.subject,
     course: notification.course,
     dueDate: notification.dueDate.toISOString(),


### PR DESCRIPTION
## Änderungen

- erkennt verpasste lokale Lernsessions mit offener verknüpfter Aufgabe serverseitig
- erzeugt nutzerspezifische, idempotente Benachrichtigungen für 1-2 verpasste Sessions und dringende Warnungen ab 3 Sessions
- ergänzt persistierte Benachrichtigungseinstellungen für beide Schwellen
- zeigt Lernsessions in der Benachrichtigungsseite inklusive dringender Hervorhebung an
- ergänzt Sidebar-Badge und ein wegklickbares Popup links unten für offene Benachrichtigungen

## Warum

Studierende sollen verpasste Lernsessions direkt sehen und entweder einzelne Sessions verschieben oder ab mehreren verpassten Sessions den Lernplan neu planen können.

## Validierung

- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd test`
- `npx.cmd prisma validate`
- Browserprüfung: Popup bleibt links unten fixed und ist wegklickbar

## Hinweis

`npm.cmd run build` kompiliert, bricht in dieser lokalen Umgebung aber beim Next.js Page-Data-Schritt mit `Cannot find module for page: /_document` beziehungsweise zuvor `/study-plan` ab. Das wirkt unabhängig von den K1-Änderungen.