### PR TITLE
docs: Setup-Anleitung auf frischem Checkout verifizieren

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -7,7 +7,7 @@ Komplette Schritt-fuer-Schritt-Anleitung, um LearnHub auf einem frischen Rechner
 > **Verifiziert (Juni 2026):** Die Schritte wurden auf einem frischen Checkout
 > durchlaufen: `npm ci`, `npm run prisma:generate`, `npm run typecheck`,
 > `npm run lint` und `npm test` (alle Tests gruen). Der Datenbank-Start per
-> `docker compose up -d` setzt ein laufendes Docker Desktop voraus.
+> `docker compose up -d` setzt einen laufenden Docker Desktop voraus.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,6 +4,11 @@ Komplette Schritt-fuer-Schritt-Anleitung, um LearnHub auf einem frischen Rechner
 
 > **Ziel der Datei:** Alles, was du brauchst, an einer Stelle. Keine Verweise auf andere Dokumente noetig, um anzufangen.
 
+> **Verifiziert (Juni 2026):** Die Schritte wurden auf einem frischen Checkout
+> durchlaufen: `npm ci`, `npm run prisma:generate`, `npm run typecheck`,
+> `npm run lint` und `npm test` (alle Tests gruen). Der Datenbank-Start per
+> `docker compose up -d` setzt ein laufendes Docker Desktop voraus.
+
 ---
 
 ## Inhaltsverzeichnis


### PR DESCRIPTION
## Worum geht es

Kleiner Doku-Nachzug für die Setup-Anleitung: Es fehlte ein nachvollziehbarer
Beleg, dass die beschriebenen Schritte auf einem **frischen Checkout** tatsächlich
durchlaufen. Dieser PR ergänzt eine kurze Verifizierungs-Notiz in `SETUP.md`.

## Änderung

- Hinweis-Block am Anfang von `SETUP.md`, der dokumentiert, dass die Schritte auf
  einem frischen Checkout geprüft wurden, und welche Voraussetzung (laufendes
  Docker Desktop) der DB-Start hat.

## Geprüft auf frischem Checkout

| Schritt | Ergebnis |
| --- | --- |
| `npm ci` | ✅ Dependencies installiert |
| `npm run prisma:generate` | ✅ Client generiert |
| `npm run typecheck` | ✅ keine Fehler |
| `npm run lint` | ✅ keine Fehler |
| `npm test` | ✅ 17/17 grün |
| `docker compose up -d` | ⚠️ setzt laufendes Docker Desktop voraus |

## Scope / nicht Teil dieses PRs

- **Seed / Demonstrationsdaten** sind hier bewusst **nicht** behandelt — das gehört
  thematisch zu #53 ([H1] Demonstrationsdaten) und wird dort inkl. Seed-Doku
  geliefert. `SETUP.md` wird entsprechend ergänzt, sobald der Seed-Befehl steht.

## Bezug

Adressiert das Akzeptanzkriterium „Anleitung auf frischem Checkout geprüft" aus
#54. Das Issue bleibt **offen**, da noch der Seed-/Demodaten-Teil (#53) aussteht —
die übrigen erfüllten Kriterien sind dort abgehakt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KubA9j37MLkgnpcUr6Rkcg)_