### PR TITLE
[codex] Persist profile settings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,27 @@
-import type { NextConfig } from 'next'
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  outputFileTracingRoot: process.cwd(),
-}
+  outputFileTracingRoot: path.dirname(fileURLToPath(import.meta.url)),
+  webpack: (config, { dev }) => {
+    if (dev) {
+      config.watchOptions = {
+        ...config.watchOptions,
+        ignored: [
+          "**/.git/**",
+          "**/.next/**",
+          "**/node_modules/**",
+          "C:/DumpStack.log.tmp",
+          "C:/hiberfil.sys",
+          "C:/pagefile.sys",
+          "C:/swapfile.sys",
+        ],
+      };
+    }
 
-export default nextConfig
+    return config;
+  },
+};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,16 +6,23 @@ const nextConfig: NextConfig = {
   outputFileTracingRoot: path.dirname(fileURLToPath(import.meta.url)),
   webpack: (config, { dev }) => {
     if (dev) {
+      const windowsIgnored =
+        process.platform === "win32"
+          ? [
+              "C:/DumpStack.log.tmp",
+              "C:/hiberfil.sys",
+              "C:/pagefile.sys",
+              "C:/swapfile.sys",
+            ]
+          : [];
+
       config.watchOptions = {
         ...config.watchOptions,
         ignored: [
           "**/.git/**",
           "**/.next/**",
           "**/node_modules/**",
-          "C:/DumpStack.log.tmp",
-          "C:/hiberfil.sys",
-          "C:/pagefile.sys",
-          "C:/swapfile.sys",
+          ...windowsIgnored,
         ],
       };
     }

--- a/prisma/migrations/20260618120000_add_user_username/migration.sql
+++ b/prisma/migrations/20260618120000_add_user_username/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "User" ADD COLUMN "username" TEXT;
+
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model User {
   id           String   @id @default(cuid())
   email        String   @unique
   displayName  String
+  username     String?  @unique
   passwordHash String
   role         UserRole @default(USER)
   avatarUrl    String?

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { getSession } from "@/lib/auth/session";
+import { prisma } from "@/lib/prisma";
+
+const profileSchema = z.object({
+  firstName: z
+    .string()
+    .trim()
+    .min(1, "Bitte gib einen Namen an.")
+    .max(40, "Der Name darf höchstens 40 Zeichen lang sein."),
+  lastName: z
+    .string()
+    .trim()
+    .max(40, "Der Nachname darf höchstens 40 Zeichen lang sein.")
+    .optional()
+    .default(""),
+  username: z
+    .string()
+    .trim()
+    .min(1, "Bitte gib einen Username an.")
+    .max(40, "Der Username darf höchstens 40 Zeichen lang sein.")
+    .regex(
+      /^[A-Za-z0-9._-]+$/,
+      "Der Username darf nur Buchstaben, Zahlen, Punkte, Unterstriche und Bindestriche enthalten.",
+    ),
+});
+
+function serializeUser(user: {
+  id: string;
+  email: string;
+  displayName: string;
+  username: string | null;
+  avatarUrl: string | null;
+}) {
+  return {
+    id: user.id,
+    email: user.email,
+    displayName: user.displayName,
+    username: user.username,
+    avatarUrl: user.avatarUrl,
+  };
+}
+
+export async function PUT(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
+  }
+
+  const parsed = profileSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? "Ungültige Eingabe." },
+      { status: 400 },
+    );
+  }
+
+  const { firstName, lastName, username } = parsed.data;
+  const displayName = [firstName, lastName].filter(Boolean).join(" ");
+
+  try {
+    const user = await prisma.user.update({
+      where: { id: session.userId },
+      data: {
+        displayName,
+        username,
+      },
+      select: {
+        id: true,
+        email: true,
+        displayName: true,
+        username: true,
+        avatarUrl: true,
+      },
+    });
+
+    return NextResponse.json({ user: serializeUser(user) });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return NextResponse.json(
+        { error: "Dieser Username ist bereits vergeben." },
+        { status: 409 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -13,7 +13,7 @@ const profileSchema = z.object({
   lastName: z
     .string()
     .trim()
-    .max(40, "Der Nachname darf höchstens 40 Zeichen lang sein.")
+    .max(80, "Der Nachname darf höchstens 80 Zeichen lang sein.")
     .optional()
     .default(""),
   username: z

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -9,7 +9,7 @@ const profileSchema = z.object({
     .string()
     .trim()
     .min(1, "Bitte gib einen Namen an.")
-    .max(40, "Der Name darf höchstens 40 Zeichen lang sein."),
+    .max(80, "Der Name darf höchstens 80 Zeichen lang sein."),
   lastName: z
     .string()
     .trim()

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -72,7 +72,10 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   const firstName = nameParts[0] ?? "";
   const lastName = nameParts.slice(1).join(" ");
   // Username-Fallback: Teil vor dem @
-  const username = currentUser?.username ?? currentUser?.email?.split("@")[0] ?? "";
+  const username =
+    currentUser?.username ??
+    currentUser?.email?.split("@")[0]?.replace(/[^A-Za-z0-9._-]/g, "_") ??
+    "";
 
   const tabParam = searchParams.get("tab");
   // S-2 Fix: Default-Tab ist 'profile'.

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -413,6 +413,8 @@ function ProfileSettings({
           <div className="flex justify-end border-t border-gray-100 pt-4">
             {feedback && (
               <p
+                role={feedback.type === "error" ? "alert" : "status"}
+                aria-live={feedback.type === "error" ? "assertive" : "polite"}
                 className={cn(
                   "mr-auto text-sm font-medium",
                   feedback.type === "success" ? "text-green-600" : "text-red-600",

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -68,11 +68,11 @@ export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // displayName → Vorname / Nachname aufsplitten
-  const nameParts = currentUser?.displayName?.split(" ") ?? [];
+  const nameParts = currentUser?.displayName?.trim().split(/\s+/).filter(Boolean) ?? [];
   const firstName = nameParts[0] ?? "";
   const lastName = nameParts.slice(1).join(" ");
   // Username-Fallback: Teil vor dem @
-  const username = currentUser?.email?.split("@")[0] ?? "";
+  const username = currentUser?.username ?? currentUser?.email?.split("@")[0] ?? "";
 
   const tabParam = searchParams.get("tab");
   // S-2 Fix: Default-Tab ist 'profile'.
@@ -238,15 +238,65 @@ function ProfileSettings({
   username: initialUsername,
   email: initialEmail,
 }: ProfileSettingsProps) {
+  const router = useRouter();
   const [firstName, setFirstName] = useState(initialFirstName);
   const [lastName, setLastName] = useState(initialLastName);
   const [username, setUsername] = useState(initialUsername);
-  const [email, setEmail] = useState(initialEmail);
+  const [isSaving, setIsSaving] = useState(false);
+  const [feedback, setFeedback] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
 
   // S-5 Fix: Submit-Handler verhindert Page-Reload (echte Persistenz folgt mit API).
-  function handleProfileSubmit(event: React.FormEvent<HTMLFormElement>) {
+  useEffect(() => {
+    setFirstName(initialFirstName);
+    setLastName(initialLastName);
+    setUsername(initialUsername);
+  }, [initialFirstName, initialLastName, initialUsername]);
+
+  async function handleProfileSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    // TODO: An /api/profile anbinden, sobald verfügbar.
+    if (isSaving) return;
+
+    setIsSaving(true);
+    setFeedback(null);
+
+    try {
+      const response = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ firstName, lastName, username }),
+      });
+      const data = (await response.json().catch(() => ({}))) as {
+        user?: {
+          displayName: string;
+          username: string | null;
+        };
+        error?: string;
+      };
+
+      if (!response.ok || !data.user) {
+        throw new Error(data.error ?? "Profil konnte nicht gespeichert werden.");
+      }
+
+      const savedNameParts = data.user.displayName.trim().split(/\s+/).filter(Boolean);
+      setFirstName(savedNameParts[0] ?? "");
+      setLastName(savedNameParts.slice(1).join(" "));
+      setUsername(data.user.username ?? "");
+      setFeedback({ type: "success", message: "Profil gespeichert." });
+      router.refresh();
+    } catch (saveError) {
+      setFeedback({
+        type: "error",
+        message:
+          saveError instanceof Error
+            ? saveError.message
+            : "Profil konnte nicht gespeichert werden.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
   }
 
   return (
@@ -298,15 +348,33 @@ function ProfileSettings({
           <div className="grid gap-4 md:grid-cols-2">
             <Field label="Name" htmlFor="first-name">
               {/* S-14 Fix: name-Attribut. Controlled input — kein uncontrolled-Warning. */}
-              <Input id="first-name" name="firstName" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+              <Input
+                id="first-name"
+                name="firstName"
+                value={firstName}
+                disabled={isSaving}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
             </Field>
             <Field label="Nachname" htmlFor="last-name">
-              <Input id="last-name" name="lastName" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+              <Input
+                id="last-name"
+                name="lastName"
+                value={lastName}
+                disabled={isSaving}
+                onChange={(e) => setLastName(e.target.value)}
+              />
             </Field>
           </div>
 
           <Field label="Username" htmlFor="username">
-            <Input id="username" name="username" value={username} onChange={(e) => setUsername(e.target.value)} />
+            <Input
+              id="username"
+              name="username"
+              value={username}
+              disabled={isSaving}
+              onChange={(e) => setUsername(e.target.value)}
+            />
           </Field>
 
           <div className="grid gap-4 md:grid-cols-[1fr_auto] md:items-end">
@@ -315,11 +383,12 @@ function ProfileSettings({
                 id="email"
                 name="email"
                 type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
+                value={initialEmail}
+                readOnly
+                className="cursor-default text-gray-500"
               />
             </Field>
-            <Button type="button" variant="outline" className="md:mb-0">
+            <Button type="button" variant="outline" className="md:mb-0" disabled>
               <Mail className="h-4 w-4" />
               E-Mail ändern
             </Button>
@@ -339,7 +408,17 @@ function ProfileSettings({
           </div>
 
           <div className="flex justify-end border-t border-gray-100 pt-4">
-            <Button type="submit">
+            {feedback && (
+              <p
+                className={cn(
+                  "mr-auto text-sm font-medium",
+                  feedback.type === "success" ? "text-green-600" : "text-red-600",
+                )}
+              >
+                {feedback.message}
+              </p>
+            )}
+            <Button type="submit" disabled={isSaving}>
               <Save className="h-4 w-4" />
               Änderungen speichern
             </Button>

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -14,6 +14,7 @@ export interface CurrentUser {
   id: string;
   email: string;
   displayName: string;
+  username?: string | null;
   role: UserRole;
   avatarUrl?: string | null;
 }
@@ -60,7 +61,14 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
     where: { id: token },
     include: {
       user: {
-        select: { id: true, email: true, displayName: true, role: true, avatarUrl: true },
+        select: {
+          id: true,
+          email: true,
+          displayName: true,
+          username: true,
+          role: true,
+          avatarUrl: true,
+        },
       },
     },
   });


### PR DESCRIPTION
## What changed

- Added a persisted `username` field to `User` with a Prisma migration.
- Added `PUT /api/profile` to save first name, last name, and username for the authenticated user.
- Wired the settings profile form to the new API, including saving state and success/error feedback.
- Kept email read-only in the profile form because email changes are not fully implemented yet.
- Scoped the Next.js dev watcher to the project root and ignored Windows root system files that caused repeated Watchpack errors.

## Why

Profile name and username edits were only stored in local React state, so navigating away and back restored the old database values. The dev server also watched too broadly and tried to stat Windows system files such as `hiberfil.sys`.

## Validation

- `npm.cmd run prisma:generate`
- `npm.cmd run prisma:deploy`
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd test`
- `npm.cmd run dev` reached Ready without the Watchpack root-file errors