### PR TITLE
[codex] Update study plan algorithm factors

### DIFF
--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -14,7 +14,7 @@ Der User muss eine Deadline angeben, an welchem Tag die Klausur ansteht.
 
 2-4Wochen 1.1 Der User muss sich ranhalten
 
-< 2 Wochen 1.2 User hat nicht mehr viel zeit wird geprüft bei kritisch
+< 2 Wochen 1.2 User hat nicht mehr viel Zeit wird geprüft bei kritisch
 
 D = Faktor der Deadline
 

--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -52,9 +52,9 @@ Der User gibt ein Volumen an was er für die Klausur an Wissen erlangen muss. (z
 
 0-50 Seiten = 0.7
 
-50-150 = 1.0
+51-150 = 1.0
 
-150-300 = 1.3
+151-300 = 1.3
 
 \>300 = 1.6
 

--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -12,9 +12,9 @@ Der User muss eine Deadline angeben, an welchem Tag die Klausur ansteht.
 
 1-2 Monate 0.9 Der User hat den idealen Zeitraum
 
-2-4Wochen 1.2 Der User muss sich ranhalten
+2-4Wochen 1.1 Der User muss sich ranhalten
 
-< 2 Wochen 1.5 User hat nicht mehr viel zeit wird geprüft bei kritisch
+< 2 Wochen 1.2 User hat nicht mehr viel zeit wird geprüft bei kritisch
 
 D = Faktor der Deadline
 
@@ -52,11 +52,11 @@ Der User gibt ein Volumen an was er für die Klausur an Wissen erlangen muss. (z
 
 0-50 Seiten = 0.7
 
-50-100 = 1.0
+50-150 = 1.0
 
-100-150 = 1.3
+150-300 = 1.3
 
-\>150 = 1.6
+\>300 = 1.6
 
 Evtl bisschen längeres Grundlagen Fenster da der User viele Seiten behandeln muss.
 

--- a/docs/Algorithmus/Algorithmus_neue_Formel.md
+++ b/docs/Algorithmus/Algorithmus_neue_Formel.md
@@ -52,11 +52,11 @@ Der User gibt ein Volumen an was er für die Klausur an Wissen erlangen muss. (z
 
 0-50 Seiten = 0.7
 
-51-150 = 1.0
+51-150 Seiten = 1.0
 
-151-300 = 1.3
+151-300 Seiten = 1.3
 
-\>300 = 1.6
+\>300 Seiten = 1.6
 
 Evtl bisschen längeres Grundlagen Fenster da der User viele Seiten behandeln muss.
 

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -72,7 +72,7 @@ function getDeadlineFactor(daysUntilDeadline: number): number {
   if (daysUntilDeadline > 60) return 1.1;  // 2–3 Monate
   if (daysUntilDeadline > 30) return 0.9;  // 1–2 Monate
   if (daysUntilDeadline > 14) return 1.1;  // 2–4 Wochen
-  return 1.2;                               // < 2 Wochen
+  return 1.2;                               // ≤ 2 Wochen
 }
 
 function getDifficultyFactor(difficulty: number): number {

--- a/src/lib/calculations/studyPlanAlgorithm.ts
+++ b/src/lib/calculations/studyPlanAlgorithm.ts
@@ -71,8 +71,8 @@ function getDeadlineFactor(daysUntilDeadline: number): number {
   if (daysUntilDeadline > 90) return 1.4;  // > 3 Monate
   if (daysUntilDeadline > 60) return 1.1;  // 2–3 Monate
   if (daysUntilDeadline > 30) return 0.9;  // 1–2 Monate
-  if (daysUntilDeadline > 14) return 1.2;  // 2–4 Wochen
-  return 1.5;                               // < 2 Wochen
+  if (daysUntilDeadline > 14) return 1.1;  // 2–4 Wochen
+  return 1.2;                               // < 2 Wochen
 }
 
 function getDifficultyFactor(difficulty: number): number {
@@ -87,8 +87,8 @@ function getKnowledgeFactor(priorKnowledge: number): number {
 
 function getVolumeFactor(pages: number): number {
   if (pages <= 50) return 0.7;
-  if (pages <= 100) return 1.0;
-  if (pages <= 150) return 1.3;
+  if (pages <= 150) return 1.0;
+  if (pages <= 300) return 1.3;
   return 1.6;
 }
 

--- a/tests/study-plan/learningPlan.test.mjs
+++ b/tests/study-plan/learningPlan.test.mjs
@@ -51,6 +51,31 @@ test("erstellt einen normalen deterministischen Plan über mehrere Wochen", () =
   assert.ok(plannedWeeks.size >= 4);
 });
 
+test("verwendet die aktualisierten Deadline- und Seitenfaktoren", () => {
+  const baseInput = {
+    referenceDate: localDate(2026, 6, 1),
+    deadlineDate: localDate(2026, 6, 22),
+    difficulty: 3,
+    priorKnowledge: 3,
+    pages: 51,
+    credits: 6,
+  };
+
+  assert.equal(calculateStudyPlan(baseInput).deadlineFactor, 1.1);
+  assert.equal(
+    calculateStudyPlan({
+      ...baseInput,
+      deadlineDate: localDate(2026, 6, 11),
+    }).deadlineFactor,
+    1.2,
+  );
+
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 50 }).volumeFactor, 0.7);
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 150 }).volumeFactor, 1.0);
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 300 }).volumeFactor, 1.3);
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 301 }).volumeFactor, 1.6);
+});
+
 test("begrenzt den Plan kontrolliert bei sehr wenig verfügbarer Zeit", () => {
   const referenceDate = localDate(2026, 6, 1, 8);
   const deadlineDate = localDate(2026, 6, 3);

--- a/tests/study-plan/learningPlan.test.mjs
+++ b/tests/study-plan/learningPlan.test.mjs
@@ -63,10 +63,15 @@ test("verwendet die aktualisierten Deadline- und Seitenfaktoren", () => {
 
   assert.equal(calculateStudyPlan(baseInput).deadlineFactor, 1.1);
   assert.equal(
-    calculateStudyPlan({
-      ...baseInput,
-      deadlineDate: localDate(2026, 6, 11),
-    }).deadlineFactor,
+    calculateStudyPlan({ ...baseInput, deadlineDate: localDate(2026, 6, 16) }).deadlineFactor,
+    1.1,
+  );
+  assert.equal(
+    calculateStudyPlan({ ...baseInput, deadlineDate: localDate(2026, 6, 15) }).deadlineFactor,
+    1.2,
+  );
+  assert.equal(
+    calculateStudyPlan({ ...baseInput, deadlineDate: localDate(2026, 6, 11) }).deadlineFactor,
     1.2,
   );
 

--- a/tests/study-plan/learningPlan.test.mjs
+++ b/tests/study-plan/learningPlan.test.mjs
@@ -71,7 +71,9 @@ test("verwendet die aktualisierten Deadline- und Seitenfaktoren", () => {
   );
 
   assert.equal(calculateStudyPlan({ ...baseInput, pages: 50 }).volumeFactor, 0.7);
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 51 }).volumeFactor, 1.0);
   assert.equal(calculateStudyPlan({ ...baseInput, pages: 150 }).volumeFactor, 1.0);
+  assert.equal(calculateStudyPlan({ ...baseInput, pages: 151 }).volumeFactor, 1.3);
   assert.equal(calculateStudyPlan({ ...baseInput, pages: 300 }).volumeFactor, 1.3);
   assert.equal(calculateStudyPlan({ ...baseInput, pages: 301 }).volumeFactor, 1.6);
 });


### PR DESCRIPTION
## Summary

- Adjusts the deadline factors for the study plan algorithm: 2-4 weeks now uses 1.1, and less than 2 weeks now uses 1.2.
- Updates the page volume factors to the requested ranges: 0-50, 50-150, 150-300, and >300 pages.
- Updates the algorithm documentation and adds test coverage for the new factor boundaries.

## Validation

- `npm.cmd test`
- `npm.cmd run typecheck`