### PR TITLE
[codex] fix sidebar user overflow

### DIFF
--- a/src/app/(app)/study-plan/page.tsx
+++ b/src/app/(app)/study-plan/page.tsx
@@ -1,15 +1,16 @@
 import { StudyPlanOverview } from "@/components/study-plan/StudyPlanOverview";
 
 interface StudyPlanPageProps {
-  searchParams?: {
+  searchParams?: Promise<{
     create?: string | string[];
-  };
+  }>;
 }
 
-export default function StudyPlanPage({ searchParams }: StudyPlanPageProps) {
-  const createParam = Array.isArray(searchParams?.create)
-    ? searchParams.create[0]
-    : searchParams?.create;
+export default async function StudyPlanPage({ searchParams }: StudyPlanPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const createParam = Array.isArray(resolvedSearchParams?.create)
+    ? resolvedSearchParams.create[0]
+    : resolvedSearchParams?.create;
 
   return <StudyPlanOverview initialCreateOpen={createParam === "1"} />;
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -139,7 +139,7 @@ export function Sidebar({ currentUser, notificationSummary }: SidebarProps) {
       {/* User Card – führt zum Profil-Tab in den Einstellungen */}
       <Link
         href="/settings?tab=profile"
-        className="flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-white/10"
+        className="flex min-w-0 items-center gap-3 rounded-lg p-2 transition-colors hover:bg-white/10"
       >
         <div
           className="flex shrink-0 items-center justify-center overflow-hidden rounded-full text-sm font-bold text-white"
@@ -156,9 +156,13 @@ export function Sidebar({ currentUser, notificationSummary }: SidebarProps) {
             getInitials(displayName)
           )}
         </div>
-        <div className="flex flex-col">
-          <span className="text-sm font-semibold text-white">{displayName}</span>
-          <span className="text-xs text-sidebar-foreground/60">{email}</span>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-semibold text-white" title={displayName}>
+            {displayName}
+          </span>
+          <span className="truncate text-xs text-sidebar-foreground/60" title={email}>
+            {email}
+          </span>
         </div>
       </Link>
     </div>


### PR DESCRIPTION
## Summary
- Prevent long user display names and email addresses from overflowing the sidebar footer.
- Add truncation and native hover titles so the full values remain accessible.

## Root cause
The user text container in the sidebar footer did not have a shrinkable width (`min-w-0`/`flex-1`), and the name/email spans were rendered without truncation styles. Long email addresses could therefore be clipped at the sidebar edge.

## Validation
- `cmd /c npm run lint`