### PR TITLE
Benachrichtigungs-Einstellungen anbinden + Passwort-vergessen-Seite

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -186,6 +186,12 @@ Der Setup-Ablauf erzeugt bewusst **keine neue Migration**. Nur wenn du selbst
 `prisma/schema.prisma` aenderst, verwendest du als Entwickler
 `npm run prisma:migrate`, um eine neue Migration anzulegen.
 
+> **Hinweis:** `prisma generate` laeuft seit Kurzem automatisch als
+> `postinstall`-Skript nach jedem `npm ci` / `npm install`. Der explizite
+> Aufruf hier ist nur noch eine Absicherung. Nach einer **Schema-Aenderung oder
+> einem `prisma:deploy`** solltest du ihn aber weiterhin ausfuehren, damit der
+> generierte Client zu den neuen Tabellen/Spalten passt.
+
 ### Schritt 6: Entwicklungs-Server starten
 
 ```bash
@@ -446,10 +452,10 @@ Das geht etwa 3 Minuten und ist die Variante fuer „irgendwas ist kaputt, ich w
 Stand des MVP (Mai/Juni 2026), wichtig zu wissen:
 
 - **Keine Email-Verifizierung beim Registrieren** — jede E-Mail wird akzeptiert, Hauptsache eindeutig.
-- **Keine Passwort-Wiederherstellung** — wer das Passwort vergisst, muss neu registrieren oder direkt in die DB schreiben.
+- **Keine Passwort-Wiederherstellung** — die Seite „Passwort vergessen?" weist transparent darauf hin, dass das Zurücksetzen erst mit der geplanten DHBW-SSO-Anbindung kommt. Aktuell muss man neu registrieren oder direkt in die DB schreiben.
 - **DHBW-Kalender:** Vorlesungen werden ueber den DHBW-ICS-Feed geladen. Der externe Server ist gelegentlich instabil; bei Fehlern erscheint eine Hinweismeldung, die App bleibt nutzbar.
 - **Avatar-Bilder** werden aktuell direkt als Binaerdaten in PostgreSQL gespeichert. Fuer das lokale MVP ist das ausreichend; fuer einen Produktivbetrieb waere ein Objektspeicher sinnvoller.
-- **Profil- und Benachrichtigungseinstellungen** sind teilweise noch Mock-Oberflaechen. Unter anderem sind Namens-/E-Mail-Aenderung, Passwort-Reset und allgemeine Deadline-Erinnerungen noch nicht vollstaendig angebunden.
+- **Profil- und Benachrichtigungseinstellungen:** Name/Username (inkl. Avatar-Upload) und alle Benachrichtigungseinstellungen (verpasste Sessions, Deadline-Erinnerungen mit Vorlauf, tägliche Lernübersicht, Session-Erinnerungen, überfällige Aufgaben) werden persistiert und ausgewertet. Noch nicht angebunden sind ausschliesslich die **E-Mail-Aenderung** und der **Passwort-Reset** (kommen mit der DHBW-SSO-Anbindung).
 - **Lernplaene, Aufgaben, algorithmische Planung und Kalenderuebernahme** sind implementiert. Die Berechnungsfaktoren sind ein transparenter Projektansatz, aber noch nicht lernwissenschaftlich validiert.
 - **Performance auf Windows** ist durch die WSL-Schicht etwas langsamer als auf macOS oder Linux. Fuer die Entwicklung kein Problem.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "learnmanagement-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.4.1",
         "@prisma/client": "^6.19.3",
@@ -19,6 +20,7 @@
         "next": "^15.5.15",
         "node-ical": "^0.20.1",
         "postcss": "^8.5.12",
+        "prisma": "^6.19.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "shadcn": "^4.5.0",
@@ -34,7 +36,6 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "^15.5.15",
-        "prisma": "^6.19.3",
         "typescript": "^5"
       }
     },
@@ -1909,7 +1910,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
       "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -1922,14 +1922,12 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
       "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
       "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1943,14 +1941,12 @@
       "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
       "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
       "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3",
@@ -1962,7 +1958,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
       "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.3"
@@ -2004,7 +1999,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -3532,7 +3526,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -3561,7 +3554,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3668,7 +3660,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -3684,7 +3675,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -3843,14 +3833,12 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -4108,7 +4096,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -4194,7 +4181,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4219,7 +4205,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -4306,7 +4291,6 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
       "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4330,7 +4314,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5132,14 +5115,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -5699,7 +5680,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -7635,7 +7615,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-ical": {
@@ -7688,7 +7667,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
       "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.2",
@@ -7706,7 +7684,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -7843,7 +7820,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/on-finished": {
@@ -8141,14 +8117,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -8182,7 +8156,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.4",
@@ -8282,7 +8255,6 @@
       "version": "6.19.3",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
       "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8374,7 +8346,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8450,7 +8421,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -8493,7 +8463,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9601,7 +9570,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",
-    "setup": "node scripts/setup.mjs"
+    "setup": "node scripts/setup.mjs",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next": "^15.5.15",
     "node-ical": "^0.20.1",
     "postcss": "^8.5.12",
+    "prisma": "^6.19.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "shadcn": "^4.5.0",
@@ -42,7 +43,6 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "^15.5.15",
-    "prisma": "^6.19.3",
     "typescript": "^5"
   }
 }

--- a/prisma/migrations/20260621120000_add_notification_preferences/migration.sql
+++ b/prisma/migrations/20260621120000_add_notification_preferences/migration.sql
@@ -1,0 +1,8 @@
+-- Add deadline, daily digest and session notification preferences.
+ALTER TABLE "NotificationSettings"
+  ADD COLUMN "deadlineRemindersEnabled" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "deadlineLeadMinutes" INTEGER NOT NULL DEFAULT 1440,
+  ADD COLUMN "dailyDigestEnabled" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "digestTime" TEXT NOT NULL DEFAULT '18:00',
+  ADD COLUMN "sessionRemindersEnabled" BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN "overdueTaskRemindersEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,15 @@ model NotificationSettings {
   ownerId                           String   @unique
   missedSessionRescheduleEnabled    Boolean  @default(true)
   missedSessionReplanWarningEnabled Boolean  @default(true)
+  // Deadline-Erinnerungen für Lernplan-Zieltermine und Aufgaben-Fälligkeiten.
+  deadlineRemindersEnabled          Boolean  @default(true)
+  deadlineLeadMinutes               Int      @default(1440) // Vorlauf in Minuten (10/60/1440/4320)
+  // Tägliche Lernübersicht: einmal pro Tag ab der gewählten Uhrzeit.
+  dailyDigestEnabled                Boolean  @default(true)
+  digestTime                        String   @default("18:00") // "HH:MM"
+  // Erinnerungen an heute geplante Lernsessions und überfällige Aufgaben.
+  sessionRemindersEnabled           Boolean  @default(true)
+  overdueTaskRemindersEnabled       Boolean  @default(false)
   createdAt                         DateTime @default(now())
   updatedAt                         DateTime @updatedAt
 

--- a/src/app/api/notifications/check/route.ts
+++ b/src/app/api/notifications/check/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { runNotificationChecks } from "@/lib/notifications/automatic";
+import { prisma } from "@/lib/prisma";
 
 async function handleCheck() {
   const session = await getSession();
@@ -8,16 +9,23 @@ async function handleCheck() {
     return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
   }
 
-  const result = await runNotificationChecks(session.userId);
+  const now = new Date();
+  // Abgelaufene Einträge zuerst entfernen, damit ein abgelaufener Eintrag mit
+  // gleichem triggerKey die Neuerstellung (createMany skipDuplicates) nicht blockiert.
+  await prisma.notification.deleteMany({
+    where: { ownerId: session.userId, expiresAt: { lte: now } },
+  });
+
+  const result = await runNotificationChecks(session.userId, now);
   return NextResponse.json(result);
 }
 
-/** GET /api/notifications/check - verpasste Lernsessions prüfen. */
+/** GET /api/notifications/check - alle automatischen Benachrichtigungen prüfen. */
 export async function GET() {
   return handleCheck();
 }
 
-/** POST /api/notifications/check - verpasste Lernsessions prüfen. */
+/** POST /api/notifications/check - alle automatischen Benachrichtigungen prüfen. */
 export async function POST() {
   return handleCheck();
 }

--- a/src/app/api/notifications/check/route.ts
+++ b/src/app/api/notifications/check/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { checkMissedSessionNotifications } from "@/lib/notifications/missedSessions";
+import { runNotificationChecks } from "@/lib/notifications/automatic";
 
 async function handleCheck() {
   const session = await getSession();
@@ -8,7 +8,7 @@ async function handleCheck() {
     return NextResponse.json({ error: "Nicht angemeldet." }, { status: 401 });
   }
 
-  const result = await checkMissedSessionNotifications(session.userId);
+  const result = await runNotificationChecks(session.userId);
   return NextResponse.json(result);
 }
 

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -18,20 +18,24 @@ export async function GET() {
   }
 
   const now = new Date();
+
+  // Abgelaufene Einträge zuerst entfernen, damit ein abgelaufener Eintrag mit
+  // gleichem triggerKey die Neuerstellung in runNotificationChecks
+  // (createMany skipDuplicates) nicht blockiert – z. B. wenn sich ein Zieldatum
+  // ändert und dieselbe Erinnerung erneut fällig wird.
+  await prisma.notification.deleteMany({
+    where: { ownerId: session.userId, expiresAt: { lte: now } },
+  });
+
   await runNotificationChecks(session.userId, now);
 
-  const [, notifications] = await prisma.$transaction([
-    prisma.notification.deleteMany({
-      where: { ownerId: session.userId, expiresAt: { lte: now } },
-    }),
-    prisma.notification.findMany({
-      where: {
-        ownerId: session.userId,
-        expiresAt: { gt: now },
-      },
-      orderBy: [{ isArchived: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
-    }),
-  ]);
+  const notifications = await prisma.notification.findMany({
+    where: {
+      ownerId: session.userId,
+      expiresAt: { gt: now },
+    },
+    orderBy: [{ isArchived: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
+  });
 
   return NextResponse.json({
     notifications: notifications.map(serializeNotification),

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
-import { checkMissedSessionNotifications } from "@/lib/notifications/missedSessions";
+import { runNotificationChecks } from "@/lib/notifications/automatic";
 import {
   isNotificationType,
   serializeNotification,
@@ -18,7 +18,7 @@ export async function GET() {
   }
 
   const now = new Date();
-  await checkMissedSessionNotifications(session.userId, now);
+  await runNotificationChecks(session.userId, now);
 
   const [, notifications] = await prisma.$transaction([
     prisma.notification.deleteMany({

--- a/src/app/api/settings/notifications/route.ts
+++ b/src/app/api/settings/notifications/route.ts
@@ -2,25 +2,9 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import {
   getNotificationSettings,
+  parseNotificationSettings,
   updateNotificationSettings,
-  type NotificationSettingsDTO,
 } from "@/lib/notifications/settings";
-
-function parseSettingsInput(body: unknown): NotificationSettingsDTO | null {
-  const input = (body ?? {}) as Record<string, unknown>;
-
-  if (
-    typeof input.missedSessionRescheduleEnabled !== "boolean" ||
-    typeof input.missedSessionReplanWarningEnabled !== "boolean"
-  ) {
-    return null;
-  }
-
-  return {
-    missedSessionRescheduleEnabled: input.missedSessionRescheduleEnabled,
-    missedSessionReplanWarningEnabled: input.missedSessionReplanWarningEnabled,
-  };
-}
 
 /** GET /api/settings/notifications - Benachrichtigungseinstellungen laden. */
 export async function GET() {
@@ -47,7 +31,7 @@ export async function PUT(request: Request) {
     return NextResponse.json({ error: "Ungültiger Anfrage-Body." }, { status: 400 });
   }
 
-  const settings = parseSettingsInput(body);
+  const settings = parseNotificationSettings(body);
   if (!settings) {
     return NextResponse.json({ error: "Ungültige Einstellungen." }, { status: 400 });
   }

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,120 @@
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowLeft, KeyRound, ShieldAlert } from "lucide-react";
+import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
+
+export default function ForgotPasswordPage() {
+  return (
+    <div className="flex min-h-screen">
+      <div
+        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
+        style={{
+          backgroundImage:
+            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
+        }}
+      >
+        <svg
+          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <defs>
+            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
+              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
+              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
+              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
+              <circle cx="0" cy="0" r="1.4" fill="white" />
+              <circle cx="80" cy="0" r="1.4" fill="white" />
+              <circle cx="0" cy="80" r="1.4" fill="white" />
+              <circle cx="80" cy="80" r="1.4" fill="white" />
+              <circle cx="40" cy="40" r="2.2" fill="white" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
+        </svg>
+
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
+          }}
+        />
+
+        <div className="relative flex items-center justify-between">
+          <LearnHubBrand
+            markClassName="h-16 w-20"
+            markVariant="white"
+            textClassName="text-5xl"
+            hubClassName="text-[#7a000a] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]"
+          />
+          <Image
+            src="/images/Dhbw_Icon.png"
+            alt="DHBW Logo"
+            width={90}
+            height={90}
+            className="object-contain opacity-90"
+          />
+        </div>
+
+        <div className="relative flex-1 flex items-center">
+          <div className="space-y-6">
+            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
+              Passwort{" "}
+              <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>
+                vergessen
+              </span>
+              ?
+            </p>
+            <p className="text-lg text-white/70 max-w-md">
+              Künftig läuft das Zurücksetzen über deinen zentralen DHBW-Account.
+              Die Anbindung ist aktuell noch in Vorbereitung.
+            </p>
+          </div>
+        </div>
+
+        <div className="relative text-sm text-white/60">
+          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
+        <div className="w-full max-w-md">
+          <div className="mb-8">
+            <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-red/10 text-brand-red">
+              <KeyRound className="h-6 w-6" />
+            </div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              Passwort zurücksetzen
+            </h1>
+            <p className="text-gray-500 text-sm">
+              Diese Funktion ist noch nicht verfügbar.
+            </p>
+          </div>
+
+          <div
+            role="status"
+            className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          >
+            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
+            <p>
+              <span className="font-semibold">
+                Auth-System noch nicht mit DHBW-System verbunden.
+              </span>{" "}
+              Sobald die Anmeldung über das zentrale DHBW-Login (SSO) läuft,
+              erfolgt das Zurücksetzen direkt über deinen DHBW-Account.
+            </p>
+          </div>
+
+          <Link
+            href="/login"
+            className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Zurück zur Anmeldung
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,120 +1,61 @@
 import Link from "next/link";
-import Image from "next/image";
 import { ArrowLeft, KeyRound, ShieldAlert } from "lucide-react";
-import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
+import { AuthSplitLayout } from "@/components/login/AuthSplitLayout";
 
 export default function ForgotPasswordPage() {
   return (
-    <div className="flex min-h-screen">
-      <div
-        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
-        style={{
-          backgroundImage:
-            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
-        }}
-      >
-        <svg
-          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-        >
-          <defs>
-            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
-              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
-              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
-              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
-              <circle cx="0" cy="0" r="1.4" fill="white" />
-              <circle cx="80" cy="0" r="1.4" fill="white" />
-              <circle cx="0" cy="80" r="1.4" fill="white" />
-              <circle cx="80" cy="80" r="1.4" fill="white" />
-              <circle cx="40" cy="40" r="2.2" fill="white" />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
-        </svg>
+    <AuthSplitLayout
+      headline={
+        <>
+          Passwort{" "}
+          <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>
+            vergessen
+          </span>
+          ?
+        </>
+      }
+      subtitle={
+        <>
+          Künftig läuft das Zurücksetzen über deinen zentralen DHBW-Account.
+          Die Anbindung ist aktuell noch in Vorbereitung.
+        </>
+      }
+    >
+      <div className="w-full max-w-md">
+        <div className="mb-8">
+          <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-red/10 text-brand-red">
+            <KeyRound className="h-6 w-6" />
+          </div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            Passwort zurücksetzen
+          </h1>
+          <p className="text-gray-500 text-sm">
+            Diese Funktion ist noch nicht verfügbar.
+          </p>
+        </div>
 
         <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
-          }}
-        />
-
-        <div className="relative flex items-center justify-between">
-          <LearnHubBrand
-            markClassName="h-16 w-20"
-            markVariant="white"
-            textClassName="text-5xl"
-            hubClassName="text-[#7a000a] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]"
-          />
-          <Image
-            src="/images/Dhbw_Icon.png"
-            alt="DHBW Logo"
-            width={90}
-            height={90}
-            className="object-contain opacity-90"
-          />
+          role="status"
+          className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
+          <p>
+            <span className="font-semibold">
+              Auth-System noch nicht mit DHBW-System verbunden.
+            </span>{" "}
+            Sobald die Anmeldung über das zentrale DHBW-Login (SSO) läuft,
+            erfolgt das Zurücksetzen direkt über deinen DHBW-Account.
+          </p>
         </div>
 
-        <div className="relative flex-1 flex items-center">
-          <div className="space-y-6">
-            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
-              Passwort{" "}
-              <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>
-                vergessen
-              </span>
-              ?
-            </p>
-            <p className="text-lg text-white/70 max-w-md">
-              Künftig läuft das Zurücksetzen über deinen zentralen DHBW-Account.
-              Die Anbindung ist aktuell noch in Vorbereitung.
-            </p>
-          </div>
-        </div>
-
-        <div className="relative text-sm text-white/60">
-          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
-        </div>
+        <Link
+          href="/login"
+          className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Zurück zur Anmeldung
+        </Link>
       </div>
-
-      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
-        <div className="w-full max-w-md">
-          <div className="mb-8">
-            <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-xl bg-brand-red/10 text-brand-red">
-              <KeyRound className="h-6 w-6" />
-            </div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              Passwort zurücksetzen
-            </h1>
-            <p className="text-gray-500 text-sm">
-              Diese Funktion ist noch nicht verfügbar.
-            </p>
-          </div>
-
-          <div
-            role="status"
-            className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
-          >
-            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0" />
-            <p>
-              <span className="font-semibold">
-                Auth-System noch nicht mit DHBW-System verbunden.
-              </span>{" "}
-              Sobald die Anmeldung über das zentrale DHBW-Login (SSO) läuft,
-              erfolgt das Zurücksetzen direkt über deinen DHBW-Account.
-            </p>
-          </div>
-
-          <Link
-            href="/login"
-            className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Zurück zur Anmeldung
-          </Link>
-        </div>
-      </div>
-    </div>
+    </AuthSplitLayout>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,89 +1,31 @@
 import { Suspense } from "react";
 import { LoginForm } from "@/components/login/LoginForm";
-import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
-import Image from "next/image";
+import { AuthSplitLayout } from "@/components/login/AuthSplitLayout";
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen">
-      <div
-        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
-        style={{
-          backgroundImage:
-            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
-        }}
-      >
-        <svg
-          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-        >
-          <defs>
-            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
-              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
-              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
-              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
-              <circle cx="0" cy="0" r="1.4" fill="white" />
-              <circle cx="80" cy="0" r="1.4" fill="white" />
-              <circle cx="0" cy="80" r="1.4" fill="white" />
-              <circle cx="80" cy="80" r="1.4" fill="white" />
-              <circle cx="40" cy="40" r="2.2" fill="white" />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
-        </svg>
-
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
-          }}
-        />
-
-        {/* Header: Titel links + Icon rechts */}
-        <div className="relative flex items-center justify-between">
-          <LearnHubBrand
-            markClassName="h-16 w-20"
-            markVariant="white"
-            textClassName="text-5xl"
-            hubClassName="text-[#7a000a] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]"
-          />
-          <Image
-            src="/images/Dhbw_Icon.png"
-            alt="DHBW Logo"
-            width={90}
-            height={90}
-            className="object-contain opacity-90"
-          />
-        </div>
-
-        {/* Mitte: vertikal zentrierter Willkommenstext */}
-        <div className="relative flex-1 flex items-center">
-          <div className="space-y-6">
-            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
-              Weil <span className="italic">Zettelchaos</span>
-              <br />
-              keine <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>Karriere</span> macht.
-            </p>
-            <p className="text-lg text-white/70 max-w-md">
-              Plane deine Klausuren, generiere personalisierte Lernpläne und
-              verfolge deinen Fortschritt – alles an einem Ort.
-            </p>
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div className="relative text-sm text-white/60">
-          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
-        </div>
-      </div>
-
-      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
-        <Suspense fallback={null}>
-          <LoginForm />
-        </Suspense>
-      </div>
-    </div>
+    <AuthSplitLayout
+      headline={
+        <>
+          Weil <span className="italic">Zettelchaos</span>
+          <br />
+          keine{" "}
+          <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>
+            Karriere
+          </span>{" "}
+          macht.
+        </>
+      }
+      subtitle={
+        <>
+          Plane deine Klausuren, generiere personalisierte Lernpläne und
+          verfolge deinen Fortschritt – alles an einem Ort.
+        </>
+      }
+    >
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
+    </AuthSplitLayout>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,83 +1,28 @@
 import { RegisterForm } from "@/components/register/RegisterForm";
-import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
-import Image from "next/image";
+import { AuthSplitLayout } from "@/components/login/AuthSplitLayout";
 
 export default function RegisterPage() {
   return (
-    <div className="flex min-h-screen">
-      <div
-        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
-        style={{
-          backgroundImage:
-            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
-        }}
-      >
-        <svg
-          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
-          xmlns="http://www.w3.org/2000/svg"
-          aria-hidden="true"
-        >
-          <defs>
-            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
-              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
-              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
-              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
-              <circle cx="0" cy="0" r="1.4" fill="white" />
-              <circle cx="80" cy="0" r="1.4" fill="white" />
-              <circle cx="0" cy="80" r="1.4" fill="white" />
-              <circle cx="80" cy="80" r="1.4" fill="white" />
-              <circle cx="40" cy="40" r="2.2" fill="white" />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
-        </svg>
-
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            backgroundImage:
-              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
-          }}
-        />
-
-        <div className="relative flex items-center justify-between">
-          <LearnHubBrand
-            markClassName="h-16 w-20"
-            markVariant="white"
-            textClassName="text-5xl"
-            hubClassName="text-[#7a000a] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]"
-          />
-          <Image
-            src="/images/Dhbw_Icon.png"
-            alt="DHBW Logo"
-            width={90}
-            height={90}
-            className="object-contain opacity-90"
-          />
-        </div>
-
-        <div className="relative flex-1 flex items-center">
-          <div className="space-y-6">
-            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
-              Starte deinen <span className="italic">strukturierten</span>
-              <br />
-              Weg zum <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>Lernerfolg</span>.
-            </p>
-            <p className="text-lg text-white/70 max-w-md">
-              Lege dir in wenigen Sekunden ein Konto an und plane deine
-              Klausuren, Lerninhalte und Termine an einem Ort.
-            </p>
-          </div>
-        </div>
-
-        <div className="relative text-sm text-white/60">
-          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
-        </div>
-      </div>
-
-      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
-        <RegisterForm />
-      </div>
-    </div>
+    <AuthSplitLayout
+      headline={
+        <>
+          Starte deinen <span className="italic">strukturierten</span>
+          <br />
+          Weg zum{" "}
+          <span style={{ color: "#7a000a", filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.4))" }}>
+            Lernerfolg
+          </span>
+          .
+        </>
+      }
+      subtitle={
+        <>
+          Lege dir in wenigen Sekunden ein Konto an und plane deine
+          Klausuren, Lerninhalte und Termine an einem Ort.
+        </>
+      }
+    >
+      <RegisterForm />
+    </AuthSplitLayout>
   );
 }

--- a/src/components/login/AuthSplitLayout.tsx
+++ b/src/components/login/AuthSplitLayout.tsx
@@ -1,0 +1,98 @@
+import Image from "next/image";
+import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
+
+interface AuthSplitLayoutProps {
+  /** Große Überschrift im linken Marken-Panel. */
+  headline: React.ReactNode;
+  /** Erklärender Untertitel unter der Überschrift. */
+  subtitle: React.ReactNode;
+  /** Inhalt der rechten Spalte (Formular bzw. Hinweis). */
+  children: React.ReactNode;
+}
+
+/**
+ * Geteiltes Split-Screen-Layout der Auth-Seiten (Login, Registrieren,
+ * Passwort vergessen): links das rote Marken-Panel mit Blueprint-Grid,
+ * rechts der seitenspezifische Inhalt. Vermeidet dreifach dupliziertes Markup.
+ */
+export function AuthSplitLayout({
+  headline,
+  subtitle,
+  children,
+}: AuthSplitLayoutProps) {
+  return (
+    <div className="flex min-h-screen">
+      <div
+        className="hidden lg:flex lg:w-1/2 text-white flex-col pt-2 pb-2 px-6 relative overflow-hidden"
+        style={{
+          backgroundImage:
+            "radial-gradient(at 20% 20%, color-mix(in srgb, var(--color-brand-red-light) 35%, transparent) 0%, transparent 55%), radial-gradient(at 80% 80%, var(--color-brand-red-dark) 0%, transparent 55%), linear-gradient(135deg, var(--color-brand-red) 0%, var(--color-brand-red-dark) 100%)",
+        }}
+      >
+        <svg
+          className="absolute inset-0 w-full h-full opacity-[0.18] pointer-events-none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          <defs>
+            <pattern id="blueprint-grid" width="80" height="80" patternUnits="userSpaceOnUse">
+              <path d="M 80 0 L 0 0 0 80" fill="none" stroke="white" strokeWidth="0.6" />
+              <path d="M 0 0 L 80 80 M 80 0 L 0 80" fill="none" stroke="white" strokeWidth="0.4" />
+              <path d="M 40 0 L 40 80 M 0 40 L 80 40" fill="none" stroke="white" strokeWidth="0.4" />
+              <circle cx="0" cy="0" r="1.4" fill="white" />
+              <circle cx="80" cy="0" r="1.4" fill="white" />
+              <circle cx="0" cy="80" r="1.4" fill="white" />
+              <circle cx="80" cy="80" r="1.4" fill="white" />
+              <circle cx="40" cy="40" r="2.2" fill="white" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
+        </svg>
+
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 30% 30%, rgba(255,255,255,0.10) 0%, transparent 40%), radial-gradient(circle at 100% 100%, rgba(0,0,0,0.35) 0%, transparent 60%)",
+          }}
+        />
+
+        {/* Header: Titel links + DHBW-Logo rechts */}
+        <div className="relative flex items-center justify-between">
+          <LearnHubBrand
+            markClassName="h-16 w-20"
+            markVariant="white"
+            textClassName="text-5xl"
+            hubClassName="text-[#7a000a] drop-shadow-[0_1px_2px_rgba(0,0,0,0.4)]"
+          />
+          <Image
+            src="/images/Dhbw_Icon.png"
+            alt="DHBW Logo"
+            width={90}
+            height={90}
+            className="object-contain opacity-90"
+          />
+        </div>
+
+        {/* Mitte: vertikal zentrierter Text */}
+        <div className="relative flex-1 flex items-center">
+          <div className="space-y-6">
+            <p className="text-5xl xl:text-6xl font-extrabold leading-[1.1] tracking-tight max-w-xl">
+              {headline}
+            </p>
+            <p className="text-lg text-white/70 max-w-md">{subtitle}</p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="relative text-sm text-white/60">
+          © {new Date().getFullYear()} LearnHub. Alle Rechte vorbehalten.
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -700,7 +700,7 @@ function NotificationSettings() {
             onCheckedChange={(checked) =>
               setSettings((previous) => ({
                 ...previous,
-                overdueTaskRemindersEnabled: checked,
+                overdueTaskRemindersEnabled: checked === true,
               }))
             }
           />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -36,7 +36,12 @@ const settingsCategories: SettingsCategory[] = [
   { id: "calendar", label: "Kalender", icon: CalendarDays },
 ];
 
-const reminderOptions = ["10 Minuten vorher", "1 Stunde vorher", "1 Tag vorher", "3 Tage vorher"];
+const reminderOptions: { label: string; minutes: number }[] = [
+  { label: "10 Minuten vorher", minutes: 10 },
+  { label: "1 Stunde vorher", minutes: 60 },
+  { label: "1 Tag vorher", minutes: 1440 },
+  { label: "3 Tage vorher", minutes: 4320 },
+];
 const digestTimes = ["07:00", "12:00", "18:00", "20:00"];
 
 // S-15 Fix: Wiederverwendbarer Tailwind-String für native <select>-Elemente.
@@ -49,11 +54,23 @@ const ALLOWED_AVATAR_TYPES = ["image/png", "image/jpeg", "image/webp"];
 interface NotificationSettingsState {
   missedSessionRescheduleEnabled: boolean;
   missedSessionReplanWarningEnabled: boolean;
+  deadlineRemindersEnabled: boolean;
+  deadlineLeadMinutes: number;
+  dailyDigestEnabled: boolean;
+  digestTime: string;
+  sessionRemindersEnabled: boolean;
+  overdueTaskRemindersEnabled: boolean;
 }
 
 const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsState = {
   missedSessionRescheduleEnabled: true,
   missedSessionReplanWarningEnabled: true,
+  deadlineRemindersEnabled: true,
+  deadlineLeadMinutes: 1440,
+  dailyDigestEnabled: true,
+  digestTime: "18:00",
+  sessionRemindersEnabled: true,
+  overdueTaskRemindersEnabled: false,
 };
 
 export function SettingsPage({ currentUser }: { currentUser?: CurrentUser }) {
@@ -404,7 +421,11 @@ function ProfileSettings({
                 Sende einen Link zum Zurücksetzen deines Passworts.
               </p>
             </div>
-            <Button type="button" variant="outline">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => router.push("/forgot-password")}
+            >
               <KeyRound className="h-4 w-4" />
               Passwort zurücksetzen
             </Button>
@@ -579,18 +600,32 @@ function NotificationSettings() {
             id="deadline-reminders"
             name="deadlineReminders"
             label="Deadline-Erinnerungen aktivieren"
-            defaultChecked
+            checked={settings.deadlineRemindersEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                deadlineRemindersEnabled: checked,
+              }))
+            }
           />
           <Field label="Erinnerungsvorlauf" htmlFor="deadline-lead-time">
             <select
               id="deadline-lead-time"
               name="deadlineLeadTime"
-              defaultValue="1 Tag vorher"
+              value={settings.deadlineLeadMinutes}
+              disabled={isLoading || isSaving || !settings.deadlineRemindersEnabled}
+              onChange={(event) =>
+                setSettings((previous) => ({
+                  ...previous,
+                  deadlineLeadMinutes: Number(event.target.value),
+                }))
+              }
               className={SELECT_CLASSES}
             >
               {reminderOptions.map((option) => (
-                <option key={option} value={option}>
-                  {option}
+                <option key={option.minutes} value={option.minutes}>
+                  {option.label}
                 </option>
               ))}
             </select>
@@ -606,13 +641,27 @@ function NotificationSettings() {
             id="daily-digest"
             name="dailyDigest"
             label="Tägliche Lernübersicht aktivieren"
-            defaultChecked
+            checked={settings.dailyDigestEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                dailyDigestEnabled: checked,
+              }))
+            }
           />
           <Field label="Uhrzeit" htmlFor="digest-time">
             <select
               id="digest-time"
               name="digestTime"
-              defaultValue="18:00"
+              value={settings.digestTime}
+              disabled={isLoading || isSaving || !settings.dailyDigestEnabled}
+              onChange={(event) =>
+                setSettings((previous) => ({
+                  ...previous,
+                  digestTime: event.target.value,
+                }))
+              }
               className={SELECT_CLASSES}
             >
               {digestTimes.map((time) => (
@@ -633,12 +682,27 @@ function NotificationSettings() {
             id="session-reminders"
             name="sessionReminders"
             label="Erinnerungen für geplante Lernsessions"
-            defaultChecked
+            checked={settings.sessionRemindersEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                sessionRemindersEnabled: checked,
+              }))
+            }
           />
           <CheckboxField
             id="overdue-tasks"
             name="overdueTasks"
             label="Überfällige Aufgaben zusätzlich hervorheben"
+            checked={settings.overdueTaskRemindersEnabled}
+            disabled={isLoading || isSaving}
+            onCheckedChange={(checked) =>
+              setSettings((previous) => ({
+                ...previous,
+                overdueTaskRemindersEnabled: checked,
+              }))
+            }
           />
         </SettingsBlock>
 

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -687,7 +687,7 @@ function NotificationSettings() {
             onCheckedChange={(checked) =>
               setSettings((previous) => ({
                 ...previous,
-                sessionRemindersEnabled: checked,
+                sessionRemindersEnabled: checked === true,
               }))
             }
           />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -646,7 +646,7 @@ function NotificationSettings() {
             onCheckedChange={(checked) =>
               setSettings((previous) => ({
                 ...previous,
-                dailyDigestEnabled: checked,
+                dailyDigestEnabled: checked === true,
               }))
             }
           />

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -605,7 +605,7 @@ function NotificationSettings() {
             onCheckedChange={(checked) =>
               setSettings((previous) => ({
                 ...previous,
-                deadlineRemindersEnabled: checked,
+                deadlineRemindersEnabled: checked === true,
               }))
             }
           />

--- a/src/lib/notifications/automatic.ts
+++ b/src/lib/notifications/automatic.ts
@@ -50,11 +50,90 @@ async function createNotifications(
   notifications: Prisma.NotificationCreateManyInput[],
 ): Promise<number> {
   if (notifications.length === 0) return 0;
-  const result = await prisma.notification.createMany({
-    data: notifications,
-    skipDuplicates: true,
+
+  const notificationsWithTriggerKey = notifications.filter(
+    (
+      notification,
+    ): notification is Prisma.NotificationCreateManyInput & { triggerKey: string } =>
+      typeof notification.triggerKey === "string" && notification.triggerKey.length > 0,
+  );
+  const notificationsWithoutTriggerKey = notifications.filter(
+    (notification) =>
+      typeof notification.triggerKey !== "string" || notification.triggerKey.length === 0,
+  );
+
+  let createdCount = 0;
+
+  await prisma.$transaction(async (tx) => {
+    if (notificationsWithTriggerKey.length > 0) {
+      const existingNotifications = await tx.notification.findMany({
+        where: {
+          OR: notificationsWithTriggerKey.map((notification) => ({
+            ownerId: notification.ownerId,
+            triggerKey: notification.triggerKey,
+          })),
+        },
+        select: { ownerId: true, triggerKey: true },
+      });
+
+      const existingKeys = new Set(
+        existingNotifications.map(
+          (notification) => `${notification.ownerId}:${notification.triggerKey ?? ""}`,
+        ),
+      );
+
+      const toCreate: Prisma.NotificationCreateManyInput[] = [];
+      const toUpdate: Array<Prisma.NotificationCreateManyInput & { triggerKey: string }> = [];
+
+      for (const notification of notificationsWithTriggerKey) {
+        const dedupeKey = `${notification.ownerId}:${notification.triggerKey}`;
+        if (existingKeys.has(dedupeKey)) {
+          toUpdate.push(notification);
+        } else {
+          toCreate.push(notification);
+        }
+      }
+
+      if (toCreate.length > 0) {
+        const result = await tx.notification.createMany({
+          data: toCreate,
+          skipDuplicates: true,
+        });
+        createdCount += result.count;
+      }
+
+      await Promise.all(
+        toUpdate.map((notification) =>
+          tx.notification.update({
+            where: {
+              ownerId_triggerKey: {
+                ownerId: notification.ownerId,
+                triggerKey: notification.triggerKey,
+              },
+            },
+            data: {
+              type: notification.type,
+              subject: notification.subject,
+              course: notification.course,
+              dueDate: notification.dueDate,
+              description: notification.description,
+              isUrgent: notification.isUrgent,
+              expiresAt: notification.expiresAt,
+            },
+          }),
+        ),
+      );
+    }
+
+    if (notificationsWithoutTriggerKey.length > 0) {
+      const result = await tx.notification.createMany({
+        data: notificationsWithoutTriggerKey,
+      });
+      createdCount += result.count;
+    }
   });
-  return result.count;
+
+  return createdCount;
 }
 
 // ─── Deadline-Erinnerungen ──────────────────────────────────────────────────

--- a/src/lib/notifications/automatic.ts
+++ b/src/lib/notifications/automatic.ts
@@ -1,0 +1,329 @@
+import type { Prisma } from "@prisma/client";
+import { checkMissedSessionNotifications } from "@/lib/notifications/missedSessions";
+import {
+  getNotificationSettings,
+  type NotificationSettingsDTO,
+} from "@/lib/notifications/settings";
+import { prisma } from "@/lib/prisma";
+
+// Automatisch erzeugte Benachrichtigungen folgen alle demselben Muster wie die
+// verpassten Lernsessions (siehe missedSessions.ts): Beim Laden der Notifications
+// werden relevante Daten geprüft und – über einen eindeutigen triggerKey
+// dedupliziert – neue Hinweise per createMany(skipDuplicates) angelegt.
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+const TIME_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function endOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+function startOfNextDay(date: Date): Date {
+  const d = startOfDay(date);
+  d.setDate(d.getDate() + 1);
+  return d;
+}
+
+function dateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+    date.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+async function createNotifications(
+  notifications: Prisma.NotificationCreateManyInput[],
+): Promise<number> {
+  if (notifications.length === 0) return 0;
+  const result = await prisma.notification.createMany({
+    data: notifications,
+    skipDuplicates: true,
+  });
+  return result.count;
+}
+
+// ─── Deadline-Erinnerungen ──────────────────────────────────────────────────
+
+/** Zieltermine (Lernpläne) und Aufgaben-Fälligkeiten im Vorlauf-Fenster. */
+export async function checkDeadlineNotifications(
+  ownerId: string,
+  now: Date,
+  settings: NotificationSettingsDTO,
+): Promise<number> {
+  if (!settings.deadlineRemindersEnabled) return 0;
+
+  const windowEnd = new Date(now.getTime() + settings.deadlineLeadMinutes * 60 * 1000);
+  const urgentThreshold = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+  const [plans, tasks] = await Promise.all([
+    prisma.studyPlan.findMany({
+      where: { ownerId, targetDate: { gte: now, lte: windowEnd } },
+      select: { id: true, subject: true, goalType: true, targetDate: true },
+    }),
+    prisma.task.findMany({
+      where: {
+        completed: false,
+        dueDate: { gte: now, lte: windowEnd },
+        studyPlan: { ownerId },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        studyPlan: { select: { subject: true } },
+      },
+    }),
+  ]);
+
+  const notifications: Prisma.NotificationCreateManyInput[] = [];
+
+  for (const plan of plans) {
+    const isExam = plan.goalType === "KLAUSUR" || plan.goalType === "PRAESENTATION";
+    notifications.push({
+      type: isExam ? "EXAM" : "ASSIGNMENT",
+      subject: "Zieltermin steht an",
+      course: plan.subject,
+      dueDate: plan.targetDate,
+      description: `Dein Zieltermin für "${plan.subject}" ist am ${DATE_FORMATTER.format(
+        plan.targetDate,
+      )}.`,
+      isUrgent: plan.targetDate <= urgentThreshold,
+      ownerId,
+      expiresAt: endOfDay(plan.targetDate),
+      triggerKey: `deadline:plan:${plan.id}`,
+    });
+  }
+
+  for (const task of tasks) {
+    notifications.push({
+      type: "ASSIGNMENT",
+      subject: "Aufgabe fällig",
+      course: task.studyPlan.subject,
+      dueDate: task.dueDate,
+      description: `Die Aufgabe "${task.title}" ist am ${DATE_FORMATTER.format(
+        task.dueDate,
+      )} fällig.`,
+      isUrgent: task.dueDate <= urgentThreshold,
+      ownerId,
+      expiresAt: endOfDay(task.dueDate),
+      triggerKey: `deadline:task:${task.id}`,
+    });
+  }
+
+  return createNotifications(notifications);
+}
+
+// ─── Überfällige Aufgaben ────────────────────────────────────────────────────
+
+export async function checkOverdueTaskNotifications(
+  ownerId: string,
+  now: Date,
+  settings: NotificationSettingsDTO,
+): Promise<number> {
+  if (!settings.overdueTaskRemindersEnabled) return 0;
+
+  // Nur kürzlich überfällige Aufgaben (max. 30 Tage), damit keine uralten
+  // Aufgaben dauerhaft Hinweise erzeugen.
+  const oldestRelevant = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  const tasks = await prisma.task.findMany({
+    where: {
+      completed: false,
+      dueDate: { lt: now, gte: oldestRelevant },
+      studyPlan: { ownerId },
+    },
+    select: {
+      id: true,
+      title: true,
+      dueDate: true,
+      studyPlan: { select: { subject: true } },
+    },
+  });
+
+  const notifications: Prisma.NotificationCreateManyInput[] = tasks.map((task) => ({
+    type: "ASSIGNMENT",
+    subject: "Aufgabe überfällig",
+    course: task.studyPlan.subject,
+    dueDate: task.dueDate,
+    description: `Die Aufgabe "${task.title}" war am ${DATE_FORMATTER.format(
+      task.dueDate,
+    )} fällig und ist noch offen.`,
+    isUrgent: true,
+    ownerId,
+    // Hinweis bleibt zwei Wochen nach Fälligkeit bestehen, danach läuft er ab.
+    expiresAt: new Date(task.dueDate.getTime() + 14 * 24 * 60 * 60 * 1000),
+    triggerKey: `overdue:task:${task.id}`,
+  }));
+
+  return createNotifications(notifications);
+}
+
+// ─── Bevorstehende Lernsessions (heute) ──────────────────────────────────────
+
+export async function checkUpcomingSessionNotifications(
+  ownerId: string,
+  now: Date,
+  settings: NotificationSettingsDTO,
+): Promise<number> {
+  if (!settings.sessionRemindersEnabled) return 0;
+
+  const events = await prisma.calendarEvent.findMany({
+    where: {
+      ownerId,
+      source: "LOCAL",
+      type: "LERNEINHEIT",
+      startsAt: { gt: now, lte: endOfDay(now) },
+    },
+    select: {
+      id: true,
+      title: true,
+      subject: true,
+      startsAt: true,
+      studyPlan: { select: { subject: true } },
+    },
+  });
+
+  const notifications: Prisma.NotificationCreateManyInput[] = events.map((event) => ({
+    type: "ASSIGNMENT",
+    subject: "Lernsession heute",
+    course: event.subject?.trim() || event.studyPlan?.subject?.trim() || "Lernsession",
+    dueDate: event.startsAt,
+    description: `Heute um ${TIME_FORMATTER.format(event.startsAt)} Uhr ist "${
+      event.title
+    }" geplant.`,
+    isUrgent: false,
+    ownerId,
+    expiresAt: endOfDay(now),
+    triggerKey: `session-upcoming:${event.id}`,
+  }));
+
+  return createNotifications(notifications);
+}
+
+// ─── Tägliche Lernübersicht ──────────────────────────────────────────────────
+
+function isPastDigestTime(now: Date, digestTime: string): boolean {
+  const [hours, minutes] = digestTime.split(":").map((part) => Number(part));
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return false;
+  const threshold = startOfDay(now);
+  threshold.setHours(hours, minutes, 0, 0);
+  return now >= threshold;
+}
+
+export async function checkDailyDigestNotification(
+  ownerId: string,
+  now: Date,
+  settings: NotificationSettingsDTO,
+): Promise<number> {
+  if (!settings.dailyDigestEnabled) return 0;
+  if (!isPastDigestTime(now, settings.digestTime)) return 0;
+
+  const todayStart = startOfDay(now);
+  const todayEnd = endOfDay(now);
+  const weekEnd = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const [todaysSessions, openTasks, upcomingPlanDeadlines, upcomingTaskDeadlines] =
+    await Promise.all([
+      prisma.calendarEvent.count({
+        where: {
+          ownerId,
+          source: "LOCAL",
+          type: "LERNEINHEIT",
+          startsAt: { gte: todayStart, lte: todayEnd },
+        },
+      }),
+      prisma.task.count({
+        where: { completed: false, studyPlan: { ownerId } },
+      }),
+      prisma.studyPlan.count({
+        where: { ownerId, targetDate: { gte: now, lte: weekEnd } },
+      }),
+      prisma.task.count({
+        where: {
+          completed: false,
+          dueDate: { gte: now, lte: weekEnd },
+          studyPlan: { ownerId },
+        },
+      }),
+    ]);
+
+  const upcomingDeadlines = upcomingPlanDeadlines + upcomingTaskDeadlines;
+
+  // Nichts Berichtenswertes → keine leere Übersicht erzeugen.
+  if (todaysSessions === 0 && openTasks === 0 && upcomingDeadlines === 0) {
+    return 0;
+  }
+
+  const description =
+    `${todaysSessions} Lernsession${todaysSessions === 1 ? "" : "s"} heute, ` +
+    `${openTasks} offene Aufgabe${openTasks === 1 ? "" : "n"}, ` +
+    `${upcomingDeadlines} Frist${upcomingDeadlines === 1 ? "" : "en"} in den nächsten 7 Tagen.`;
+
+  return createNotifications([
+    {
+      type: "ASSIGNMENT",
+      subject: "Tägliche Lernübersicht",
+      course: "Übersicht",
+      dueDate: now,
+      description,
+      isUrgent: false,
+      ownerId,
+      expiresAt: startOfNextDay(now),
+      triggerKey: `daily-digest:${dateKey(now)}`,
+    },
+  ]);
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────────────────
+
+export interface NotificationCheckResult {
+  createdNotificationCount: number;
+}
+
+/**
+ * Führt alle aktivierten automatischen Benachrichtigungs-Checks aus.
+ * Jeder Check ist isoliert: schlägt einer fehl, brechen die übrigen (und damit
+ * die Notifications-Seite) nicht ab.
+ */
+export async function runNotificationChecks(
+  ownerId: string,
+  now = new Date(),
+): Promise<NotificationCheckResult> {
+  const settings = await getNotificationSettings(ownerId);
+  let createdNotificationCount = 0;
+
+  const checks: Array<() => Promise<number>> = [
+    async () =>
+      (await checkMissedSessionNotifications(ownerId, now, settings))
+        .createdNotificationCount,
+    () => checkDeadlineNotifications(ownerId, now, settings),
+    () => checkOverdueTaskNotifications(ownerId, now, settings),
+    () => checkUpcomingSessionNotifications(ownerId, now, settings),
+    () => checkDailyDigestNotification(ownerId, now, settings),
+  ];
+
+  for (const check of checks) {
+    try {
+      createdNotificationCount += await check();
+    } catch (error) {
+      console.error("[notifications] Check fehlgeschlagen:", error);
+    }
+  }
+
+  return { createdNotificationCount };
+}

--- a/src/lib/notifications/missedSessions.ts
+++ b/src/lib/notifications/missedSessions.ts
@@ -1,5 +1,8 @@
 import type { Prisma } from "@prisma/client";
-import { getNotificationSettings } from "@/lib/notifications/settings";
+import {
+  getNotificationSettings,
+  type NotificationSettingsDTO,
+} from "@/lib/notifications/settings";
 import { prisma } from "@/lib/prisma";
 
 const AUTO_NOTIFICATION_EXPIRES_AT = new Date("2099-12-31T23:59:59.000Z");
@@ -99,8 +102,9 @@ function createReplanNotification(
 export async function checkMissedSessionNotifications(
   ownerId: string,
   now = new Date(),
+  providedSettings?: NotificationSettingsDTO,
 ): Promise<MissedSessionCheckResult> {
-  const settings = await getNotificationSettings(ownerId);
+  const settings = providedSettings ?? (await getNotificationSettings(ownerId));
   const missedSessions = await prisma.calendarEvent.findMany({
     where: {
       ownerId,

--- a/src/lib/notifications/settings.ts
+++ b/src/lib/notifications/settings.ts
@@ -4,22 +4,98 @@ import { prisma } from "@/lib/prisma";
 export interface NotificationSettingsDTO {
   missedSessionRescheduleEnabled: boolean;
   missedSessionReplanWarningEnabled: boolean;
+  deadlineRemindersEnabled: boolean;
+  deadlineLeadMinutes: number;
+  dailyDigestEnabled: boolean;
+  digestTime: string;
+  sessionRemindersEnabled: boolean;
+  overdueTaskRemindersEnabled: boolean;
 }
 
 export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettingsDTO = {
   missedSessionRescheduleEnabled: true,
   missedSessionReplanWarningEnabled: true,
+  deadlineRemindersEnabled: true,
+  deadlineLeadMinutes: 1440,
+  dailyDigestEnabled: true,
+  digestTime: "18:00",
+  sessionRemindersEnabled: true,
+  overdueTaskRemindersEnabled: false,
 };
 
+/** Erlaubte Vorlaufzeiten (Minuten) für Deadline-Erinnerungen. */
+export const DEADLINE_LEAD_MINUTE_OPTIONS = [10, 60, 1440, 4320] as const;
+
+/** Erlaubte Uhrzeiten für die tägliche Lernübersicht. */
+export const DIGEST_TIME_OPTIONS = ["07:00", "12:00", "18:00", "20:00"] as const;
+
 export function serializeNotificationSettings(
-  settings: Pick<
-    DbNotificationSettings,
-    "missedSessionRescheduleEnabled" | "missedSessionReplanWarningEnabled"
-  >,
+  settings: DbNotificationSettings,
 ): NotificationSettingsDTO {
   return {
     missedSessionRescheduleEnabled: settings.missedSessionRescheduleEnabled,
     missedSessionReplanWarningEnabled: settings.missedSessionReplanWarningEnabled,
+    deadlineRemindersEnabled: settings.deadlineRemindersEnabled,
+    deadlineLeadMinutes: settings.deadlineLeadMinutes,
+    dailyDigestEnabled: settings.dailyDigestEnabled,
+    digestTime: settings.digestTime,
+    sessionRemindersEnabled: settings.sessionRemindersEnabled,
+    overdueTaskRemindersEnabled: settings.overdueTaskRemindersEnabled,
+  };
+}
+
+/**
+ * Validiert einen rohen Request-Body und gibt eine vollständige, normalisierte
+ * DTO zurück – oder null, wenn die Eingabe ungültig ist. Unbekannte Werte für
+ * Vorlauf/Uhrzeit werden abgelehnt, damit nur erlaubte Optionen gespeichert werden.
+ */
+export function parseNotificationSettings(
+  body: unknown,
+): NotificationSettingsDTO | null {
+  if (typeof body !== "object" || body === null) return null;
+  const input = body as Record<string, unknown>;
+
+  const booleanKeys = [
+    "missedSessionRescheduleEnabled",
+    "missedSessionReplanWarningEnabled",
+    "deadlineRemindersEnabled",
+    "dailyDigestEnabled",
+    "sessionRemindersEnabled",
+    "overdueTaskRemindersEnabled",
+  ] as const;
+
+  for (const key of booleanKeys) {
+    if (typeof input[key] !== "boolean") return null;
+  }
+
+  if (
+    typeof input.deadlineLeadMinutes !== "number" ||
+    !DEADLINE_LEAD_MINUTE_OPTIONS.includes(
+      input.deadlineLeadMinutes as (typeof DEADLINE_LEAD_MINUTE_OPTIONS)[number],
+    )
+  ) {
+    return null;
+  }
+
+  if (
+    typeof input.digestTime !== "string" ||
+    !DIGEST_TIME_OPTIONS.includes(
+      input.digestTime as (typeof DIGEST_TIME_OPTIONS)[number],
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    missedSessionRescheduleEnabled: input.missedSessionRescheduleEnabled as boolean,
+    missedSessionReplanWarningEnabled:
+      input.missedSessionReplanWarningEnabled as boolean,
+    deadlineRemindersEnabled: input.deadlineRemindersEnabled as boolean,
+    deadlineLeadMinutes: input.deadlineLeadMinutes,
+    dailyDigestEnabled: input.dailyDigestEnabled as boolean,
+    digestTime: input.digestTime,
+    sessionRemindersEnabled: input.sessionRemindersEnabled as boolean,
+    overdueTaskRemindersEnabled: input.overdueTaskRemindersEnabled as boolean,
   };
 }
 


### PR DESCRIPTION
## Überblick

Folgearbeiten aus dem QA-Review. Behebt drei sichtbare Schwachstellen und härtet das Setup ab.

## Änderungen

### Passwort-vergessen / -zurücksetzen (vorher tote Einstiegspunkte)
- Neue Seite `/forgot-password` im Login-Layout (linkes Marken-Panel), rechts der transparente Hinweis **„Auth-System noch nicht mit DHBW-System verbunden."**
- „Passwort vergessen?"-Link (Login) führt jetzt dorthin statt ins 404.
- „Passwort zurücksetzen"-Button (Einstellungen → Profil) bekam einen Handler und navigiert dorthin (vorher: kein `onClick`, nichts passierte).

### Benachrichtigungs-Einstellungen funktionieren wirklich
Vorher wurde nur „Verpasste Lernsessions" gespeichert, der Rest war totes UI. Jetzt **persistiert und ausgewertet**:
- **Deadline-Erinnerungen** (+ Vorlauf 10min/1h/1Tag/3Tage) → Hinweise für Zieltermine & Aufgaben-Fälligkeiten
- **Tägliche Lernübersicht** (+ Uhrzeit) → einmal pro Tag eine Zusammenfassung
- **Session-Erinnerungen** → heute anstehende Lerneinheiten
- **Überfällige Aufgaben** → offene, überfällige Aufgaben

Umsetzung nach dem bestehenden `on-read + triggerKey`-Muster in `src/lib/notifications/automatic.ts`, jeder Generator per try/catch isoliert (ein Fehler kann die Notifications-Seite nie brechen). Dazu Schema + Migration für die neuen `NotificationSettings`-Felder und serverseitige Validierung der erlaubten Vorlauf-/Uhrzeit-Werte.

### Setup-Härtung
- `postinstall: "prisma generate"` → Client wird nach `npm ci`/`npm install` automatisch generiert (kein Typecheck-/Build-Fehler mehr nach frischem Checkout).
- `SETUP.md`: veraltete „Bekannte Einschränkungen" aktualisiert + Hinweis zu `postinstall`.

## Migration
`20260621120000_add_notification_preferences` ergänzt `NotificationSettings` um 6 Felder (mit Defaults). Nach dem Merge: `npm run prisma:deploy` (+ `prisma:generate` läuft via postinstall).

## Test
- `typecheck` ✓, `lint` ✓, `test` 17/17 ✓, `build` ✓ (28 Seiten)
- End-to-End-Smoke-Test gegen die DB: Register → Settings laden (8 Felder) → speichern (persistiert) → ungültige Eingabe = 400 → `/api/notifications` = 200 (Generatoren laufen fehlerfrei)

🤖 Generated with [Claude Code](https://claude.com/claude-code)