### PR TITLE
fix: ungültige Events vor Scheduler-Aufruf herausfiltern

### DIFF
--- a/src/components/study-plan/SchedulePreviewModal.tsx
+++ b/src/components/study-plan/SchedulePreviewModal.tsx
@@ -101,6 +101,12 @@ export function SchedulePreviewModal({
           credits: plan.credits as number,
         });
 
+        const validEvents = [...localEvents, ...externalEvents].filter((e) => {
+          const s = e.start.getTime();
+          const en = e.end.getTime();
+          return Number.isFinite(s) && Number.isFinite(en) && en > s;
+        });
+
         const scheduled = scheduleStudyPlan(
           result,
           {
@@ -108,7 +114,7 @@ export function SchedulePreviewModal({
             now: referenceDate,
             subject: plan.subject,
           },
-          [...localEvents, ...externalEvents],
+          validEvents,
         );
         setSchedule(scheduled);
         // Kritische Anmerkungen: zu viel Lernen pro Tag / ein Fach zu oft pro Woche


### PR DESCRIPTION
## Problem

Beim Klick auf „In Kalender eintragen" in der Lernplan-Detailansicht kam der Fehler:

> `existingEvents enthält einen ungültigen Termin.`

## Ursache

Der Scheduler (`scheduleStudyPlan`) prüft alle übergebenen Events auf gültige Datumswerte (`start < end`, kein `NaN`). Externe DHBW-Events aus dem ICS-Feed oder lokale All-Day-Events können jedoch `end <= start` oder ungültige Timestamps haben – was den Fehler auslöste.

## Fix

In `SchedulePreviewModal.tsx` werden alle Events vor dem Scheduler-Aufruf gefiltert:

```ts
const validEvents = [...localEvents, ...externalEvents].filter((e) => {
  const s = e.start.getTime();
  const en = e.end.getTime();
  return Number.isFinite(s) && Number.isFinite(en) && en > s;
});
```

Ungültige Events werden stillschweigend ignoriert – der Scheduler läuft dann ohne Fehler durch.