### PR TITLE
Admin-Analytics-Dashboard hinzufügen

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { AdminDashboard } from "@/components/admin/AdminDashboard";
+import { getAdminAnalyticsPayload } from "@/lib/admin/analytics";
 import { getAdminUsersPayload } from "@/lib/admin/users";
 import {
   canManageFeedbackRole,
@@ -18,13 +19,15 @@ export default async function AdminPage() {
     redirect("/dashboard");
   }
 
-  const [initialUsersData, initialFeedbackData] = await Promise.all([
+  const [initialUsersData, initialFeedbackData, initialAnalyticsData] = await Promise.all([
     currentUser.role === "ADMIN" ? getAdminUsersPayload() : Promise.resolve(null),
     getFeedbackPayload(),
+    currentUser.role === "ADMIN" ? getAdminAnalyticsPayload() : Promise.resolve(null),
   ]);
 
   return (
     <AdminDashboard
+      initialAnalyticsData={initialAnalyticsData}
       initialUsersData={initialUsersData}
       initialFeedbackData={initialFeedbackData}
       currentUserId={currentUser.id}

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getAdminAnalyticsPayload } from "@/lib/admin/analytics";
+import { getAdminAuth } from "@/lib/auth/admin";
+
+function unauthorized(status: "unauthenticated" | "forbidden") {
+  return NextResponse.json(
+    {
+      error:
+        status === "unauthenticated" ? "Nicht angemeldet." : "Keine Admin-Berechtigung.",
+    },
+    { status: status === "unauthenticated" ? 401 : 403 },
+  );
+}
+
+export async function GET() {
+  const auth = await getAdminAuth();
+  if (auth.status !== "ok") {
+    return unauthorized(auth.status);
+  }
+
+  return NextResponse.json(await getAdminAnalyticsPayload());
+}

--- a/src/components/admin/AdminAnalytics.tsx
+++ b/src/components/admin/AdminAnalytics.tsx
@@ -327,7 +327,14 @@ function ProgressRow({ label, value }: ProgressRowProps) {
         <span className="font-medium text-gray-700">{label}</span>
         <span className="font-bold text-gray-950">{value} %</span>
       </div>
-      <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+      <div
+        className="h-2 overflow-hidden rounded-full bg-gray-100"
+        role="progressbar"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
         <div className="h-full rounded-full bg-gray-950" style={{ width: `${value}%` }} />
       </div>
     </div>

--- a/src/components/admin/AdminAnalytics.tsx
+++ b/src/components/admin/AdminAnalytics.tsx
@@ -355,7 +355,14 @@ function BucketList({ buckets, compact = false }: BucketListProps) {
             <span className="font-medium text-gray-700">{bucket.label}</span>
             <span className="font-bold text-gray-950">{formatNumber(bucket.count)}</span>
           </div>
-          <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+          <div
+            className="h-2 overflow-hidden rounded-full bg-gray-100"
+            role="progressbar"
+            aria-label={bucket.label}
+            aria-valuenow={bucket.percentage}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
             <div
               className="h-full rounded-full bg-gray-950"
               style={{ width: `${bucket.percentage}%` }}

--- a/src/components/admin/AdminAnalytics.tsx
+++ b/src/components/admin/AdminAnalytics.tsx
@@ -6,13 +6,11 @@ import {
   BarChart3,
   CalendarClock,
   CheckCircle2,
-  Clock3,
   ListChecks,
   RefreshCw,
   ShieldCheck,
   Target,
   UserCheck,
-  UserPlus,
   Users,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/admin/AdminAnalytics.tsx
+++ b/src/components/admin/AdminAnalytics.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  BarChart3,
+  CalendarClock,
+  CheckCircle2,
+  Clock3,
+  ListChecks,
+  RefreshCw,
+  ShieldCheck,
+  Target,
+  UserCheck,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { AdminAnalyticsPayload, AnalyticsBucket } from "@/lib/admin/analytics";
+import { cn } from "@/lib/utils";
+
+interface AdminAnalyticsProps {
+  initialData: AdminAnalyticsPayload;
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function formatNumber(value: number) {
+  return new Intl.NumberFormat("de-DE").format(value);
+}
+
+function formatHours(value: number) {
+  return `${new Intl.NumberFormat("de-DE", {
+    maximumFractionDigits: 1,
+  }).format(value)} h`;
+}
+
+export function AdminAnalytics({ initialData }: AdminAnalyticsProps) {
+  const [data, setData] = useState(initialData);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(
+    null,
+  );
+
+  const studyPlanAdoptionRate = useMemo(() => {
+    if (data.users.total === 0) {
+      return 0;
+    }
+    return Math.round((data.users.usersWithStudyPlans / data.users.total) * 100);
+  }, [data.users.total, data.users.usersWithStudyPlans]);
+
+  async function reloadAnalytics() {
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      const response = await fetch("/api/admin/analytics");
+      const nextData = (await response.json().catch(() => null)) as
+        | (AdminAnalyticsPayload & { error?: string })
+        | null;
+
+      if (!response.ok || !nextData) {
+        throw new Error(nextData?.error ?? "Analysen konnten nicht geladen werden.");
+      }
+
+      setData(nextData);
+      setMessage({ type: "success", text: "Analysen wurden aktualisiert." });
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Analysen konnten nicht geladen werden.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <div className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-start">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-700">
+              <BarChart3 className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-base font-semibold text-gray-950">Aggregierte Analysen</h2>
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-gray-500">
+                Diese Ansicht zeigt nur zusammengefasste Nutzungs- und Fortschrittsdaten. Sie
+                dient der Produktbewertung, nicht der Kontrolle einzelner Studierender.
+              </p>
+              <p className="mt-2 text-xs font-medium text-gray-400">
+                Aktualisiert: {formatDateTime(data.generatedAt)}
+              </p>
+            </div>
+          </div>
+          <Button type="button" variant="outline" onClick={reloadAnalytics} disabled={loading}>
+            <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
+            Aktualisieren
+          </Button>
+        </div>
+      </section>
+
+      {message && (
+        <p
+          role="status"
+          className={cn(
+            "rounded-lg border px-4 py-3 text-sm font-medium",
+            message.type === "success"
+              ? "border-green-200 bg-green-50 text-green-700"
+              : "border-red-200 bg-red-50 text-red-700",
+          )}
+        >
+          {message.text}
+        </p>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          icon={Users}
+          label="Registrierte Nutzer"
+          value={formatNumber(data.users.total)}
+          detail={`+${formatNumber(data.users.newLast30Days)} in 30 Tagen`}
+          tone="gray"
+        />
+        <MetricCard
+          icon={UserCheck}
+          label="Aktive Sessions"
+          value={formatNumber(data.users.activeSessionUsers)}
+          detail={`${formatNumber(data.users.signedInLast30Days)} Nutzer mit Login in 30 Tagen`}
+          tone="blue"
+        />
+        <MetricCard
+          icon={Target}
+          label="Lernplan-Nutzung"
+          value={`${studyPlanAdoptionRate} %`}
+          detail={`${formatNumber(data.users.usersWithStudyPlans)} Nutzer mit Lernplänen`}
+          tone="green"
+        />
+        <MetricCard
+          icon={CalendarClock}
+          label="Kalenderquellen"
+          value={`${data.calendar.sourceAdoptionRate} %`}
+          detail={`${formatNumber(data.calendar.calendarSources)} gespeicherte Quellen`}
+          tone="amber"
+        />
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-2">
+        <AnalyticsSection
+          title="Lernplanung"
+          description="Aufgabenfortschritt und Planungsstand über alle Nutzer hinweg."
+          icon={ListChecks}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <MiniMetric label="Lernpläne gesamt" value={formatNumber(data.learning.studyPlans)} />
+            <MiniMetric label="Aktive Lernpläne" value={formatNumber(data.learning.activeStudyPlans)} />
+            <MiniMetric label="Aufgaben gesamt" value={formatNumber(data.learning.tasks)} />
+            <MiniMetric label="Offene Aufgaben" value={formatNumber(data.learning.openTasks)} />
+            <MiniMetric label="Überfällige Aufgaben" value={formatNumber(data.learning.overdueTasks)} />
+            <MiniMetric label="Geschätzte Lernzeit" value={formatHours(data.learning.plannedHours)} />
+          </div>
+          <ProgressRow label="Aufgaben abgeschlossen" value={data.learning.completionRate} />
+          <ProgressRow
+            label="Durchschnittlicher Lernplanfortschritt"
+            value={data.learning.averagePlanProgress}
+          />
+        </AnalyticsSection>
+
+        <AnalyticsSection
+          title="Kalender und Erinnerungen"
+          description="Wie stark Planung, Termine und Benachrichtigungen genutzt werden."
+          icon={CalendarClock}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <MiniMetric label="Kalendereinträge" value={formatNumber(data.calendar.events)} />
+            <MiniMetric label="Lerneinheiten" value={formatNumber(data.calendar.learningEvents)} />
+            <MiniMetric label="Externe Termine" value={formatNumber(data.calendar.externalEvents)} />
+            <MiniMetric
+              label="Nutzer mit Kalenderquelle"
+              value={formatNumber(data.users.usersWithCalendarSources)}
+            />
+            <MiniMetric label="Offene Hinweise" value={formatNumber(data.notifications.open)} />
+            <MiniMetric
+              label="Verpasste Lerneinheiten"
+              value={formatNumber(data.notifications.missedSessionOpen)}
+            />
+          </div>
+          <ProgressRow label="DHBW-/ICS-Adoption" value={data.calendar.sourceAdoptionRate} />
+          <ProgressRow label="Nutzer mit Lernplan" value={studyPlanAdoptionRate} />
+        </AnalyticsSection>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-2">
+        <AnalyticsSection
+          title="Feedback-Auswertung"
+          description="Status und Themen der eingereichten Rückmeldungen."
+          icon={CheckCircle2}
+        >
+          <div className="grid gap-3 sm:grid-cols-4">
+            <MiniMetric label="Gesamt" value={formatNumber(data.feedback.total)} />
+            <MiniMetric label="Offen" value={formatNumber(data.feedback.open)} />
+            <MiniMetric label="Kritisch" value={formatNumber(data.feedback.critical)} />
+            <MiniMetric label="Umgesetzt" value={formatNumber(data.feedback.done)} />
+          </div>
+          <BucketList buckets={data.feedback.byStatus} />
+          <BucketList buckets={data.feedback.byCategory} compact />
+        </AnalyticsSection>
+
+        <AnalyticsSection
+          title="Admin-Übersicht"
+          description="Rollenverteilung und Hinweise für den Betrieb."
+          icon={ShieldCheck}
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <MiniMetric label="Admin-Accounts" value={formatNumber(data.users.adminAccounts)} />
+            <MiniMetric label="Dev-Accounts" value={formatNumber(data.users.devAccounts)} />
+            <MiniMetric label="Überfällige Lernpläne" value={formatNumber(data.learning.overdueStudyPlans)} />
+            <MiniMetric label="Dringende Hinweise" value={formatNumber(data.notifications.urgent)} />
+            <MiniMetric
+              label="Erledigte Lernzeit"
+              value={formatHours(data.learning.completedEstimatedHours)}
+            />
+            <MiniMetric label="Benachrichtigungen" value={formatNumber(data.notifications.total)} />
+          </div>
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <div className="flex gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Diese Zahlen sind Momentaufnahmen aus dem MVP-Datenbestand. Für einen echten
+                Produktivbetrieb wären zusätzlich Datenschutzkonzept, Zeitraumfilter und
+                Audit-Logging sinnvoll.
+              </p>
+            </div>
+          </div>
+        </AnalyticsSection>
+      </div>
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  detail: string;
+  tone: "gray" | "blue" | "green" | "amber";
+}
+
+function MetricCard({ icon: Icon, label, value, detail, tone }: MetricCardProps) {
+  const toneClass = {
+    gray: "bg-gray-100 text-gray-700",
+    blue: "bg-blue-50 text-blue-700",
+    green: "bg-green-50 text-green-700",
+    amber: "bg-amber-50 text-amber-700",
+  }[tone];
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3">
+        <div className={cn("flex h-11 w-11 shrink-0 items-center justify-center rounded-lg", toneClass)}>
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-2xl font-bold text-gray-950">{value}</p>
+          <p className="text-sm font-medium text-gray-700">{label}</p>
+          <p className="mt-1 text-xs text-gray-500">{detail}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AnalyticsSectionProps {
+  title: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+}
+
+function AnalyticsSection({ title, description, icon: Icon, children }: AnalyticsSectionProps) {
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-5 flex items-start gap-3 border-b border-gray-100 pb-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-700">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div>
+          <h2 className="text-base font-semibold text-gray-950">{title}</h2>
+          <p className="text-sm text-gray-500">{description}</p>
+        </div>
+      </div>
+      <div className="grid gap-4">{children}</div>
+    </section>
+  );
+}
+
+interface MiniMetricProps {
+  label: string;
+  value: string;
+}
+
+function MiniMetric({ label, value }: MiniMetricProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+      <p className="text-xs font-semibold uppercase tracking-wider text-gray-500">{label}</p>
+      <p className="mt-1 text-lg font-bold text-gray-950">{value}</p>
+    </div>
+  );
+}
+
+interface ProgressRowProps {
+  label: string;
+  value: number;
+}
+
+function ProgressRow({ label, value }: ProgressRowProps) {
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="font-medium text-gray-700">{label}</span>
+        <span className="font-bold text-gray-950">{value} %</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+        <div className="h-full rounded-full bg-gray-950" style={{ width: `${value}%` }} />
+      </div>
+    </div>
+  );
+}
+
+interface BucketListProps {
+  buckets: AnalyticsBucket[];
+  compact?: boolean;
+}
+
+function BucketList({ buckets, compact = false }: BucketListProps) {
+  return (
+    <div className={cn("grid gap-3", compact && "sm:grid-cols-3")}>
+      {buckets.map((bucket) => (
+        <div key={bucket.key} className="grid gap-2">
+          <div className="flex items-center justify-between gap-3 text-sm">
+            <span className="font-medium text-gray-700">{bucket.label}</span>
+            <span className="font-bold text-gray-950">{formatNumber(bucket.count)}</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              className="h-full rounded-full bg-gray-950"
+              style={{ width: `${bucket.percentage}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import {
+  BarChart3,
   Code2,
   MessageSquareText,
   Pencil,
@@ -16,7 +17,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AdminAnalytics } from "@/components/admin/AdminAnalytics";
 import { FeedbackManagement } from "@/components/admin/FeedbackManagement";
+import type { AdminAnalyticsPayload } from "@/lib/admin/analytics";
 import type { AdminUserListItem, AdminUsersPayload } from "@/lib/admin/users";
 import type { FeedbackPayload } from "@/lib/feedback/types";
 import { cn } from "@/lib/utils";
@@ -69,6 +72,7 @@ function roleBadgeClass(role: FormState["role"]) {
 }
 
 interface AdminDashboardProps {
+  initialAnalyticsData: AdminAnalyticsPayload | null;
   initialUsersData: AdminUsersPayload | null;
   initialFeedbackData: FeedbackPayload;
   currentUserId: string;
@@ -77,6 +81,7 @@ interface AdminDashboardProps {
 }
 
 export function AdminDashboard({
+  initialAnalyticsData,
   initialUsersData,
   initialFeedbackData,
   currentUserId,
@@ -84,7 +89,9 @@ export function AdminDashboard({
   fixedAdminEmail,
 }: AdminDashboardProps) {
   const canManageUsers = currentUserRole === "ADMIN";
-  const [activeTab, setActiveTab] = useState<"feedback" | "users">("feedback");
+  const [activeTab, setActiveTab] = useState<"analytics" | "feedback" | "users">(
+    canManageUsers && initialAnalyticsData ? "analytics" : "feedback",
+  );
   const [feedbackBadgeCount, setFeedbackBadgeCount] = useState(initialFeedbackData.newCount);
   const [users, setUsers] = useState<AdminUserListItem[]>(initialUsersData?.users ?? []);
   const [total, setTotal] = useState(initialUsersData?.total ?? 0);
@@ -234,6 +241,22 @@ export function AdminDashboard({
       </div>
 
       <div className="flex flex-wrap gap-2 rounded-lg border border-gray-200 bg-white p-1 shadow-sm">
+        {canManageUsers && initialAnalyticsData && (
+          <button
+            type="button"
+            onClick={() => setActiveTab("analytics")}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition-colors",
+              activeTab === "analytics"
+                ? "bg-gray-950 text-white dark:bg-white dark:text-black"
+                : "text-gray-600 hover:bg-gray-100 hover:text-gray-950",
+            )}
+          >
+            <BarChart3 className="h-4 w-4" />
+            Analysen
+          </button>
+        )}
+
         <button
           type="button"
           onClick={() => setActiveTab("feedback")}
@@ -269,6 +292,10 @@ export function AdminDashboard({
           </button>
         )}
       </div>
+
+      {activeTab === "analytics" && initialAnalyticsData && (
+        <AdminAnalytics initialData={initialAnalyticsData} />
+      )}
 
       {activeTab === "feedback" && (
         <FeedbackManagement

--- a/src/lib/admin/analytics.ts
+++ b/src/lib/admin/analytics.ts
@@ -256,11 +256,15 @@ export async function getAdminAnalyticsPayload(): Promise<AdminAnalyticsPayload>
   const completedByPlan = new Map(
     completedTaskGroups.map((group) => [group.studyPlanId, countAll(group)]),
   );
-  const planProgressValues = taskGroups.map((group) => {
+  const progressForPlansWithTasks = taskGroups.map((group) => {
     const completedForPlan = completedByPlan.get(group.studyPlanId) ?? 0;
     const taskCount = countAll(group);
     return taskCount === 0 ? 0 : completedForPlan / taskCount;
   });
+  const plansWithoutTasks = Math.max(0, studyPlans - progressForPlansWithTasks.length);
+  const planProgressValues = progressForPlansWithTasks.concat(
+    Array.from({ length: plansWithoutTasks }, () => 0),
+  );
 
   return {
     generatedAt: now.toISOString(),

--- a/src/lib/admin/analytics.ts
+++ b/src/lib/admin/analytics.ts
@@ -236,7 +236,7 @@ export async function getAdminAnalyticsPayload(): Promise<AdminAnalyticsPayload>
     }),
     prisma.feedback.count(),
     prisma.feedback.count({ where: { status: "OPEN" } }),
-    prisma.feedback.count({ where: { priority: "CRITICAL" satisfies FeedbackPriority } }),
+    prisma.feedback.count({ where: { priority: "CRITICAL" } }),
     prisma.feedback.count({ where: { status: "DONE" } }),
     prisma.feedback.groupBy({
       by: ["status"],

--- a/src/lib/admin/analytics.ts
+++ b/src/lib/admin/analytics.ts
@@ -1,0 +1,324 @@
+import type {
+  FeedbackCategory,
+  FeedbackPriority,
+  FeedbackStatus,
+  UserRole,
+} from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+export interface AnalyticsBucket {
+  key: string;
+  label: string;
+  count: number;
+  percentage: number;
+}
+
+export interface AdminAnalyticsPayload {
+  generatedAt: string;
+  users: {
+    total: number;
+    newLast30Days: number;
+    activeSessionUsers: number;
+    signedInLast30Days: number;
+    adminAccounts: number;
+    devAccounts: number;
+    usersWithStudyPlans: number;
+    usersWithCalendarSources: number;
+  };
+  learning: {
+    studyPlans: number;
+    activeStudyPlans: number;
+    overdueStudyPlans: number;
+    tasks: number;
+    completedTasks: number;
+    openTasks: number;
+    overdueTasks: number;
+    completionRate: number;
+    averagePlanProgress: number;
+    plannedHours: number;
+    completedEstimatedHours: number;
+  };
+  calendar: {
+    events: number;
+    learningEvents: number;
+    externalEvents: number;
+    calendarSources: number;
+    sourceAdoptionRate: number;
+  };
+  notifications: {
+    total: number;
+    open: number;
+    urgent: number;
+    missedSessionOpen: number;
+  };
+  feedback: {
+    total: number;
+    open: number;
+    critical: number;
+    done: number;
+    byStatus: AnalyticsBucket[];
+    byCategory: AnalyticsBucket[];
+  };
+}
+
+const feedbackStatusLabels: Record<FeedbackStatus, string> = {
+  OPEN: "Offen",
+  IN_PROGRESS: "In Bearbeitung",
+  DONE: "Umgesetzt",
+  REJECTED: "Abgelehnt",
+};
+
+const feedbackCategoryLabels: Record<FeedbackCategory, string> = {
+  BUG: "Fehler",
+  IMPROVEMENT: "Verbesserung",
+  FEATURE: "Feature",
+};
+
+const feedbackStatuses: FeedbackStatus[] = ["OPEN", "IN_PROGRESS", "DONE", "REJECTED"];
+const feedbackCategories: FeedbackCategory[] = ["BUG", "IMPROVEMENT", "FEATURE"];
+
+type CountableRow = {
+  _count?: true | { _all?: number };
+};
+
+function percentage(part: number, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+  return Math.round((part / total) * 100);
+}
+
+function hoursFromMinutes(minutes: number | null | undefined) {
+  return Math.round(((minutes ?? 0) / 60) * 10) / 10;
+}
+
+function average(values: number[]) {
+  if (values.length === 0) {
+    return 0;
+  }
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 100);
+}
+
+function bucketRows<T extends string>(
+  keys: T[],
+  labels: Record<T, string>,
+  rows: CountableRow[],
+  total: number,
+  field: string,
+): AnalyticsBucket[] {
+  return keys.map((key) => {
+    const count = countAll(rows.find((row) => (row as Record<string, unknown>)[field] === key));
+
+    return {
+      key,
+      label: labels[key],
+      count,
+      percentage: percentage(count, total),
+    };
+  });
+}
+
+function countAll(row: CountableRow | undefined) {
+  if (!row || typeof row._count !== "object") {
+    return 0;
+  }
+  return row._count._all ?? 0;
+}
+
+export async function getAdminAnalyticsPayload(): Promise<AdminAnalyticsPayload> {
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const [
+    totalUsers,
+    newLast30Days,
+    roleGroups,
+    activeSessions,
+    recentSessions,
+    usersWithStudyPlans,
+    usersWithCalendarSources,
+    studyPlans,
+    activeStudyPlans,
+    overdueStudyPlans,
+    tasks,
+    completedTasks,
+    overdueTasks,
+    plannedMinutes,
+    completedMinutes,
+    taskGroups,
+    completedTaskGroups,
+    calendarEvents,
+    learningEvents,
+    externalEvents,
+    calendarSources,
+    notifications,
+    openNotifications,
+    urgentNotifications,
+    missedSessionOpen,
+    feedbackTotal,
+    openFeedback,
+    criticalFeedback,
+    doneFeedback,
+    feedbackStatusGroups,
+    feedbackCategoryGroups,
+  ] = await prisma.$transaction([
+    prisma.user.count(),
+    prisma.user.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
+    prisma.user.groupBy({
+      by: ["role"],
+      orderBy: { role: "asc" },
+      _count: { _all: true },
+    }),
+    prisma.session.findMany({
+      where: { expiresAt: { gt: now } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.session.findMany({
+      where: { createdAt: { gte: thirtyDaysAgo } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.studyPlan.findMany({
+      distinct: ["ownerId"],
+      select: { ownerId: true },
+    }),
+    prisma.calendarSource.findMany({
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+    prisma.studyPlan.count(),
+    prisma.studyPlan.count({ where: { targetDate: { gte: now } } }),
+    prisma.studyPlan.count({
+      where: {
+        targetDate: { lt: now },
+        tasks: { some: { completed: false } },
+      },
+    }),
+    prisma.task.count(),
+    prisma.task.count({ where: { completed: true } }),
+    prisma.task.count({
+      where: {
+        completed: false,
+        dueDate: { lt: now },
+      },
+    }),
+    prisma.task.aggregate({ _sum: { estimatedMinutes: true } }),
+    prisma.task.aggregate({
+      where: { completed: true },
+      _sum: { estimatedMinutes: true },
+    }),
+    prisma.task.groupBy({
+      by: ["studyPlanId"],
+      orderBy: { studyPlanId: "asc" },
+      _count: { _all: true },
+    }),
+    prisma.task.groupBy({
+      by: ["studyPlanId"],
+      where: { completed: true },
+      orderBy: { studyPlanId: "asc" },
+      _count: { _all: true },
+    }),
+    prisma.calendarEvent.count(),
+    prisma.calendarEvent.count({ where: { type: "LERNEINHEIT" } }),
+    prisma.calendarEvent.count({ where: { source: "EXTERNAL" } }),
+    prisma.calendarSource.count(),
+    prisma.notification.count(),
+    prisma.notification.count({ where: { isDone: false, isArchived: false } }),
+    prisma.notification.count({ where: { isUrgent: true, isDone: false, isArchived: false } }),
+    prisma.notification.count({
+      where: {
+        type: "MISSED_SESSION",
+        isDone: false,
+        isArchived: false,
+      },
+    }),
+    prisma.feedback.count(),
+    prisma.feedback.count({ where: { status: "OPEN" } }),
+    prisma.feedback.count({ where: { priority: "CRITICAL" satisfies FeedbackPriority } }),
+    prisma.feedback.count({ where: { status: "DONE" } }),
+    prisma.feedback.groupBy({
+      by: ["status"],
+      orderBy: { status: "asc" },
+      _count: { _all: true },
+    }),
+    prisma.feedback.groupBy({
+      by: ["category"],
+      orderBy: { category: "asc" },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const roleCount = (role: UserRole) =>
+    countAll(roleGroups.find((group) => group.role === role));
+
+  const completedByPlan = new Map(
+    completedTaskGroups.map((group) => [group.studyPlanId, countAll(group)]),
+  );
+  const planProgressValues = taskGroups.map((group) => {
+    const completedForPlan = completedByPlan.get(group.studyPlanId) ?? 0;
+    const taskCount = countAll(group);
+    return taskCount === 0 ? 0 : completedForPlan / taskCount;
+  });
+
+  return {
+    generatedAt: now.toISOString(),
+    users: {
+      total: totalUsers,
+      newLast30Days,
+      activeSessionUsers: activeSessions.length,
+      signedInLast30Days: recentSessions.length,
+      adminAccounts: roleCount("ADMIN"),
+      devAccounts: roleCount("DEV"),
+      usersWithStudyPlans: usersWithStudyPlans.length,
+      usersWithCalendarSources: usersWithCalendarSources.length,
+    },
+    learning: {
+      studyPlans,
+      activeStudyPlans,
+      overdueStudyPlans,
+      tasks,
+      completedTasks,
+      openTasks: tasks - completedTasks,
+      overdueTasks,
+      completionRate: percentage(completedTasks, tasks),
+      averagePlanProgress: average(planProgressValues),
+      plannedHours: hoursFromMinutes(plannedMinutes._sum.estimatedMinutes),
+      completedEstimatedHours: hoursFromMinutes(completedMinutes._sum.estimatedMinutes),
+    },
+    calendar: {
+      events: calendarEvents,
+      learningEvents,
+      externalEvents,
+      calendarSources,
+      sourceAdoptionRate: percentage(usersWithCalendarSources.length, totalUsers),
+    },
+    notifications: {
+      total: notifications,
+      open: openNotifications,
+      urgent: urgentNotifications,
+      missedSessionOpen,
+    },
+    feedback: {
+      total: feedbackTotal,
+      open: openFeedback,
+      critical: criticalFeedback,
+      done: doneFeedback,
+      byStatus: bucketRows(
+        feedbackStatuses,
+        feedbackStatusLabels,
+        feedbackStatusGroups,
+        feedbackTotal,
+        "status",
+      ),
+      byCategory: bucketRows(
+        feedbackCategories,
+        feedbackCategoryLabels,
+        feedbackCategoryGroups,
+        feedbackTotal,
+        "category",
+      ),
+    },
+  };
+}


### PR DESCRIPTION
## Überblick

Dieser PR ergänzt die bestehende Admin-Verwaltung um einen neuen Tab **Analysen**. Die Ansicht zeigt aggregierte, nicht personenbezogene Kennzahlen zur Nutzung von LearnHub und zur Produktbewertung.

## Änderungen

- serverseitige Aggregation für Admin-Analytics ergänzt
- neue Admin-API `GET /api/admin/analytics` hinzugefügt
- neuen Admin-Tab `Analysen` eingebaut
- Kennzahlen zu Nutzern, Sessions, Lernplänen, Aufgaben, Kalenderquellen, Benachrichtigungen und Feedback ergänzt
- Analytics nur für `ADMIN` sichtbar; `DEV` bleibt auf Feedback-Verwaltung beschränkt

## Validierung

- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd test`
- `npm.cmd run build`

Hinweis: Eine vollständige Browser-Sichtprüfung konnte lokal nicht abgeschlossen werden, weil der In-App-Browser bei der Navigation hängen blieb. Build, Typecheck, Linting und Tests sind erfolgreich.