### PR TITLE
[codex] Implement dashboard overview and overdue task highlighting

### DIFF
--- a/src/app/(app)/study-plan/page.tsx
+++ b/src/app/(app)/study-plan/page.tsx
@@ -1,14 +1,15 @@
 import { StudyPlanOverview } from "@/components/study-plan/StudyPlanOverview";
 
 interface StudyPlanPageProps {
-  searchParams?: Promise<{
+  searchParams?: {
     create?: string | string[];
-  }>;
+  };
 }
 
-export default async function StudyPlanPage({ searchParams }: StudyPlanPageProps) {
-  const params = await searchParams;
-  const createParam = Array.isArray(params?.create) ? params?.create[0] : params?.create;
+export default function StudyPlanPage({ searchParams }: StudyPlanPageProps) {
+  const createParam = Array.isArray(searchParams?.create)
+    ? searchParams.create[0]
+    : searchParams?.create;
 
   return <StudyPlanOverview initialCreateOpen={createParam === "1"} />;
 }

--- a/src/app/(app)/study-plan/page.tsx
+++ b/src/app/(app)/study-plan/page.tsx
@@ -1,5 +1,14 @@
 import { StudyPlanOverview } from "@/components/study-plan/StudyPlanOverview";
 
-export default function StudyPlanPage() {
-  return <StudyPlanOverview />;
+interface StudyPlanPageProps {
+  searchParams?: Promise<{
+    create?: string | string[];
+  }>;
+}
+
+export default async function StudyPlanPage({ searchParams }: StudyPlanPageProps) {
+  const params = await searchParams;
+  const createParam = Array.isArray(params?.create) ? params?.create[0] : params?.create;
+
+  return <StudyPlanOverview initialCreateOpen={createParam === "1"} />;
 }

--- a/src/app/api/study-plan/route.ts
+++ b/src/app/api/study-plan/route.ts
@@ -34,7 +34,8 @@ export async function GET() {
 
   const studyPlans: StudyPlanSummaryDTO[] = plans.map((p) => {
     const { completedTaskCount } = calculateTaskProgress(p.tasks);
-    const next = p.tasks.find((t) => !t.completed) ?? null;
+    const openTasks = p.tasks.filter((t) => !t.completed);
+    const next = openTasks[0] ?? null;
     return {
       ...serializeStudyPlan(p),
       taskCount: p.tasks.length,
@@ -42,6 +43,11 @@ export async function GET() {
       nextTask: next
         ? { id: next.id, title: next.title, dueDate: next.dueDate.toISOString() }
         : null,
+      openTasks: openTasks.map((task) => ({
+        id: task.id,
+        title: task.title,
+        dueDate: task.dueDate.toISOString(),
+      })),
     };
   });
 

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
+  AlertTriangle,
   BookOpen,
   CalendarClock,
   CalendarDays,
@@ -18,6 +19,7 @@ import {
   isLernsessionEvent,
   type CalEvent,
 } from "@/components/calendar/events";
+import { isOpenTaskOverdue } from "@/lib/study-plan/dueDates";
 import type { StudyPlanSummaryDTO } from "@/lib/study-plan/types";
 import { cn } from "@/lib/utils";
 
@@ -27,6 +29,7 @@ type DashboardTask = {
   id: string;
   title: string;
   dueDate: Date;
+  overdue: boolean;
   studyPlanId: string;
   studyPlanTitle: string;
   subject: string;
@@ -83,7 +86,6 @@ function formatDayTime(d: Date): string {
 function formatTaskDueDate(d: Date, today: Date, tomorrow: Date): string {
   if (isSameDay(d, today)) return "Heute fällig";
   if (isSameDay(d, tomorrow)) return "Morgen fällig";
-  if (d.getTime() < today.getTime()) return `Überfällig seit ${formatDate(d)}`;
   return `Fällig am ${formatDate(d)}`;
 }
 
@@ -175,6 +177,10 @@ export function DashboardContent() {
             id: task.id,
             title: task.title,
             dueDate: new Date(task.dueDate),
+            overdue: isOpenTaskOverdue(
+              { completed: false, dueDate: task.dueDate },
+              today,
+            ),
             studyPlanId: plan.id,
             studyPlanTitle: plan.title,
             subject: plan.subject,
@@ -185,7 +191,7 @@ export function DashboardContent() {
           if (dateDiff !== 0) return dateDiff;
           return a.title.localeCompare(b.title, "de");
         }),
-    [plans],
+    [plans, today],
   );
 
   const visibleOpenTasks = openTasks.slice(0, MAX_DASHBOARD_ITEMS);
@@ -302,13 +308,30 @@ export function DashboardContent() {
                 <Link
                   key={task.id}
                   href={`/study-plan/${task.studyPlanId}`}
-                  className="flex items-center gap-3 rounded-xl border border-gray-200 px-4 py-2.5 transition-colors hover:border-gray-300"
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl border px-4 py-2.5 transition-colors",
+                    task.overdue
+                      ? "border-red-200 bg-red-50/70 hover:border-red-300"
+                      : "border-gray-200 hover:border-gray-300",
+                  )}
                 >
-                  <ClipboardList className="h-4 w-4 shrink-0 text-amber-500" />
+                  {task.overdue ? (
+                    <AlertTriangle className="h-4 w-4 shrink-0 text-red-600" />
+                  ) : (
+                    <ClipboardList className="h-4 w-4 shrink-0 text-amber-500" />
+                  )}
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-gray-900">{task.title}</p>
-                    <p className="truncate text-xs text-gray-500">
-                      {task.subject} · {formatTaskDueDate(task.dueDate, today, tomorrow)}
+                    <p
+                      className={cn(
+                        "truncate text-xs",
+                        task.overdue ? "font-medium text-red-700" : "text-gray-500",
+                      )}
+                    >
+                      {task.subject} ·{" "}
+                      {task.overdue
+                        ? `Überfällig seit ${formatDate(task.dueDate)}`
+                        : formatTaskDueDate(task.dueDate, today, tomorrow)}
                     </p>
                   </div>
                   <ArrowRight className="h-4 w-4 shrink-0 text-gray-400" />

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -3,34 +3,109 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
+  ArrowRight,
   BookOpen,
+  CalendarClock,
   CalendarDays,
   CircleCheckBig,
   ClipboardList,
   Clock,
+  Plus,
 } from "lucide-react";
-import { isLernsessionEvent, type CalEvent } from "@/components/calendar/events";
+import {
+  eventOverlapsDay,
+  expandRecurring,
+  isLernsessionEvent,
+  type CalEvent,
+} from "@/components/calendar/events";
 import type { StudyPlanSummaryDTO } from "@/lib/study-plan/types";
 import { cn } from "@/lib/utils";
 
 type ApiEvent = Omit<CalEvent, "start" | "end"> & { start: string; end: string };
 
+type DashboardTask = {
+  id: string;
+  title: string;
+  dueDate: Date;
+  studyPlanId: string;
+  studyPlanTitle: string;
+  subject: string;
+};
+
+const MAX_DASHBOARD_ITEMS = 5;
+
 function deserialize(events: ApiEvent[]): CalEvent[] {
   return events.map((e) => ({ ...e, start: new Date(e.start), end: new Date(e.end) }));
 }
 
-function startOfWeek(d: Date): Date {
+function startOfDay(d: Date): Date {
   const out = new Date(d);
   out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function addDays(d: Date, days: number): Date {
+  const out = new Date(d);
+  out.setDate(out.getDate() + days);
+  return out;
+}
+
+function startOfWeek(d: Date): Date {
+  const out = startOfDay(d);
   const wd = out.getDay();
   out.setDate(out.getDate() - (wd === 0 ? 6 : wd - 1));
   return out;
 }
 
-function formatDayTime(d: Date): string {
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function formatDate(d: Date): string {
   const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+}
+
+function formatTime(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatDayTime(d: Date): string {
   const weekdays = ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"];
-  return `${weekdays[d.getDay()]}, ${pad(d.getDate())}.${pad(d.getMonth() + 1)}. · ${pad(d.getHours())}:${pad(d.getMinutes())} Uhr`;
+  return `${weekdays[d.getDay()]}, ${formatDate(d)} um ${formatTime(d)} Uhr`;
+}
+
+function formatTaskDueDate(d: Date, today: Date, tomorrow: Date): string {
+  if (isSameDay(d, today)) return "Heute fällig";
+  if (isSameDay(d, tomorrow)) return "Morgen fällig";
+  if (d.getTime() < today.getTime()) return `Überfällig seit ${formatDate(d)}`;
+  return `Fällig am ${formatDate(d)}`;
+}
+
+function formatEventTime(event: CalEvent): string {
+  if (event.allDay) return "Ganztägig";
+  if (isSameDay(event.start, event.end)) {
+    return `${formatTime(event.start)}-${formatTime(event.end)} Uhr`;
+  }
+  return `${formatDayTime(event.start)} bis ${formatDayTime(event.end)}`;
+}
+
+function sortEventsByStart(a: CalEvent, b: CalEvent): number {
+  const timeDiff = a.start.getTime() - b.start.getTime();
+  if (timeDiff !== 0) return timeDiff;
+  return a.title.localeCompare(b.title, "de");
+}
+
+function isActivePlan(plan: StudyPlanSummaryDTO, today: Date): boolean {
+  const openTaskCount = plan.taskCount - plan.completedTaskCount;
+  if (openTaskCount > 0) return true;
+  const targetDate = new Date(plan.targetDate);
+  return plan.taskCount === 0 && startOfDay(targetDate).getTime() >= today.getTime();
 }
 
 export function DashboardContent() {
@@ -42,9 +117,10 @@ export function DashboardContent() {
     let cancelled = false;
     (async () => {
       try {
-        const [planRes, eventRes] = await Promise.all([
+        const [planRes, eventRes, externalEventRes] = await Promise.all([
           fetch("/api/study-plan"),
           fetch("/api/calendar/events"),
+          fetch("/api/calendar/external"),
         ]);
         const planData = planRes.ok
           ? ((await planRes.json()) as { studyPlans?: StudyPlanSummaryDTO[] })
@@ -52,11 +128,17 @@ export function DashboardContent() {
         const eventData = eventRes.ok
           ? ((await eventRes.json()) as { events?: ApiEvent[] })
           : { events: [] };
+        const externalEventData = externalEventRes.ok
+          ? ((await externalEventRes.json()) as { events?: ApiEvent[] })
+          : { events: [] };
         if (cancelled) return;
         setPlans(planData.studyPlans ?? []);
-        setEvents(deserialize(eventData.events ?? []));
+        setEvents([
+          ...deserialize(eventData.events ?? []),
+          ...deserialize(externalEventData.events ?? []),
+        ]);
       } catch {
-        // DB nicht erreichbar → leeres Dashboard
+        // DB oder externer Kalender nicht erreichbar -> leeres Dashboard statt Crash.
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -66,49 +148,89 @@ export function DashboardContent() {
     };
   }, []);
 
+  const now = useMemo(() => new Date(), []);
+  const today = useMemo(() => startOfDay(now), [now]);
+  const tomorrow = useMemo(() => addDays(today, 1), [today]);
+  const afterTomorrow = useMemo(() => addDays(today, 2), [today]);
+  const weekStart = useMemo(() => startOfWeek(now), [now]);
+
   const sessions = useMemo(
     () => events.filter((e) => isLernsessionEvent(e) && e.taskId),
     [events],
   );
 
-  const now = useMemo(() => new Date(), []);
-  const weekStart = useMemo(() => startOfWeek(now), [now]);
-
-  const completedSessions = useMemo(
+  const completedThisWeek = useMemo(
     () =>
-      sessions
-        .filter((e) => e.taskCompleted)
-        .sort((a, b) => b.start.getTime() - a.start.getTime()),
-    [sessions],
+      sessions.filter(
+        (e) => e.taskCompleted && e.start.getTime() >= weekStart.getTime(),
+      ).length,
+    [sessions, weekStart],
   );
-  const completedThisWeek = completedSessions.filter(
-    (e) => e.start.getTime() >= weekStart.getTime(),
-  ).length;
 
-  const upcomingSessions = useMemo(
+  const openTasks = useMemo<DashboardTask[]>(
     () =>
-      sessions
-        .filter((e) => !e.taskCompleted && e.end.getTime() >= now.getTime())
-        .sort((a, b) => a.start.getTime() - b.start.getTime())
-        .slice(0, 5),
-    [sessions, now],
+      plans
+        .flatMap((plan) =>
+          plan.openTasks.map((task) => ({
+            id: task.id,
+            title: task.title,
+            dueDate: new Date(task.dueDate),
+            studyPlanId: plan.id,
+            studyPlanTitle: plan.title,
+            subject: plan.subject,
+          })),
+        )
+        .sort((a, b) => {
+          const dateDiff = a.dueDate.getTime() - b.dueDate.getTime();
+          if (dateDiff !== 0) return dateDiff;
+          return a.title.localeCompare(b.title, "de");
+        }),
+    [plans],
   );
 
-  const openTaskCount = plans.reduce(
-    (sum, p) => sum + (p.taskCount - p.completedTaskCount),
-    0,
+  const visibleOpenTasks = openTasks.slice(0, MAX_DASHBOARD_ITEMS);
+
+  const expandedEvents = useMemo(
+    () => expandRecurring(events, today, afterTomorrow),
+    [events, today, afterTomorrow],
   );
+
+  const todayEvents = useMemo(
+    () =>
+      expandedEvents
+        .filter((event) => eventOverlapsDay(event, today))
+        .sort(sortEventsByStart)
+        .slice(0, MAX_DASHBOARD_ITEMS),
+    [expandedEvents, today],
+  );
+
+  const tomorrowEvents = useMemo(
+    () =>
+      expandedEvents
+        .filter((event) => eventOverlapsDay(event, tomorrow))
+        .sort(sortEventsByStart)
+        .slice(0, MAX_DASHBOARD_ITEMS),
+    [expandedEvents, tomorrow],
+  );
+
+  const activePlans = useMemo(
+    () => plans.filter((plan) => isActivePlan(plan, today)),
+    [plans, today],
+  );
+  const visibleActivePlans = activePlans.slice(0, MAX_DASHBOARD_ITEMS);
+
+  const openTaskCount = openTasks.length;
 
   if (loading) {
     return (
-      <div className="flex flex-col p-6 gap-4">
-        <div className="h-8 w-48 rounded-lg bg-gray-100 animate-pulse" />
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="flex flex-col gap-4 p-6">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-gray-100" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-24 rounded-2xl bg-gray-100 animate-pulse" />
+            <div key={i} className="h-24 animate-pulse rounded-2xl bg-gray-100" />
           ))}
         </div>
-        <div className="h-64 rounded-2xl bg-gray-100 animate-pulse" />
+        <div className="h-64 animate-pulse rounded-2xl bg-gray-100" />
       </div>
     );
   }
@@ -128,18 +250,17 @@ export function DashboardContent() {
     },
     {
       label: "Aktive Lernpläne",
-      value: plans.length,
+      value: activePlans.length,
       icon: BookOpen,
       iconClass: "bg-blue-50 text-blue-600",
     },
   ];
 
   return (
-    <div className="flex flex-col h-full p-6 gap-5 overflow-auto">
+    <div className="flex h-full flex-col gap-5 overflow-auto p-6">
       <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
 
-      {/* Statistiken */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         {stats.map(({ label, value, icon: Icon, iconClass }) => (
           <div
             key={label}
@@ -161,80 +282,97 @@ export function DashboardContent() {
         ))}
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {/* Nächste Lernsessions */}
-        <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-            Nächste Lernsessions
-          </p>
-          {upcomingSessions.length === 0 ? (
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Nächste offene Aufgaben
+            </p>
+            <Link href="/study-plan" className="text-xs font-medium text-brand-red hover:underline">
+              Alle Lernpläne
+            </Link>
+          </div>
+          {visibleOpenTasks.length === 0 ? (
             <p className="text-sm text-gray-500">
-              Keine anstehenden Lernsessions. Plane einen Lernplan in den Kalender ein.
+              Keine offenen Aufgaben. Sobald du Aufgaben anlegst, erscheinen die nächsten hier.
             </p>
           ) : (
             <div className="flex flex-col gap-2">
-              {upcomingSessions.map((e) => (
-                <div
-                  key={e.id}
-                  className="flex items-center gap-3 rounded-xl border border-gray-200 px-4 py-2.5"
+              {visibleOpenTasks.map((task) => (
+                <Link
+                  key={task.id}
+                  href={`/study-plan/${task.studyPlanId}`}
+                  className="flex items-center gap-3 rounded-xl border border-gray-200 px-4 py-2.5 transition-colors hover:border-gray-300"
                 >
-                  <Clock className="h-4 w-4 shrink-0 text-gray-400" />
+                  <ClipboardList className="h-4 w-4 shrink-0 text-amber-500" />
                   <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-gray-900">{e.title}</p>
-                    <p className="text-xs text-gray-500">{formatDayTime(e.start)}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Zuletzt erledigt */}
-        <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-            Zuletzt erledigt
-          </p>
-          {completedSessions.length === 0 ? (
-            <p className="text-sm text-gray-500">
-              Noch keine abgehakten Lernsessions. Erledigte Termine kannst du im Kalender
-              abhaken – sie erscheinen dann hier.
-            </p>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {completedSessions.slice(0, 5).map((e) => (
-                <div
-                  key={e.id}
-                  className="flex items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 px-4 py-2.5"
-                >
-                  <CircleCheckBig className="h-4 w-4 shrink-0 text-green-600" />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-gray-400 line-through">
-                      {e.title}
+                    <p className="truncate text-sm font-medium text-gray-900">{task.title}</p>
+                    <p className="truncate text-xs text-gray-500">
+                      {task.subject} · {formatTaskDueDate(task.dueDate, today, tomorrow)}
                     </p>
-                    <p className="text-xs text-gray-500">{formatDayTime(e.start)}</p>
                   </div>
-                </div>
+                  <ArrowRight className="h-4 w-4 shrink-0 text-gray-400" />
+                </Link>
               ))}
             </div>
           )}
-        </div>
+        </section>
+
+        <section className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Termine heute und morgen
+            </p>
+            <Link href="/calendar" className="text-xs font-medium text-brand-red hover:underline">
+              Kalender öffnen
+            </Link>
+          </div>
+          {todayEvents.length === 0 && tomorrowEvents.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Heute und morgen stehen keine Termine im Kalender.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+              <EventDayList label="Heute" events={todayEvents} emptyText="Keine Termine heute." />
+              <EventDayList
+                label="Morgen"
+                events={tomorrowEvents}
+                emptyText="Keine Termine morgen."
+              />
+            </div>
+          )}
+        </section>
       </div>
 
-      {/* Lernplan-Fortschritt */}
-      <div className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-          Lernpläne
-        </p>
-        {plans.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            Noch keine Lernpläne.{" "}
-            <Link href="/study-plan" className="font-medium text-brand-red hover:underline">
-              Lege deinen ersten Lernplan an.
-            </Link>
+      <section className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Aktive Lernpläne
           </p>
+          {activePlans.length > visibleActivePlans.length && (
+            <Link href="/study-plan" className="text-xs font-medium text-brand-red hover:underline">
+              Alle anzeigen
+            </Link>
+          )}
+        </div>
+        {visibleActivePlans.length === 0 ? (
+          <div className="flex flex-col items-start gap-3">
+            <p className="text-sm text-gray-500">
+              {plans.length === 0
+                ? "Noch keine Lernpläne. Erstelle einen Lernplan, um Aufgaben und Lerntermine zu planen."
+                : "Keine aktiven Lernpläne. Starte einen neuen Plan oder öffne abgeschlossene Pläne in der Lernplanübersicht."}
+            </p>
+            <Link
+              href="/study-plan?create=1"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-red px-4 py-2 text-sm font-bold text-white shadow-sm transition-opacity hover:opacity-90 active:scale-95"
+            >
+              <Plus className="h-4 w-4" />
+              Lernplan erstellen
+            </Link>
+          </div>
         ) : (
           <div className="flex flex-col gap-2">
-            {plans.map((p) => {
+            {visibleActivePlans.map((p) => {
               const progress =
                 p.taskCount > 0
                   ? Math.round((p.completedTaskCount / p.taskCount) * 100)
@@ -247,9 +385,12 @@ export function DashboardContent() {
                 >
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-gray-900">{p.title}</p>
-                    <p className="flex items-center gap-1 text-xs text-gray-500">
-                      <CalendarDays className="h-3.5 w-3.5" />
-                      {p.subject}
+                    <p className="flex items-center gap-1 truncate text-xs text-gray-500">
+                      <CalendarDays className="h-3.5 w-3.5 shrink-0" />
+                      <span className="truncate">
+                        {p.subject}
+                        {p.nextTask ? ` · Nächste Aufgabe: ${p.nextTask.title}` : ""}
+                      </span>
                     </p>
                   </div>
                   <div className="flex w-40 shrink-0 items-center gap-2">
@@ -268,7 +409,49 @@ export function DashboardContent() {
             })}
           </div>
         )}
-      </div>
+      </section>
+    </div>
+  );
+}
+
+function EventDayList({
+  label,
+  events,
+  emptyText,
+}: {
+  label: string;
+  events: CalEvent[];
+  emptyText: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <p className="text-xs font-semibold text-gray-500">{label}</p>
+      {events.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-gray-200 px-3 py-2 text-xs text-gray-500">
+          {emptyText}
+        </p>
+      ) : (
+        events.map((event) => (
+          <Link
+            key={event.id}
+            href="/calendar"
+            className="flex items-center gap-3 rounded-xl border border-gray-200 px-3 py-2 transition-colors hover:border-gray-300"
+          >
+            {event.allDay ? (
+              <CalendarClock className="h-4 w-4 shrink-0 text-blue-500" />
+            ) : (
+              <Clock className="h-4 w-4 shrink-0 text-blue-500" />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-gray-900">{event.title}</p>
+              <p className="truncate text-xs text-gray-500">
+                {formatEventTime(event)}
+                {event.subject ? ` · ${event.subject}` : ""}
+              </p>
+            </div>
+          </Link>
+        ))
+      )}
     </div>
   );
 }

--- a/src/components/study-plan/StudyPlanOverview.tsx
+++ b/src/components/study-plan/StudyPlanOverview.tsx
@@ -7,10 +7,14 @@ import type { StudyPlanSummaryDTO } from "@/lib/study-plan/types";
 import { StudyPlanCard } from "./StudyPlanCard";
 import { StudyPlanForm } from "./StudyPlanForm";
 
-export function StudyPlanOverview() {
+interface StudyPlanOverviewProps {
+  initialCreateOpen?: boolean;
+}
+
+export function StudyPlanOverview({ initialCreateOpen = false }: StudyPlanOverviewProps) {
   const { plans, loading, error, refresh } = useStudyPlans();
 
-  const [formOpen, setFormOpen] = useState(false);
+  const [formOpen, setFormOpen] = useState(initialCreateOpen);
   const [editPlan, setEditPlan] = useState<StudyPlanSummaryDTO | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<StudyPlanSummaryDTO | null>(null);
   const [deleting, setDeleting] = useState(false);

--- a/src/components/study-plan/TaskItem.tsx
+++ b/src/components/study-plan/TaskItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import {
+  AlertTriangle,
   CalendarCheck,
   CalendarDays,
   CalendarPlus,
@@ -11,9 +12,10 @@ import {
   Trash2,
 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
+import { isOpenTaskOverdue } from "@/lib/study-plan/dueDates";
 import { cn } from "@/lib/utils";
 import type { TaskCalendarEventDTO, TaskDTO } from "@/lib/study-plan/types";
-import { daysUntil, formatDate, formatMinutes } from "./planMeta";
+import { formatDate, formatMinutes } from "./planMeta";
 
 interface TaskItemProps {
   planId: string;
@@ -47,7 +49,7 @@ export function TaskItem({
   const [busy, setBusy] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  const overdue = !task.completed && daysUntil(task.dueDate) < 0;
+  const overdue = isOpenTaskOverdue(task);
 
   async function toggleCompleted(checked: boolean) {
     setBusy(true);
@@ -80,8 +82,10 @@ export function TaskItem({
   return (
     <div
       className={cn(
-        "group flex items-start gap-3 rounded-xl border border-gray-200 px-4 py-3 transition-colors",
-        task.completed ? "bg-gray-50" : "bg-white hover:border-gray-300",
+        "group flex items-start gap-3 rounded-xl border px-4 py-3 transition-colors",
+        task.completed && "border-gray-200 bg-gray-50",
+        !task.completed && !overdue && "border-gray-200 bg-white hover:border-gray-300",
+        overdue && "border-red-200 bg-red-50/70 hover:border-red-300",
       )}
     >
       <div className="pt-0.5">
@@ -109,12 +113,20 @@ export function TaskItem({
           <span
             className={cn(
               "inline-flex items-center gap-1",
-              overdue && "text-red-600 font-medium",
+              overdue && "font-medium text-red-700",
             )}
           >
-            <CalendarDays className="w-3.5 h-3.5" />
+            {overdue ? (
+              <AlertTriangle className="w-3.5 h-3.5" />
+            ) : (
+              <CalendarDays className="w-3.5 h-3.5" />
+            )}
             {formatDate(task.dueDate)}
-            {overdue && " · überfällig"}
+            {overdue && (
+              <span className="rounded-full bg-red-100 px-1.5 py-0.5 text-[11px] font-semibold text-red-700">
+                Überfällig
+              </span>
+            )}
           </span>
           <span className="inline-flex items-center gap-1">
             <Clock className="w-3.5 h-3.5" />

--- a/src/lib/study-plan/dueDates.ts
+++ b/src/lib/study-plan/dueDates.ts
@@ -1,0 +1,21 @@
+export function startOfLocalDay(date: Date): Date {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+export function isPastDueDate(
+  dueDate: Date | string,
+  referenceDate: Date = new Date(),
+): boolean {
+  const due = typeof dueDate === "string" ? new Date(dueDate) : dueDate;
+  if (Number.isNaN(due.getTime())) return false;
+  return startOfLocalDay(due).getTime() < startOfLocalDay(referenceDate).getTime();
+}
+
+export function isOpenTaskOverdue(
+  task: { completed: boolean; dueDate: Date | string },
+  referenceDate: Date = new Date(),
+): boolean {
+  return !task.completed && isPastDueDate(task.dueDate, referenceDate);
+}

--- a/src/lib/study-plan/types.ts
+++ b/src/lib/study-plan/types.ts
@@ -57,6 +57,7 @@ export interface StudyPlanSummaryDTO extends StudyPlanDTO {
   taskCount: number;
   completedTaskCount: number;
   nextTask: { id: string; title: string; dueDate: string } | null;
+  openTasks: { id: string; title: string; dueDate: string }[];
 }
 
 /** Detailansicht – mit voller Aufgabenliste. */

--- a/tests/study-plan/dueDates.test.mjs
+++ b/tests/study-plan/dueDates.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isOpenTaskOverdue, isPastDueDate } from "../../src/lib/study-plan/dueDates.ts";
+
+const reference = new Date(2026, 5, 19, 12, 0, 0);
+
+test("erkennt Faelligkeitsdaten vor dem Referenztag als ueberfaellig", () => {
+  assert.equal(isPastDueDate(new Date(2026, 5, 18, 23, 59, 59), reference), true);
+});
+
+test("markiert heutige oder zukuenftige Aufgaben nicht als ueberfaellig", () => {
+  assert.equal(isPastDueDate(new Date(2026, 5, 19, 0, 0, 0), reference), false);
+  assert.equal(isPastDueDate(new Date(2026, 5, 20, 0, 0, 0), reference), false);
+});
+
+test("markiert nur offene Aufgaben als ueberfaellig", () => {
+  assert.equal(
+    isOpenTaskOverdue(
+      { completed: false, dueDate: new Date(2026, 5, 18, 0, 0, 0) },
+      reference,
+    ),
+    true,
+  );
+  assert.equal(
+    isOpenTaskOverdue(
+      { completed: true, dueDate: new Date(2026, 5, 18, 0, 0, 0) },
+      reference,
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

- Replace the dashboard placeholder with real user-scoped overview data for open tasks, today/tomorrow events, and active study plans.
- Add a direct create-study-plan flow from the dashboard empty state via `/study-plan?create=1`.
- Highlight overdue open tasks consistently on the dashboard and in study-plan detail views.
- Add shared overdue-date helpers and unit coverage so completed tasks are never marked overdue.

## Validation

- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd test`