### PR TITLE
Meilenstein 3: Rechtsseiten + Dokumentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,10 +391,12 @@ Vor jeder größeren Änderung:
 
 # 13. Bekannte Baustellen
 
-* Profilname, E-Mail und Passwort-Reset sind in den Einstellungen noch nicht angebunden
-* Allgemeine Deadline-Erinnerungen und tägliche Übersichten sind teilweise UI-Stubs
-* Reproduzierbare Demo-Daten/Seed fehlen noch
-* Automatisierte Tests decken bisher vor allem Lernplanlogik ab; API-/E2E-Tests fehlen
+* Anzeigename, Benutzername und Profilbild sind in den Einstellungen angebunden und persistent (`PUT /api/profile`, `POST /api/profile/avatar`)
+* Die Benachrichtigungs-Einstellungen sind persistent angebunden (`NotificationSettings` + `/api/settings/notifications`)
+* E-Mail-Änderung ist bewusst nicht editierbar; Passwort-Reset ist bewusst ein Mockup (`/forgot-password`) und soll künftig über das DHBW-SSO laufen
+* Reproduzierbare Demo-Daten/Seed fehlen noch (Should-Have S4)
+* Eine UI-Transparenzanzeige „warum liegt diese Aufgabe an diesem Tag" (Should-Have S5) ist noch nicht umgesetzt
+* Automatisierte Tests decken bisher vor allem Lernplanlogik ab (`tests/study-plan/`); API-/E2E-Tests fehlen
 * Der DHBW-ICS-Server ist extern und kann instabil sein; Retry, Timeout und Cache beibehalten
 * KI-Funktionen wurden bewusst nicht in den MVP aufgenommen
-* Produktivbetrieb, Rate Limiting, Passwort-Recovery und externes Datei-Storage sind nicht Teil des lokalen MVP
+* Produktivbetrieb, Rate Limiting, SSO/Passwort-Recovery und externes Datei-Storage sind nicht Teil des lokalen MVP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,7 +394,7 @@ Vor jeder größeren Änderung:
 * Anzeigename, Benutzername und Profilbild sind in den Einstellungen angebunden und persistent (`PUT /api/profile`, `POST /api/profile/avatar`)
 * Die Benachrichtigungs-Einstellungen sind persistent angebunden (`NotificationSettings` + `/api/settings/notifications`)
 * E-Mail-Änderung ist bewusst nicht editierbar; Passwort-Reset ist bewusst ein Mockup (`/forgot-password`) und soll künftig über das DHBW-SSO laufen
-* Reproduzierbare Demo-Daten/Seed fehlen noch (Should-Have S4)
+* Reproduzierbare Demo-Daten via `npm run seed` vorhanden (Should-Have S4); idempotent, nur Demo-Account
 * Eine UI-Transparenzanzeige „warum liegt diese Aufgabe an diesem Tag" (Should-Have S5) ist noch nicht umgesetzt
 * Automatisierte Tests decken bisher vor allem Lernplanlogik ab (`tests/study-plan/`); API-/E2E-Tests fehlen
 * Der DHBW-ICS-Server ist extern und kann instabil sein; Retry, Timeout und Cache beibehalten

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Eine ausfuehrliche Schritt-fuer-Schritt-Anleitung inklusive Windows-Hinweisen, D
 | Linter | `npm run lint` |
 | TypeScript pruefen | `npm run typecheck` |
 | Unit-Tests | `npm test` |
+| Demo-Daten laden | `npm run seed` |
 
 Nach einem `git pull` mit neuen Dateien unter `prisma/migrations/`:
 
@@ -67,6 +68,20 @@ Der feste Admin-Account wird beim ersten Login automatisch angelegt. Die Default
 | --- | --- |
 | E-Mail | `0000@learnhub.admin` |
 | Passwort | `0000admin` |
+
+---
+
+## Demo-Daten
+
+`npm run seed` befuellt die lokale Datenbank mit reproduzierbaren Beispieldaten
+fuer die Praesentation (drei Lernplaene, Aufgaben inkl. erledigter und
+ueberfaelliger, Kalendertermine). Das Skript ist idempotent und ruehrt nur den
+Demo-Account an.
+
+| Feld | Wert |
+| --- | --- |
+| E-Mail | `demo@learnhub.test` |
+| Passwort | `demo12345` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ Der feste Admin-Account wird beim ersten Login automatisch angelegt. Die Default
 ## Projekt-Dokumentation
 
 - [Setup-Anleitung](./SETUP.md) — ausfuehrlicher lokaler Setup- und Troubleshooting-Guide
-- [Product Requirements Document](./docs/prd.md) — fachlicher Funktionsumfang
+- [Product Requirements Document](./docs/prd.md) — fachlicher Funktionsumfang inkl. Feature-Status (§17)
+- [Architekturueberblick](./docs/architecture.md) — Schichten, Datenmodell und API-Oberflaeche
 - [Tech-Stack](./docs/tech-stack.md) — eingesetzte Technologien und Begruendung
 - [Auth-Konzept](./docs/auth-concept.md) — Login, Sessions, Schutzlogik
 - [Manueller Abnahmetest](./docs/testing/manual-acceptance-test.md) — Test-Checkliste fuer UC1–UC6
 - [Algorithmus-Konzept](./docs/Algorithmus/) — Formel, Phasen und Ausgabeformat der Lernplanung
+- [Mockups & offene Punkte](./docs/mockups.md) — was echt funktioniert und was Vorschau ist
+- [Uebergabedokumentation](./docs/handover.md) — Einstieg fuer Weiterbetrieb und -entwicklung (in Vorbereitung)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,151 @@
+# Architekturüberblick — LearnHub
+
+| Feld       | Inhalt                                                            |
+| ---------- | ----------------------------------------------------------------- |
+| **Zweck**  | Kompakter technischer Überblick für Abgabe, Übergabe und Review   |
+| **Stand**  | 25.06.2026 (Meilenstein 3)                                        |
+| **Bezug**  | Ergänzt [CLAUDE.md](../CLAUDE.md) und [docs/tech-stack.md](./tech-stack.md) |
+
+---
+
+## 1. Überblick in einem Satz
+
+LearnHub ist eine Next.js-15-Anwendung (App Router) mit React 18 und TypeScript,
+die über Prisma auf eine PostgreSQL-Datenbank zugreift. Der fachliche Kern ist
+eine deterministische, serverseitige Lernplanungslogik. Die Anwendung läuft im
+Projektkontext lokal (Datenbank via Docker).
+
+---
+
+## 2. Schichten
+
+```txt
+Browser
+  │  (HTTP, lh_session-Cookie)
+  ▼
+Next.js App Router  ──────────────────────────────────────────────┐
+  │                                                                │
+  ├─ middleware.ts        Auth-Guard (Cookie-Prüfung, Redirects)   │
+  │                                                                │
+  ├─ app/(app)/*          Geschützte Seiten (Server Components)    │
+  │     └─ DashboardShell → Sidebar / Topbar / Feature-Seiten      │
+  │                                                                │
+  ├─ app/login|register|forgot-password   Öffentliche Auth-Seiten  │
+  ├─ app/impressum|datenschutz|nutzungsordnung   Rechtsseiten      │
+  │                                                                │
+  └─ app/api/*            Route Handler (NextResponse.json)        │
+        │                                                          │
+        ▼                                                          │
+   lib/<feature>/         Logik, Validierung (zod), DTOs ──────────┘
+        │
+        ▼
+   Prisma Client  ──►  PostgreSQL
+```
+
+Strukturprinzip (siehe CLAUDE.md §3–4): `app/` bleibt dünn, Render-/Interaktions-
+logik liegt in `components/<feature>/`, Berechnungen und Datenzugriff in
+`lib/<feature>/`. Wiederverwendbare UI in `components/ui/`, Layout in
+`components/layout/`.
+
+---
+
+## 3. Request-Fluss (Beispiel: Lernplan-Detailseite)
+
+1. Browser ruft `/study-plan/<id>` auf.
+2. `middleware.ts` prüft das `lh_session`-Cookie. Fehlt es → Redirect auf
+   `/login?redirect=…`.
+3. Die Server Component lädt über `lib/auth/session` die Session und über Prisma
+   den Lernplan — stets auf `ownerId`/`userId` der angemeldeten Person begrenzt.
+4. Interaktive Teile (Aufgaben abhaken, Umplanung) sind kleine Client-Komponenten,
+   die `app/api/study-plan/[id]/...`-Route-Handler aufrufen.
+5. Route Handler validieren (zod), schreiben über Prisma und antworten mit
+   `NextResponse.json()`.
+
+---
+
+## 4. Datenmodell (Prisma)
+
+Zentrale Modelle in [prisma/schema.prisma](../prisma/schema.prisma):
+
+- **User / Session** — Auth; Session-`id` ist der opake Token im Cookie.
+- **StudyPlan** — Lernplan inkl. Algorithmus-Eingaben (difficulty, priorKnowledge,
+  pages, credits) und -Ergebnis (totalHours, hoursPerDay, planType).
+- **Task** — Aufgabe eines Lernplans; optionale 1:1-Verknüpfung zu einem
+  `CalendarEvent` (Should-Have S1).
+- **CalendarEvent** — Termine (LOCAL/EXTERNAL), farbcodiert nach Typ.
+- **CalendarSource** — externe Kalenderquellen (z. B. DHBW-ICS).
+- **Notification / NotificationSettings** — Benachrichtigungen und persistente
+  Präferenzen.
+- **Feedback** — eingereichtes Nutzer-Feedback.
+
+**Wichtige Löschregeln:** Lernplan-Löschung kaskadiert auf Tasks und generierte
+Lerneinheiten; Task-Löschung trennt nur die Verknüpfung zum Kalendertermin
+(`SetNull`). Details siehe Schema-Kommentare und PRD §8.1.
+
+---
+
+## 5. API-Oberfläche
+
+Alle Route Handler liegen unter `src/app/api/<resource>/route.ts` und antworten
+über `NextResponse.json()`:
+
+| Bereich        | Routen (Auszug)                                                        |
+| -------------- | ---------------------------------------------------------------------- |
+| Auth           | `/api/auth/login`, `/register`, `/logout`                              |
+| Profil         | `/api/profile`, `/api/profile/avatar`                                  |
+| Lernpläne      | `/api/study-plan`, `/[id]`, `/[id]/replan`, `/[id]/tasks`, `/[id]/tasks/[taskId]` |
+| Kalender       | `/api/calendar/events`, `/[id]`, `/external`, `/sources`              |
+| Benachrichtig. | `/api/notifications`, `/[id]`, `/check`, `/api/settings/notifications` |
+| Feedback       | `/api/feedback`, `/[id]`                                               |
+| Admin          | `/api/admin/users`, `/[id]`                                            |
+
+---
+
+## 6. Authentifizierung & Autorisierung
+
+Eigene E-Mail/Passwort-Auth (bcrypt) mit DB-Sessions per HTTP-Only-Cookie
+(`lh_session`, `SameSite=Lax`). Konzept: [docs/auth-concept.md](./auth-concept.md).
+
+- `middleware.ts` prüft nur die **Cookie-Existenz** (Edge-Runtime ohne Prisma)
+  und steuert Redirects/401 sowie Admin-/DEV-Rollen.
+- Die echte Session-Validierung läuft in Server Components und Route Handlern
+  über `getSession()`.
+- Rollen: `USER`, `ADMIN`, `DEV` (Feedback-/Verwaltungszugriff).
+
+---
+
+## 7. Externe Integration
+
+DHBW-Termine werden über `node-ical` serverseitig aus einem ICS-Feed gelesen
+(`/api/calendar/external`). Da der externe Server instabil sein kann, gelten
+Retry, Exponential Backoff, Timeout und ein In-Memory-Cache via `globalThis`
+als Pflicht. Externe Events sind read-only.
+
+---
+
+## 8. Lernplanungslogik
+
+Deterministischer Algorithmus in `src/lib/calculations/` und `src/lib/study-plan/`
+(Formel-Konzept unter [docs/Algorithmus/](./Algorithmus/)). Gleiche Eingaben und
+gleiches Bezugsdatum erzeugen dasselbe Ergebnis. Abgesichert durch Unit-Tests in
+[tests/study-plan/](../tests/study-plan/).
+
+---
+
+## 9. Qualitätssicherung
+
+- **Unit-Tests** (`node --test`): `tests/study-plan/` (Fälligkeiten,
+  Planberechnung, Fortschritt, Aufgaben-Validierung).
+- **Manueller Abnahmetest**: [docs/testing/manual-acceptance-test.md](./testing/manual-acceptance-test.md)
+  für UC1–UC6.
+- **Statische Prüfung**: `npm run typecheck` (TS strict) und `npm run lint`.
+- Offen: automatisierte API-/E2E-Tests.
+
+---
+
+## 10. Betrieb (lokal)
+
+Setup über [README.md](../README.md) / [SETUP.md](../SETUP.md): PostgreSQL via
+`docker compose`, Migrationen via `prisma:deploy`, Client via `prisma:generate`,
+Start via `npm run dev`. Ein produktives Hosting ist im MVP nicht vorgesehen
+(PRD §9).

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -1,0 +1,99 @@
+# Übergabedokumentation — LearnHub (in Vorbereitung)
+
+| Feld       | Inhalt                                                          |
+| ---------- | --------------------------------------------------------------- |
+| **Status** | In Vorbereitung — wird bis zur Abgabe (05.07.2026) finalisiert  |
+| **Stand**  | 25.06.2026 (Meilenstein 3)                                      |
+| **Zweck**  | Alles, was ein Team zum Weiterbetrieb/-entwickeln von LearnHub braucht |
+
+> Dieses Dokument ist bewusst als lebendiger Entwurf angelegt. Abschnitte mit
+> ⏳ werden bis zur finalen Abgabe vervollständigt.
+
+---
+
+## 1. Was ist LearnHub?
+
+Webbasierte Lernmanagement-Anwendung für Studierende: Lernpläne, Aufgaben,
+Kalender und Benachrichtigungen an einem Ort, mit deterministischer
+Lernplanberechnung als Kern. Fachlicher Umfang: [docs/prd.md](./prd.md).
+
+---
+
+## 2. Schnelleinstieg für Übernehmende
+
+1. Repository klonen, Voraussetzungen prüfen (Node 20+, Docker, Git).
+2. Setup nach [README.md](../README.md) bzw. [SETUP.md](../SETUP.md) durchführen.
+3. Architektur verstehen: [docs/architecture.md](./architecture.md).
+4. Arbeitsregeln und Konventionen: [CLAUDE.md](../CLAUDE.md).
+5. App lokal starten (`npm run dev`) und mit dem Admin-Zugang (siehe README)
+   anmelden.
+
+---
+
+## 3. Repository-Landkarte
+
+| Pfad                     | Inhalt                                              |
+| ------------------------ | --------------------------------------------------- |
+| `src/app/(app)/`         | Geschützte Feature-Seiten (Dashboard, Kalender, …)  |
+| `src/app/api/`           | Route Handler (REST-artige Endpunkte)              |
+| `src/components/`        | UI nach Feature + `ui/` + `layout/`                 |
+| `src/lib/`               | Logik, Validierung, Datenzugriff je Feature         |
+| `prisma/`                | Schema + Migrationen                                |
+| `tests/study-plan/`      | Unit-Tests der Planungslogik                        |
+| `docs/`                  | Projekt-, Architektur- und Testdokumentation        |
+
+---
+
+## 4. Betrieb & Konfiguration
+
+- **Datenbank:** PostgreSQL via `docker compose up -d`.
+- **Migrationen:** `npm run prisma:deploy` (Setup/Pull), `npm run prisma:migrate`
+  (eigene Schemaänderungen).
+- **Umgebungsvariablen:** siehe `.env.example` (u. a. `DATABASE_URL`,
+  `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_DISPLAY_NAME`).
+- **Admin-Account:** wird beim ersten Login automatisch angelegt (Defaults im
+  README).
+
+---
+
+## 5. Qualitätssicherung
+
+- `npm run build`, `npm run typecheck`, `npm run lint`, `npm test` vor jedem
+  Commit (siehe CLAUDE.md §11).
+- Manueller Abnahmetest UC1–UC6:
+  [docs/testing/manual-acceptance-test.md](./testing/manual-acceptance-test.md).
+- Aufgabensteuerung/Issues: GitHub Projects.
+
+---
+
+## 6. Bekannte Einschränkungen & offene Punkte
+
+Gepflegt in [CLAUDE.md §13](../CLAUDE.md) und
+[docs/tech-stack.md](./tech-stack.md) („Offene technische Punkte"). Mockups bzw.
+nicht implementierte Bereiche: [docs/mockups.md](./mockups.md).
+
+Kurzfassung:
+
+- Demo-Daten/Seed (S4) fehlen noch.
+- Transparenzanzeige der Planungslogik (S5) offen.
+- API-/E2E-Tests fehlen; Unit-Tests bisher nur für die Planungslogik.
+- E-Mail-Änderung/Passwort-Reset bewusst als Mockup (künftig DHBW-SSO).
+- KI-Funktionen bewusst zurückgestellt (Could-Have).
+
+---
+
+## 7. Empfohlene nächste Schritte (für Weiterentwicklung)
+
+1. Seed-/Demo-Daten für reproduzierbare Vorführung.
+2. API- und E2E-Tests ergänzen.
+3. SSO-Anbindung (DHBW) inkl. Passwort-Reset.
+4. Produktiv-/Hosting-Konzept inkl. externem Datei-Storage für Profilbilder.
+
+---
+
+## 8. Noch zu ergänzen ⏳
+
+- ⏳ Ansprechpartner und Verantwortlichkeiten nach Projektende.
+- ⏳ Lizenz-/Rechtehinweise zum Code und zu verwendeten Assets.
+- ⏳ Screenshots der zentralen Screens.
+- ⏳ Verweis auf das finale Abgabepaket in Moodle.

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -74,7 +74,7 @@ nicht implementierte Bereiche: [docs/mockups.md](./mockups.md).
 
 Kurzfassung:
 
-- Demo-Daten/Seed (S4) fehlen noch.
+- Demo-Daten/Seed (S4) vorhanden: `npm run seed` (idempotent, Login `demo@learnhub.test` / `demo12345`).
 - Transparenzanzeige der Planungslogik (S5) offen.
 - API-/E2E-Tests fehlen; Unit-Tests bisher nur für die Planungslogik.
 - E-Mail-Änderung/Passwort-Reset bewusst als Mockup (künftig DHBW-SSO).
@@ -84,10 +84,9 @@ Kurzfassung:
 
 ## 7. Empfohlene nächste Schritte (für Weiterentwicklung)
 
-1. Seed-/Demo-Daten für reproduzierbare Vorführung.
-2. API- und E2E-Tests ergänzen.
-3. SSO-Anbindung (DHBW) inkl. Passwort-Reset.
-4. Produktiv-/Hosting-Konzept inkl. externem Datei-Storage für Profilbilder.
+1. API- und E2E-Tests ergänzen.
+2. SSO-Anbindung (DHBW) inkl. Passwort-Reset.
+3. Produktiv-/Hosting-Konzept inkl. externem Datei-Storage für Profilbilder.
 
 ---
 

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -51,8 +51,12 @@ Lernplanberechnung als Kern. Fachlicher Umfang: [docs/prd.md](./prd.md).
   (eigene Schemaänderungen).
 - **Umgebungsvariablen:** siehe `.env.example` (u. a. `DATABASE_URL`,
   `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_DISPLAY_NAME`).
-- **Admin-Account:** wird beim ersten Login automatisch angelegt (Defaults im
-  README).
+- **Admin-Account:** Es gibt keinen separaten Anlege-Schritt. Meldet man sich
+  im Login mit der konfigurierten `ADMIN_EMAIL` **und** `ADMIN_PASSWORD` an
+  (Defaults `0000@learnhub.admin` / `0000admin`, überschreibbar via `.env`),
+  legt `ensureFixedAdminAccount()` das Konto beim ersten Mal mit Rolle `ADMIN`
+  an. Bei späteren Logins wird ein bestehendes Konto nicht verändert.
+  (Code: `src/lib/auth/admin.ts`, aufgerufen in `src/app/api/auth/login/route.ts`.)
 
 ---
 
@@ -60,9 +64,15 @@ Lernplanberechnung als Kern. Fachlicher Umfang: [docs/prd.md](./prd.md).
 
 - `npm run build`, `npm run typecheck`, `npm run lint`, `npm test` vor jedem
   Commit (siehe CLAUDE.md §11).
+- **Automatisierte Unit-Tests** (`npm test`, Node-Test-Runner) unter
+  [tests/study-plan/](../tests/study-plan/): Lernplanberechnung
+  (`learningPlan`), Umplanung, Fortschrittsberechnung (`progress`),
+  Fälligkeiten (`dueDates`) und Aufgabenvalidierung (`taskValidation`).
 - Manueller Abnahmetest UC1–UC6:
   [docs/testing/manual-acceptance-test.md](./testing/manual-acceptance-test.md).
+- Statische Prüfung: `npm run typecheck` (TS strict) und `npm run lint`.
 - Aufgabensteuerung/Issues: GitHub Projects.
+- Noch offen: automatisierte API-/E2E-Tests.
 
 ---
 

--- a/docs/mockups.md
+++ b/docs/mockups.md
@@ -50,10 +50,11 @@ erläutert:
 
 - **S2 — Termintyp-Filter im Kalender:** Ein Fächer-Filter ist vorhanden; ein
   reiner Filter nach Termintyp ist noch nicht umgesetzt.
-- **S4 — Demonstrationsdaten/Seed:** Es gibt noch kein Skript zum reproduzierbaren
-  Befüllen für die Präsentation.
 - **S5 — Transparenzanzeige der Planungslogik:** Eine UI-Begründung „warum liegt
   diese Aufgabe an diesem Tag" ist noch nicht umgesetzt.
+
+> Hinweis: S4 (Demonstrationsdaten) ist inzwischen umgesetzt — `npm run seed`
+> befüllt die Datenbank reproduzierbar (siehe README).
 
 ---
 

--- a/docs/mockups.md
+++ b/docs/mockups.md
@@ -1,0 +1,75 @@
+# Mockups & nicht implementierte Bereiche — LearnHub
+
+| Feld      | Inhalt                                                                |
+| --------- | --------------------------------------------------------------------- |
+| **Zweck** | Transparente Übersicht, welche Bereiche echt funktionieren, welche als Mockup/Vorschau gezeigt werden und welche bewusst zurückgestellt sind |
+| **Stand** | 25.06.2026 (Meilenstein 3)                                            |
+| **Bezug** | Meilenstein 3 — „fehlende Teile sind als Mockups dokumentiert"        |
+
+---
+
+## 1. Einordnung
+
+Der funktionale Kern von LearnHub (Must-Haves M1–M8 laut [PRD §6.1](./prd.md)) ist
+als lauffähige Anwendung umgesetzt, nicht als Klickprototyp. Die unten genannten
+Punkte sind die bewusst als Mockup gezeigten bzw. (noch) nicht implementierten
+Bereiche. Der vollständige Feature-Status mit Häkchen steht in [PRD §17](./prd.md).
+
+---
+
+## 2. Als Mockup / Vorschau im Produkt sichtbar
+
+| Bereich                     | Wo                       | Charakter                                                                 |
+| --------------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| Passwort zurücksetzen       | `/forgot-password`       | Funktionierende Seite, die transparent auf die künftige DHBW-SSO-Anbindung hinweist. Kein echter Reset-Flow. |
+| E-Mail-Adresse ändern       | Einstellungen → Profil   | Feld wird angezeigt, ist aber nicht editierbar (künftig über DHBW-SSO).    |
+
+Diese Stellen sind im UI als „noch nicht verfügbar" bzw. „in Vorbereitung"
+gekennzeichnet, damit in der Demo kein falscher Eindruck entsteht.
+
+---
+
+## 3. Bewusst zurückgestellt (Could-Have / Ausblick)
+
+Diese Funktionen sind laut [PRD §6.3 und §16](./prd.md) ausdrücklich **nicht** Teil
+des verbindlichen Lieferumfangs und werden in der Demo als Konzept/Ausblick
+erläutert:
+
+- KI-Check eines bestehenden Lernplans mit Verbesserungsvorschlägen (UC7).
+- KI-gestützte alternative Planvarianten.
+- KI-gestützte Aufgabenextraktion aus Lernmaterialien.
+- Statistikansicht (gelernte Stunden pro Fach) und Wochenrückblick.
+- Single-Sign-On mit DHBW-Login.
+- Versand von E-Mails (Erinnerung/Bestätigung/Passwort-Reset).
+- Browser-Push-Benachrichtigungen.
+- Mobile-App / PWA.
+
+---
+
+## 4. Geplant, aber noch offen (Should-Have)
+
+- **S2 — Termintyp-Filter im Kalender:** Ein Fächer-Filter ist vorhanden; ein
+  reiner Filter nach Termintyp ist noch nicht umgesetzt.
+- **S4 — Demonstrationsdaten/Seed:** Es gibt noch kein Skript zum reproduzierbaren
+  Befüllen für die Präsentation.
+- **S5 — Transparenzanzeige der Planungslogik:** Eine UI-Begründung „warum liegt
+  diese Aufgabe an diesem Tag" ist noch nicht umgesetzt.
+
+---
+
+## 5. Frühe Konzept-Prototypen
+
+Aus der Konzeptionsphase existiert ein statischer HTML-Klickprototyp unter
+[docs/design/prototypes/prototype_1/](./design/prototypes/prototype_1/) sowie
+Wireframes unter [docs/design/wireframes/](./design/wireframes/). Diese
+dokumentieren die frühe Designidee. **Maßgeblich für den aktuellen Stand ist die
+implementierte Webanwendung**, nicht der frühe Prototyp.
+
+---
+
+## 6. Hinweis für die Vorführung
+
+Empfohlener Umgang in der Demo:
+- Must-Have-Flows (UC1–UC6) **live** zeigen.
+- Mockup-Stellen (Abschnitt 2) kurz als „bewusst noch nicht angebunden" benennen.
+- Could-Have (Abschnitt 3) nur als Ausblick erwähnen, nicht als vorhandene Funktion.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -292,7 +292,7 @@ Der genaue Zeitplan wird laufend in GitHub Projects gepflegt. Die Meilensteine a
 | **M3 — Datenmodell und API**             | Datenbankschema, persistente Speicherung, Anbindung des bestehenden Frontends an reale Daten, Authentifizierung | abgeschlossen |
 | **M4 — Planungslogik**                   | Algorithmische Lernplan-Erstellung und Umplanung im Lernplan- und Kalenderfluss verfügbar                       | abgeschlossen |
 | **M5 — Optionale KI-Prüfung**            | Falls zeitlich möglich: KI-gestützte Prüfung oder Verbesserungsvorschläge für bestehende Lernpläne              | offen         |
-| **M6 — Stabilisierung und Präsentation** | Fehlerbehebung, manuelle Abnahmetests, Demonstrationsdaten, Setup-Dokumentation, finale Präsentation            | offen         |
+| **M6 — Stabilisierung und Präsentation** | Fehlerbehebung, manuelle Abnahmetests, Demonstrationsdaten, Setup-Dokumentation, finale Präsentation            | in Arbeit     |
 
 ---
 
@@ -350,105 +350,118 @@ Diese Punkte sind ausdrücklich **nicht** Teil des aktuellen verbindlichen Proje
 
 ## 17. Feature-Checkliste
 
-Gesamtübersicht aller geplanten Features nach Bereich.
+Gesamtübersicht aller Features nach Bereich mit Ist-Stand zu Meilenstein 3 (Stand: 25.06.2026).
+
+**Legende:** `[x]` = implementiert und nutzbar · `[~]` = teilweise / mit Einschränkung · `[ ]` = bewusst zurückgestellt bzw. offen.
 
 ---
 
 ### Authentifizierung & Nutzerkonten
 
-- [ ] Registrierung mit E-Mail und Passwort
-- [ ] Login / Logout
-- [ ] Session via HTTP-Only-Cookie
-- [ ] Passwort-Hashing (bcrypt)
-- [ ] „Eingeloggt bleiben"-Option
-- [ ] Schutz aller Routen (Middleware / Auth-Guard)
+- [x] Registrierung mit E-Mail und Passwort
+- [x] Login / Logout
+- [x] Session via HTTP-Only-Cookie
+- [x] Passwort-Hashing (bcrypt)
+- [x] „Eingeloggt bleiben"-Option
+- [x] Schutz aller Routen (Middleware / Auth-Guard)
 
 ---
 
 ### Dashboard
 
-- [ ] Dashboard-Shell (Layout)
-- [ ] Anstehende Aufgaben über alle Lernpläne hinweg
-- [ ] Heutige & morgige Kalendertermine
-- [ ] Schnellzugriff auf aktive Lernpläne
-- [ ] Visuelle Hervorhebung überfälliger Aufgaben
-- [ ] Demonstrationsdaten zum Befüllen
+- [x] Dashboard-Shell (Layout)
+- [x] Anstehende Aufgaben über alle Lernpläne hinweg
+- [x] Heutige & morgige Kalendertermine
+- [x] Schnellzugriff auf aktive Lernpläne
+- [x] Visuelle Hervorhebung überfälliger Aufgaben
+- [ ] Demonstrationsdaten zum Befüllen — Should-Have S4, noch nicht umgesetzt
 
 ---
 
 ### Kalender
 
-- [ ] Wochenansicht
-- [ ] Tagesansicht
-- [ ] Monatsansicht
-- [ ] Listenansicht
-- [ ] DHBW-Kalender-Integration via ICS-Feed
-- [ ] Termine manuell anlegen (per Drag oder Button)
-- [ ] Drag-to-Create (Maus ziehen)
-- [ ] Termin-Typen farblich unterscheidbar
-- [ ] Termine bearbeiten
-- [ ] Termine löschen
-- [ ] Termine verschieben (Drag & Drop)
-- [ ] Filter nach Termintyp
-- [ ] Verknüpfung Aufgabe ↔ Kalendereintrag
+- [x] Wochenansicht
+- [x] Tagesansicht
+- [x] Monatsansicht
+- [x] Listenansicht
+- [x] DHBW-Kalender-Integration via ICS-Feed
+- [x] Termine manuell anlegen (per Drag oder Button)
+- [x] Drag-to-Create (Maus ziehen)
+- [x] Termin-Typen farblich unterscheidbar
+- [x] Termine bearbeiten
+- [x] Termine löschen
+- [x] Termine verschieben (Drag & Drop)
+- [~] Filter im Kalender — Fächer-Filter vorhanden; reiner Termintyp-Filter (S2) noch offen
+- [x] Verknüpfung Aufgabe ↔ Kalendereintrag (Should-Have S1)
 
 ---
 
 ### Lernpläne
 
-- [ ] Lernplan anlegen (Titel, Fach, Beschreibung, Zieltyp, Zieldatum)
-- [ ] Lernplan bearbeiten
-- [ ] Lernplan löschen (inkl. zugehöriger Aufgaben)
-- [ ] Übersicht aller Lernpläne
+- [x] Lernplan anlegen (Titel, Fach, Beschreibung, Zieltyp, Zieldatum)
+- [x] Lernplan bearbeiten
+- [x] Lernplan löschen (inkl. zugehöriger Aufgaben)
+- [x] Übersicht aller Lernpläne
 
 ---
 
 ### Aufgaben (innerhalb von Lernplänen)
 
-- [ ] Aufgabe anlegen (Titel, Aufwand, Schwierigkeit, Fälligkeitsdatum)
-- [ ] Aufgabe bearbeiten
-- [ ] Aufgabe abhaken / als erledigt markieren
-- [ ] Aufgabe löschen
-- [ ] Aufgaben in Kalender sichtbar machen
+- [x] Aufgabe anlegen (Titel, Aufwand, Schwierigkeit, Fälligkeitsdatum)
+- [x] Aufgabe bearbeiten
+- [x] Aufgabe abhaken / als erledigt markieren
+- [x] Aufgabe löschen
+- [x] Aufgaben in Kalender sichtbar machen
 
 ---
 
 ### Algorithmische Lernplanung
 
-- [ ] Automatische Lernplan-Berechnung aus Eingaben (Tage bis Deadline, Seitenvolumen, Schwierigkeit, Vorwissen, ECTS)
-- [ ] Deterministische Planungslogik (reproduzierbare Ergebnisse)
-- [ ] Manuelle Nachbearbeitung des berechneten Plans
-- [ ] Umplanung (Reschedule) offener Aufgaben
-- [ ] Transparenzanzeige: Warum liegt eine Aufgabe an diesem Tag?
+- [x] Automatische Lernplan-Berechnung aus Eingaben (Tage bis Deadline, Seitenvolumen, Schwierigkeit, Vorwissen, ECTS)
+- [x] Deterministische Planungslogik (reproduzierbare Ergebnisse) — durch Unit-Tests in `tests/study-plan/` abgesichert
+- [x] Manuelle Nachbearbeitung des berechneten Plans
+- [x] Umplanung (Reschedule) offener Aufgaben
+- [ ] Transparenzanzeige: Warum liegt eine Aufgabe an diesem Tag? — Should-Have S5, noch nicht umgesetzt
 
 ---
 
 ### KI-Integration (optional)
 
-- [ ] KI-Check eines bestehenden Lernplans mit Verbesserungsvorschlägen
-- [ ] KI-gestützte alternative Planvarianten
-- [ ] KI-gestützte Aufgabenextraktion aus Lernmaterialien
+- [ ] KI-Check eines bestehenden Lernplans mit Verbesserungsvorschlägen — Could-Have, bewusst zurückgestellt
+- [ ] KI-gestützte alternative Planvarianten — Could-Have, bewusst zurückgestellt
+- [ ] KI-gestützte Aufgabenextraktion aus Lernmaterialien — Could-Have, bewusst zurückgestellt
 
 ---
 
 ### Backend & Datenbank
 
-- [ ] PostgreSQL via Docker (lokal)
-- [ ] Prisma-Schema mit allen Domain-Modellen
-- [ ] Datenbankmigrationen
-- [ ] Prisma Client eingebunden
-- [ ] API: Lernpläne (CRUD)
-- [ ] API: Aufgaben (CRUD)
-- [ ] API: Kalendertermine (CRUD)
-- [ ] API: Algorithmische Planberechnung
+- [x] PostgreSQL via Docker (lokal)
+- [x] Prisma-Schema mit allen Domain-Modellen
+- [x] Datenbankmigrationen
+- [x] Prisma Client eingebunden
+- [x] API: Lernpläne (CRUD)
+- [x] API: Aufgaben (CRUD)
+- [x] API: Kalendertermine (CRUD)
+- [x] API: Algorithmische Planberechnung
 
 ---
 
 ### Einstellungen & Sonstiges
 
-- [ ] Einstellungsseite
-- [ ] Benachrichtigungsseite
-- [ ] Profil bearbeiten (Anzeigename)
+- [x] Einstellungsseite
+- [x] Benachrichtigungsseite (persistente Präferenzen)
+- [x] Profil bearbeiten (Anzeigename, Benutzername, Profilbild)
+- [~] E-Mail-Änderung / Passwort-Reset — bewusst als Mockup, künftig über DHBW-SSO (`/forgot-password`)
+
+---
+
+### Rechtliches & Betrieb
+
+- [x] Impressum (`/impressum`)
+- [x] Datenschutzerklärung (`/datenschutz`)
+- [x] Nutzungsordnung (`/nutzungsordnung`)
+- [ ] Produktivbetrieb / Hosting — Nicht-Ziel des MVP (PRD §9)
+- [ ] Single-Sign-On (DHBW) — Could-Have / Ausblick (PRD §16)
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -374,7 +374,7 @@ Gesamtübersicht aller Features nach Bereich mit Ist-Stand zu Meilenstein 3 (Sta
 - [x] Heutige & morgige Kalendertermine
 - [x] Schnellzugriff auf aktive Lernpläne
 - [x] Visuelle Hervorhebung überfälliger Aufgaben
-- [ ] Demonstrationsdaten zum Befüllen — Should-Have S4, noch nicht umgesetzt
+- [x] Demonstrationsdaten zum Befüllen — Should-Have S4, via `npm run seed` (idempotent)
 
 ---
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -192,7 +192,6 @@ PostgreSQL-Host-Port kann lokal ueber `POSTGRES_PORT` angepasst werden.
 
 ## Offene technische Punkte
 
-- Reproduzierbare Demo-Daten beziehungsweise Seed fuer die Praesentation (Should-Have S4)
 - Automatisierte API- und End-to-End-Tests (Unit-Tests bisher nur fuer die Lernplanlogik unter `tests/study-plan/`)
 - UI-Transparenzanzeige zur Planungslogik (Should-Have S5)
 - E-Mail-Aenderung und Passwort-Reset ueber das zentrale DHBW-SSO (aktuell Mockup unter `/forgot-password`)

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -192,9 +192,10 @@ PostgreSQL-Host-Port kann lokal ueber `POSTGRES_PORT` angepasst werden.
 
 ## Offene technische Punkte
 
-- Reproduzierbare Demo-Daten beziehungsweise Seed fuer die Praesentation
-- Automatisierte API- und End-to-End-Tests
-- Persistenz der noch offenen Profil- und allgemeinen Reminder-Einstellungen
+- Reproduzierbare Demo-Daten beziehungsweise Seed fuer die Praesentation (Should-Have S4)
+- Automatisierte API- und End-to-End-Tests (Unit-Tests bisher nur fuer die Lernplanlogik unter `tests/study-plan/`)
+- UI-Transparenzanzeige zur Planungslogik (Should-Have S5)
+- E-Mail-Aenderung und Passwort-Reset ueber das zentrale DHBW-SSO (aktuell Mockup unter `/forgot-password`)
 - Produktivbetrieb, Rate Limiting und Passwort-Recovery ausserhalb des lokalen MVP
 - Externes Datei-/Objekt-Storage fuer Profilbilder bei einer spaeteren
   Produktivsetzung

--- a/docs/testing/manual-acceptance-test.md
+++ b/docs/testing/manual-acceptance-test.md
@@ -9,6 +9,15 @@
 
 ---
 
+> ⚠️ **Nur manuelle Ausführung — keine KI-Einträge.**
+> Dieser Abnahmetest wird ausschließlich von Teammitgliedern manuell ausgeführt
+> und eingetragen. KI-/Agenten-Tools dürfen hier **keine** Durchläufe abhaken
+> oder Ergebnisse eintragen. Der Eintrag vom 25.06.2026 („Claude, API-Durchlauf")
+> ist ein einmaliger, dokumentierter Vorab-Check und bleibt als Historie erhalten;
+> künftige Durchläufe erfolgen ausschließlich manuell durch das Team.
+
+---
+
 ## 1. Wie diese Datei zu benutzen ist
 
 1. Vor jedem Durchlauf eine neue Zeile in der Durchlauf-Tabelle (§2) anlegen — mit Datum, Tester, Commit-Hash und Build-Status.

--- a/docs/testing/manual-acceptance-test.md
+++ b/docs/testing/manual-acceptance-test.md
@@ -28,6 +28,7 @@ Eine Zeile pro Durchlauf. Älteste oben, neueste unten anhängen.
 | Datum      | Tester | Commit / Build                | Ergebnis                            | Notizen / Issues                                 |
 | ---------- | ------ | ----------------------------- | ----------------------------------- | ------------------------------------------------ |
 | 18.06.2026 | Finn   | `<hash>` / `npm run build` ok | `pass` / `pass with notes` / `fail` | Auffälligkeiten, Issue-Nummern, Demo-Daten-Stand |
+| 25.06.2026 | Claude | `f0e035c` / `npm run dev`     | `pass with notes`                   | UC4–UC6 auf API-Ebene verifiziert; UC5-Drag zusätzlich manuell in der UI bestätigt. Termintyp-Namen in Checkliste weichen von UI ab (z. B. „Pause" = SONSTIGES). |
 
 ---
 
@@ -199,7 +200,12 @@ Die folgenden sechs Abschnitte spiegeln UC1–UC6 aus dem PRD §7. Jeder Abschni
 
 **Tatsächliches Ergebnis** _(pro Durchlauf füllen)_
 
-- ***
+- -- Testdurchlauf 2 (Claude, API-Durchlauf) 25.06. --
+- [x] Offene Aufgaben über den verbleibenden Zeitraum neu verteilt (3 Aufgaben von 27.06. → 18.07./10.08./02.09.; `updatedTaskCount=3`).
+- [x] Bereits erledigte Aufgaben unverändert (28.06., weiterhin `completed=true`).
+- [x] Verteilung berücksichtigt verbleibende Tage/Aufwand/Schwierigkeit (gleichmäßige Spreizung bis Zieldatum).
+- [x] Verknüpfter Lernslot mitverschoben (27.06. 12:00 → 18.07. 12:00, Uhrzeit erhalten).
+- _Hinweis: Verifiziert auf API-Ebene (`POST /api/study-plan/[id]/replan` + GET-Abgleich), nicht über die UI._
 
 ### UC5 — Termin manuell pflegen
 
@@ -233,7 +239,13 @@ Die folgenden sechs Abschnitte spiegeln UC1–UC6 aus dem PRD §7. Jeder Abschni
 
 **Tatsächliches Ergebnis** _(pro Durchlauf füllen)_
 
-- ***
+- -- Testdurchlauf 2 (Claude, API-Durchlauf) 25.06. --
+- [x] Termin angelegt (`POST /api/calendar/events`, Typ SONSTIGES, eigene Farbe `bg-cyan-500`).
+- [x] Verschieben aktualisiert die Uhrzeit und ist nach erneutem GET persistent (14:00 → 16:00).
+- [x] Bearbeiten (Titel) und Löschen funktionieren ohne Fehlerabbruch (`ok=true`, danach nicht mehr in der Liste).
+- [x] Abgeleiteter/read-only Zieltermin nicht editierbar: `PATCH plan-deadline-…` → HTTP 404; `DELETE` auf unbekannte ID → HTTP 404.
+- [x] **Drag-Verschieben in der UI manuell bestätigt** (Wochenansicht): Termin per Maus gezogen, neue Zeit nach F5-Reload persistent; Klick öffnet Dialog; Bearbeiten/Löschen ohne Fehler; read-only-Termine nicht ziehbar.
+- _Hinweis: API-Ebene + manueller UI-Test (Drag/Reload) am 25.06. Der UI-Termintyp heißt „Pause" (= SONSTIGES), nicht „Sonstiges" wie in der Checkliste._
 
 ### UC6 — Abschluss einer Aufgabe
 
@@ -259,7 +271,11 @@ Die folgenden sechs Abschnitte spiegeln UC1–UC6 aus dem PRD §7. Jeder Abschni
 
 **Tatsächliches Ergebnis** _(pro Durchlauf füllen)_
 
-- ***
+- -- Testdurchlauf 2 (Claude, API-Durchlauf) 25.06. --
+- [x] Aufgabe als erledigt markiert, Erledigungszeitpunkt gespeichert (`completed=true`, `completedAt` gesetzt).
+- [x] Lernplanfortschritt aktualisiert (`completedTaskCount` 2 → 3 bei 5 Aufgaben).
+- [x] Verknüpfter Kalender-Lernslot zeigt die Erledigung (`taskCompleted=true`).
+- _Hinweis: Verifiziert auf API-Ebene (`PATCH …/tasks/[taskId]` + GET-Abgleich)._
 
 ## 5. Querschnitt — pro Durchlauf zusätzlich prüfen
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "node --test --experimental-strip-types \"tests/**/*.test.mjs\"",
+    "seed": "node --env-file=.env --experimental-strip-types scripts/seed.mjs",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// Befüllt die lokale Datenbank mit reproduzierbaren Demo-Daten für die
+// Präsentation (PRD §6.2 Should-Have S4).
+//
+// Aufruf:  npm run seed
+//
+// Eigenschaften:
+//   - Idempotent: legt einen festen Demo-Account an bzw. setzt dessen Daten
+//     bei jedem Lauf sauber neu (kein Duplizieren).
+//   - Rührt ausschließlich den Demo-Account an, keine anderen Nutzer.
+//   - Nutzt denselben Algorithmus wie die App (kein doppelter Code).
+//
+// Demo-Login:  demo@learnhub.test  /  demo12345
+
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+import { calculateStudyPlan } from "../src/lib/calculations/studyPlanAlgorithm.ts";
+
+const prisma = new PrismaClient();
+
+const DEMO_EMAIL = "demo@learnhub.test";
+const DEMO_PASSWORD = "demo12345";
+
+const now = new Date();
+/** Datum relativ zu heute, mit fester Uhrzeit (für deterministische Demo-Daten). */
+function at(daysFromNow, hour = 10, minute = 0) {
+  const d = new Date(now);
+  d.setDate(d.getDate() + daysFromNow);
+  d.setHours(hour, minute, 0, 0);
+  return d;
+}
+
+async function main() {
+  // 1. Demo-Account anlegen oder wiederverwenden (Passwort immer frisch setzen).
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 12);
+  const user = await prisma.user.upsert({
+    where: { email: DEMO_EMAIL },
+    update: { displayName: "Demo Studentin", username: "demo", passwordHash },
+    create: {
+      email: DEMO_EMAIL,
+      displayName: "Demo Studentin",
+      username: "demo",
+      passwordHash,
+      role: "USER",
+    },
+  });
+
+  // 2. Bestehende Demo-Daten entfernen (idempotent). Reihenfolge: erst Events
+  //    (referenzieren Tasks/Pläne), dann Pläne (Cascade auf Tasks), dann Rest.
+  await prisma.calendarEvent.deleteMany({ where: { ownerId: user.id } });
+  await prisma.studyPlan.deleteMany({ where: { ownerId: user.id } });
+  await prisma.notification.deleteMany({ where: { ownerId: user.id } });
+  await prisma.notificationSettings.deleteMany({ where: { ownerId: user.id } });
+
+  // 3. Standard-Benachrichtigungseinstellungen.
+  await prisma.notificationSettings.create({ data: { ownerId: user.id } });
+
+  // ── Lernplan A: Statistik Klausur (berechnet) ────────────────────────────
+  const targetA = at(35, 9);
+  const calcA = calculateStudyPlan({
+    referenceDate: now,
+    deadlineDate: targetA,
+    difficulty: 3,
+    priorKnowledge: 2,
+    pages: 120,
+    credits: 5,
+  });
+  const planA = await prisma.studyPlan.create({
+    data: {
+      title: "Statistik Klausur",
+      subject: "Statistik",
+      description: "Vorbereitung auf die Statistik-Klausur am Semesterende.",
+      goalType: "KLAUSUR",
+      targetDate: targetA,
+      ownerId: user.id,
+      difficulty: 3,
+      priorKnowledge: 2,
+      pages: 120,
+      credits: 5,
+      totalHours: calcA.totalHours,
+      hoursPerDay: calcA.hoursPerDay,
+      planType: calcA.planType,
+    },
+  });
+
+  await prisma.task.create({
+    data: { title: "Kapitel 1–3 durcharbeiten", estimatedMinutes: 180, difficulty: 3, dueDate: at(-7), completed: true, completedAt: at(-6), studyPlanId: planA.id },
+  });
+  await prisma.task.create({
+    data: { title: "Übungsblatt 1 rechnen", estimatedMinutes: 120, difficulty: 3, dueDate: at(-3), completed: true, completedAt: at(-3), studyPlanId: planA.id },
+  });
+  await prisma.task.create({
+    data: { title: "Kapitel 4: Hypothesentests", estimatedMinutes: 150, difficulty: 4, dueDate: at(-1), studyPlanId: planA.id },
+  });
+  const taskAltklausur = await prisma.task.create({
+    data: { title: "Altklausur 2024 rechnen", estimatedMinutes: 120, difficulty: 4, dueDate: at(3, 14), studyPlanId: planA.id },
+  });
+  await prisma.task.create({
+    data: { title: "Zusammenfassung erstellen", estimatedMinutes: 90, difficulty: 2, dueDate: at(10), studyPlanId: planA.id },
+  });
+
+  // Wiederkehrende Vorlesung + verknüpfte Lerneinheit zur Altklausur-Aufgabe.
+  await prisma.calendarEvent.create({
+    data: {
+      title: "Statistik Vorlesung", startsAt: at(1, 10), endsAt: at(1, 11, 30),
+      type: "VORLESUNG", typeLabel: "Vorlesung", subject: "Statistik",
+      repeat: "weekly", source: "LOCAL", ownerId: user.id, studyPlanId: planA.id,
+    },
+  });
+  await prisma.calendarEvent.create({
+    data: {
+      title: "Lernsession: Altklausur 2024", startsAt: at(3, 14), endsAt: at(3, 16),
+      type: "LERNEINHEIT", typeLabel: "Lernsession", subject: "Statistik",
+      source: "LOCAL", ownerId: user.id, studyPlanId: planA.id, taskId: taskAltklausur.id,
+    },
+  });
+
+  // ── Lernplan B: Software Engineering Abgabe (berechnet) ───────────────────
+  const targetB = at(14, 9);
+  const calcB = calculateStudyPlan({
+    referenceDate: now,
+    deadlineDate: targetB,
+    difficulty: 4,
+    priorKnowledge: 3,
+    pages: 80,
+    credits: 6,
+  });
+  const planB = await prisma.studyPlan.create({
+    data: {
+      title: "Software Engineering Abgabe",
+      subject: "Software Engineering",
+      description: "Projektabgabe inkl. Dokumentation.",
+      goalType: "ABGABE",
+      targetDate: targetB,
+      ownerId: user.id,
+      difficulty: 4,
+      priorKnowledge: 3,
+      pages: 80,
+      credits: 6,
+      totalHours: calcB.totalHours,
+      hoursPerDay: calcB.hoursPerDay,
+      planType: calcB.planType,
+    },
+  });
+
+  await prisma.task.create({
+    data: { title: "Anforderungen analysieren", estimatedMinutes: 120, difficulty: 3, dueDate: at(-2), completed: true, completedAt: at(-2), studyPlanId: planB.id },
+  });
+  const taskKlassen = await prisma.task.create({
+    data: { title: "Klassendiagramm erstellen", estimatedMinutes: 120, difficulty: 3, dueDate: at(2, 16), studyPlanId: planB.id },
+  });
+  await prisma.task.create({
+    data: { title: "Implementierung Modul Auth", estimatedMinutes: 240, difficulty: 4, dueDate: at(6), studyPlanId: planB.id },
+  });
+  await prisma.task.create({
+    data: { title: "Dokumentation schreiben", estimatedMinutes: 90, difficulty: 2, dueDate: at(11), studyPlanId: planB.id },
+  });
+
+  await prisma.calendarEvent.create({
+    data: {
+      title: "Lernsession: Klassendiagramm", startsAt: at(2, 16), endsAt: at(2, 18),
+      type: "LERNEINHEIT", typeLabel: "Lernsession", subject: "Software Engineering",
+      source: "LOCAL", ownerId: user.id, studyPlanId: planB.id, taskId: taskKlassen.id,
+    },
+  });
+
+  // ── Lernplan C: Lineare Algebra (manuell, ohne Algorithmus) ───────────────
+  const planC = await prisma.studyPlan.create({
+    data: {
+      title: "Lineare Algebra wiederholen",
+      subject: "Mathematik",
+      description: "Selbstlernziel zur Auffrischung der Grundlagen.",
+      goalType: "SELBSTLERNZIEL",
+      targetDate: at(50, 9),
+      ownerId: user.id,
+    },
+  });
+  await prisma.task.create({
+    data: { title: "Vektorräume wiederholen", estimatedMinutes: 90, difficulty: 2, dueDate: at(5), studyPlanId: planC.id },
+  });
+  await prisma.task.create({
+    data: { title: "Eigenwerte & Eigenvektoren üben", estimatedMinutes: 120, difficulty: 3, dueDate: at(12), studyPlanId: planC.id },
+  });
+
+  // ── Eigenständiger Termin (Typ Sonstiges) ────────────────────────────────
+  await prisma.calendarEvent.create({
+    data: {
+      title: "Sprechstunde Prof. Schmidt", startsAt: at(1, 14), endsAt: at(1, 15),
+      type: "SONSTIGES", typeLabel: "Sonstiges", subject: "Organisatorisches",
+      source: "LOCAL", ownerId: user.id,
+    },
+  });
+
+  const planCount = await prisma.studyPlan.count({ where: { ownerId: user.id } });
+  const taskCount = await prisma.task.count({ where: { studyPlan: { ownerId: user.id } } });
+  const eventCount = await prisma.calendarEvent.count({ where: { ownerId: user.id } });
+
+  console.log("\n✓ Demo-Daten erstellt:");
+  console.log(`  Login:        ${DEMO_EMAIL} / ${DEMO_PASSWORD}`);
+  console.log(`  Lernpläne:    ${planCount} (A=berechnet ${calcA.planType}, B=berechnet ${calcB.planType}, C=manuell)`);
+  console.log(`  Aufgaben:     ${taskCount} (inkl. erledigter und einer überfälligen)`);
+  console.log(`  Termine:      ${eventCount} (Vorlesung, Lerneinheiten, Sonstiges)`);
+  console.log("\n  Hinweis: Zieltermine erscheinen automatisch im Kalender (aus targetDate abgeleitet).\n");
+}
+
+main()
+  .catch((error) => {
+    console.error("\n✗ Seed fehlgeschlagen:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/datenschutz/page.tsx
+++ b/src/app/datenschutz/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Datenschutzerklärung – LearnHub",
+  description:
+    "Informationen zur Verarbeitung personenbezogener Daten in der LearnHub-Anwendung.",
+};
+
+export default function DatenschutzPage() {
+  return (
+    <LegalPageLayout
+      title="Datenschutzerklärung"
+      intro="Diese Erklärung beschreibt, welche Daten LearnHub verarbeitet und zu welchem Zweck. LearnHub wird als studentischer Prototyp lokal betrieben."
+      updatedAt="25. Juni 2026"
+    >
+      <section className="space-y-3">
+        <h2>1. Verantwortlicher</h2>
+        <p>
+          Verantwortlich für die Datenverarbeitung ist das Projektteam LearnHub
+          (Anwendungsprojekt Informatik, DHBW). Kontaktangaben finden sich im{" "}
+          <a href="/impressum">Impressum</a>.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>2. Grundsatz: lokaler Betrieb, Datensparsamkeit</h2>
+        <p>
+          LearnHub ist im Rahmen des Projekts für den lokalen Betrieb auf einem
+          Entwicklungsrechner ausgelegt. Es findet kein öffentliches Hosting im
+          Internet statt. Es werden ausschließlich die für die Funktion
+          notwendigen Daten erhoben. Es werden <strong>keine</strong> externen
+          Analyse-, Tracking- oder Werbedienste eingesetzt.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>3. Welche Daten verarbeitet werden</h2>
+        <h3>Kontodaten</h3>
+        <ul>
+          <li>E-Mail-Adresse</li>
+          <li>Anzeigename und optionaler Benutzername</li>
+          <li>Passwort – ausschließlich als bcrypt-Hash gespeichert, niemals im Klartext</li>
+          <li>Optionales Profilbild (lokal in der Datenbank gespeichert)</li>
+        </ul>
+        <h3>Lerndaten (vom Nutzer eingegeben)</h3>
+        <ul>
+          <li>Lernpläne (Titel, Fach, Zieltyp, Zieldatum, Algorithmus-Eingaben)</li>
+          <li>Aufgaben (Titel, Aufwand, Schwierigkeit, Fälligkeit, Status)</li>
+          <li>Kalendertermine und ggf. konfigurierte externe Kalenderquellen</li>
+          <li>Benachrichtigungs- und Einstellungspräferenzen</li>
+          <li>Optional eingereichtes Feedback</li>
+        </ul>
+        <h3>Technisch notwendige Daten</h3>
+        <ul>
+          <li>
+            Sitzungs-Cookie (<code>lh_session</code>) als HTTP-Only-Cookie zur
+            Aufrechterhaltung der Anmeldung
+          </li>
+          <li>Zeitstempel zu Erstellung und Änderung von Datensätzen</li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2>4. Zwecke und Rechtsgrundlage</h2>
+        <p>
+          Die Verarbeitung erfolgt ausschließlich zur Bereitstellung der
+          Anwendungsfunktionen (Konto, Lernplanung, Kalender, Benachrichtigungen)
+          auf Grundlage der Nutzung der Anwendung durch die angemeldete Person.
+          Jeder Nutzer sieht und verwaltet ausschließlich seine eigenen Daten;
+          ein Zugriff anderer Nutzerkonten auf diese Daten ist technisch
+          ausgeschlossen.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>5. Cookies</h2>
+        <p>
+          LearnHub setzt ein technisch notwendiges Sitzungs-Cookie
+          (<code>lh_session</code>, <code>HttpOnly</code>,{" "}
+          <code>SameSite=Lax</code>), um den Anmeldestatus zu speichern. Es
+          werden keine Tracking- oder Marketing-Cookies verwendet.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>6. Externe Kalenderquellen</h2>
+        <p>
+          Wenn ein Nutzer eine externe Kalenderquelle (z. B. den DHBW-ICS-Feed)
+          konfiguriert, ruft LearnHub die hinterlegte Adresse serverseitig ab, um
+          die Termine anzuzeigen. Dabei wird die konfigurierte URL an den jeweils
+          externen Anbieter übermittelt. Für die Datenverarbeitung des externen
+          Anbieters ist dessen Datenschutzerklärung maßgeblich.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>7. Speicherdauer</h2>
+        <p>
+          Konto- und Lerndaten werden gespeichert, solange das Nutzerkonto
+          besteht. Sitzungen laufen nach Ablauf der hinterlegten Gültigkeit oder
+          bei Abmeldung ab. Mit dem Löschen eines Lernplans werden die zugehörigen
+          Aufgaben und generierten Lerneinheiten mitgelöscht.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>8. Rechte der betroffenen Person</h2>
+        <p>
+          Im Rahmen der geltenden Datenschutzbestimmungen bestehen die Rechte auf
+          Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung sowie
+          Datenübertragbarkeit. Anfragen können über die im Impressum genannte
+          Kontaktadresse gerichtet werden.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>9. Datensicherheit</h2>
+        <p>
+          Passwörter werden ausschließlich gehasht gespeichert (bcrypt).
+          Sitzungen werden über HTTP-Only-Cookies abgewickelt. Da die Anwendung
+          im Projektkontext lokal betrieben wird, hängt die Gesamtsicherheit
+          zusätzlich von der Absicherung des jeweiligen Betriebsumfelds ab.
+        </p>
+      </section>
+    </LegalPageLayout>
+  );
+}

--- a/src/app/datenschutz/page.tsx
+++ b/src/app/datenschutz/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
 
 export const metadata: Metadata = {
@@ -19,7 +20,7 @@ export default function DatenschutzPage() {
         <p>
           Verantwortlich für die Datenverarbeitung ist das Projektteam LearnHub
           (Anwendungsprojekt Informatik, DHBW). Kontaktangaben finden sich im{" "}
-          <a href="/impressum">Impressum</a>.
+          <Link href="/impressum">Impressum</Link>.
         </p>
       </section>
 

--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Impressum – LearnHub",
+  description: "Angaben gemäß § 5 DDG zum studentischen Projekt LearnHub.",
+};
+
+export default function ImpressumPage() {
+  return (
+    <LegalPageLayout
+      title="Impressum"
+      intro="Angaben gemäß § 5 Digitale-Dienste-Gesetz (DDG)."
+      updatedAt="25. Juni 2026"
+    >
+      <section className="space-y-3">
+        <h2>Projektkontext</h2>
+        <p>
+          LearnHub ist eine im Rahmen des Anwendungsprojekts im Studiengang
+          Informatik an der Dualen Hochschule Baden-Württemberg (DHBW)
+          entwickelte Lernmanagement-Anwendung. Es handelt sich um ein
+          nicht-kommerzielles studentisches Hochschulprojekt, das ausschließlich
+          zu Studien- und Demonstrationszwecken betrieben wird. Ein öffentlicher
+          Produktivbetrieb findet im Rahmen des Projekts nicht statt.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>Verantwortlich für den Inhalt</h2>
+        <p>
+          Projektteam LearnHub (Anwendungsprojekt Informatik)
+          <br />
+          Duale Hochschule Baden-Württemberg Lörrach
+          <br />
+          Hangstraße 46-50
+          <br />
+          79539 Lörrach
+          <br />
+          E-Mail: projekt@dhbw-loerrach.de
+        </p>
+        <p>
+          Projektteam: Lucas Sedelmayr (Projektleitung), Lennard Wiek, Yannik
+          Roeder, Finn Pfleghaar, Fabian Winterhalter.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>Betreuung</h2>
+        <p>
+          Betreuender Dozent / Auftraggeber: Prof. Dr. Erik Behrends, DHBW.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>Haftung für Inhalte</h2>
+        <p>
+          Die Anwendung wird als Prototyp im Rahmen eines Studienprojekts
+          bereitgestellt. Für die Richtigkeit, Vollständigkeit und Aktualität
+          der bereitgestellten Funktionen und Inhalte wird keine Gewähr
+          übernommen. Eine Nutzung erfolgt im Rahmen des Projektkontexts.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>Urheberrecht</h2>
+        <p>
+          Die im Rahmen des Projekts erstellten Inhalte und Werke unterliegen dem
+          Urheberrecht. Verwendete Marken (z. B. das DHBW-Logo) sind Eigentum der
+          jeweiligen Rechteinhaber und werden ausschließlich im Hochschulkontext
+          genutzt.
+        </p>
+      </section>
+    </LegalPageLayout>
+  );
+}

--- a/src/app/nutzungsordnung/page.tsx
+++ b/src/app/nutzungsordnung/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
+
+export const metadata: Metadata = {
+  title: "Nutzungsordnung – LearnHub",
+  description: "Regeln und Hinweise zur Nutzung der LearnHub-Anwendung.",
+};
+
+export default function NutzungsordnungPage() {
+  return (
+    <LegalPageLayout
+      title="Nutzungsordnung"
+      intro="Diese Nutzungsordnung beschreibt den vorgesehenen Einsatz von LearnHub im Rahmen des Hochschulprojekts."
+      updatedAt="25. Juni 2026"
+    >
+      <section className="space-y-3">
+        <h2>1. Geltungsbereich und Zweck</h2>
+        <p>
+          LearnHub ist ein studentischer Prototyp zur persönlichen Lernplanung
+          (Lernpläne, Aufgaben, Kalender, Benachrichtigungen). Die Anwendung ist
+          für die Selbstorganisation einer einzelnen studierenden Person ausgelegt
+          und nicht für Lerngruppen, Dozierende oder den institutionellen Einsatz
+          konzipiert.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>2. Konto und Zugangsdaten</h2>
+        <ul>
+          <li>
+            Jede Person ist für die Geheimhaltung ihres Passworts und die
+            Nutzung ihres Kontos selbst verantwortlich.
+          </li>
+          <li>
+            Konten sind persönlich; eine Weitergabe der Zugangsdaten ist nicht
+            vorgesehen.
+          </li>
+          <li>
+            Das Zurücksetzen des Passworts ist im aktuellen Stand noch nicht
+            angebunden und soll künftig über das zentrale DHBW-Login (SSO)
+            erfolgen.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2>3. Zulässige Nutzung</h2>
+        <ul>
+          <li>
+            Die Anwendung darf ausschließlich zu den vorgesehenen Lern- und
+            Organisationszwecken genutzt werden.
+          </li>
+          <li>
+            Es dürfen keine rechtswidrigen, beleidigenden oder
+            persönlichkeitsverletzenden Inhalte eingegeben werden.
+          </li>
+          <li>
+            Versuche, die Anwendung zu manipulieren, zu überlasten oder auf Daten
+            anderer Konten zuzugreifen, sind untersagt.
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2>4. Inhalte der Nutzer</h2>
+        <p>
+          Für die selbst eingegebenen Inhalte (z. B. Lernpläne, Aufgaben,
+          Termine, Feedback) ist die jeweilige Person verantwortlich. Da es sich
+          um einen Prototyp handelt, sollten keine besonders sensiblen oder
+          unwiederbringlich wichtigen Daten ausschließlich in LearnHub gespeichert
+          werden.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>5. Verfügbarkeit und Gewährleistung</h2>
+        <p>
+          LearnHub wird als Projekt-Prototyp ohne Anspruch auf dauerhafte
+          Verfügbarkeit, Fehlerfreiheit oder Datenerhalt bereitgestellt.
+          Einzelne Funktionsbereiche können als Vorschau (Mockup) gekennzeichnet
+          oder noch nicht vollständig angebunden sein. Eine Haftung für Schäden
+          aus der Nutzung wird im Rahmen des gesetzlich Zulässigen ausgeschlossen.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2>6. Datenschutz</h2>
+        <p>
+          Einzelheiten zur Verarbeitung personenbezogener Daten finden sich in der{" "}
+          <a href="/datenschutz">Datenschutzerklärung</a>.
+        </p>
+      </section>
+    </LegalPageLayout>
+  );
+}

--- a/src/app/nutzungsordnung/page.tsx
+++ b/src/app/nutzungsordnung/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { LegalPageLayout } from "@/components/legal/LegalPageLayout";
 
 export const metadata: Metadata = {
@@ -87,7 +88,7 @@ export default function NutzungsordnungPage() {
         <h2>6. Datenschutz</h2>
         <p>
           Einzelheiten zur Verarbeitung personenbezogener Daten finden sich in der{" "}
-          <a href="/datenschutz">Datenschutzerklärung</a>.
+          <Link href="/datenschutz">Datenschutzerklärung</Link>.
         </p>
       </section>
     </LegalPageLayout>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -165,6 +165,19 @@ export function Sidebar({ currentUser, notificationSummary }: SidebarProps) {
           </span>
         </div>
       </Link>
+
+      {/* Rechtliches */}
+      <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 px-2 text-[11px] text-sidebar-foreground/50">
+        <Link href="/impressum" className="hover:text-white hover:underline">
+          Impressum
+        </Link>
+        <Link href="/datenschutz" className="hover:text-white hover:underline">
+          Datenschutz
+        </Link>
+        <Link href="/nutzungsordnung" className="hover:text-white hover:underline">
+          Nutzung
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -175,7 +175,7 @@ export function Sidebar({ currentUser, notificationSummary }: SidebarProps) {
           Datenschutz
         </Link>
         <Link href="/nutzungsordnung" className="hover:text-white hover:underline">
-          Nutzung
+          Nutzungsordnung
         </Link>
       </div>
     </div>

--- a/src/components/legal/LegalPageLayout.tsx
+++ b/src/components/legal/LegalPageLayout.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
+
+interface LegalPageLayoutProps {
+  /** Seitentitel (z. B. „Impressum"). */
+  title: string;
+  /** Kurzer einleitender Satz unter dem Titel. */
+  intro: string;
+  /** Stand-Datum der Seite, z. B. „25. Juni 2026". */
+  updatedAt: string;
+  /** Seiteninhalt (Abschnitte). */
+  children: React.ReactNode;
+}
+
+/**
+ * Gemeinsames Layout der rechtlichen Seiten (Impressum, Datenschutz,
+ * Nutzungsordnung). Ruhiges, akademisch-professionelles Lese-Layout ohne
+ * Sidebar – die Seiten sind öffentlich erreichbar (siehe middleware.ts).
+ */
+export function LegalPageLayout({
+  title,
+  intro,
+  updatedAt,
+  children,
+}: LegalPageLayoutProps) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="border-b border-gray-200 bg-white">
+        <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-6 py-4">
+          <Link href="/login" aria-label="Zur Startseite">
+            <LearnHubBrand
+              className="gap-2"
+              markClassName="h-8 w-11"
+              markVariant="plain"
+              hubClassName="text-brand-red"
+            />
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-brand-red hover:text-brand-red-dark hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Zurück
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl px-6 py-10">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900">{title}</h1>
+        <p className="mt-3 text-gray-600">{intro}</p>
+        <p className="mt-2 text-sm text-gray-400">Stand: {updatedAt}</p>
+
+        <article className="mt-8 space-y-8 text-sm leading-relaxed text-gray-700 [&_a]:font-medium [&_a]:text-brand-red [&_a:hover]:underline [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h3]:font-semibold [&_h3]:text-gray-900 [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5">
+          {children}
+        </article>
+
+        <footer className="mt-12 flex flex-wrap gap-x-6 gap-y-2 border-t border-gray-200 pt-6 text-sm text-gray-500">
+          <Link href="/impressum" className="hover:text-brand-red hover:underline">
+            Impressum
+          </Link>
+          <Link href="/datenschutz" className="hover:text-brand-red hover:underline">
+            Datenschutzerklärung
+          </Link>
+          <Link href="/nutzungsordnung" className="hover:text-brand-red hover:underline">
+            Nutzungsordnung
+          </Link>
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/components/login/AuthSplitLayout.tsx
+++ b/src/components/login/AuthSplitLayout.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 import { LearnHubBrand } from "@/components/brand/LearnHubBrand";
 import { LanguageSelect } from "@/lib/i18n/LanguageProvider";
 
@@ -91,11 +92,22 @@ export function AuthSplitLayout({
         </div>
       </div>
 
-      <div className="relative flex flex-1 items-center justify-center bg-gray-50 p-6 lg:p-12">
+      <div className="relative flex flex-1 flex-col items-center justify-center bg-gray-50 p-6 lg:p-12">
         <div className="absolute right-5 top-5">
           <LanguageSelect />
         </div>
-        {children}
+        <div className="flex w-full flex-1 items-center justify-center">{children}</div>
+        <footer className="flex flex-wrap justify-center gap-x-5 gap-y-1 pt-6 text-xs text-gray-400">
+          <Link href="/impressum" className="hover:text-brand-red hover:underline">
+            Impressum
+          </Link>
+          <Link href="/datenschutz" className="hover:text-brand-red hover:underline">
+            Datenschutz
+          </Link>
+          <Link href="/nutzungsordnung" className="hover:text-brand-red hover:underline">
+            Nutzungsordnung
+          </Link>
+        </footer>
       </div>
     </div>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,7 +18,15 @@ const AUTH_ENABLED = true;
 const ADMIN_ROLE = "ADMIN";
 const DEV_ROLE = "DEV";
 
-const PUBLIC_PATHS = ["/login", "/register", "/forgot-password", "/api/auth"];
+const PUBLIC_PATHS = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/impressum",
+  "/datenschutz",
+  "/nutzungsordnung",
+  "/api/auth",
+];
 
 function isPublicPath(pathname: string) {
   return PUBLIC_PATHS.some(


### PR DESCRIPTION
## Worum geht es

Vorbereitung auf **Meilenstein 3**: schließt die dokumentarischen und rechtlichen Lieferobjekt-Lücken. Keine Änderung an der bestehenden Fachlogik.

## Änderungen

### Rechtliches (neue öffentliche Seiten)
- `/impressum`, `/datenschutz`, `/nutzungsordnung` mit gemeinsamem `LegalPageLayout`
- In der Middleware als öffentlich freigegeben, über Footer-Links (Auth-Layout + Sidebar) erreichbar
- Datenschutz inhaltlich am echten Datenmodell ausgerichtet (bcrypt, `lh_session`, ICS-Quelle, gespeicherte Felder)

### Dokumentation
- Neu: `docs/architecture.md` (Architekturüberblick), `docs/handover.md` (Übergabedoku), `docs/mockups.md` (Mockup-/Lücken-Übersicht)
- PRD §17 Feature-Checkliste mit Ist-Stand befüllt (`[x]/[~]/[ ]`)
- `CLAUDE.md` (Bekannte Baustellen) und `tech-stack.md` (offene Punkte) aktualisiert
- README um die neuen Dokumente erweitert
- Manueller Abnahmetest: UC4–UC6 dokumentiert (auf API-Ebene verifiziert, UC5-Drag zusätzlich manuell in der UI bestätigt)

## Qualität
- `npm run typecheck`, `lint`, `build` und `test` (17/17) grün
- Die drei Rechtsseiten werden statisch vorgerendert

## Hinweis
Impressum-Anschrift (DHBW Lörrach) und Kontakt `projekt@dhbw-loerrach.de` bitte final gegenprüfen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)