### PR TITLE
feat: custom calendar picker for study plan form

### DIFF
--- a/src/components/calendar/DateTimePicker.tsx
+++ b/src/components/calendar/DateTimePicker.tsx
@@ -19,6 +19,10 @@ interface DateTimePickerProps {
   dateOnly?: boolean;
   allowMidnight?: boolean;
   stage?: "start" | "end";
+  /** Ersetzt den Standard-Trigger-Button-Style (dunkles Theme). */
+  triggerClassName?: string;
+  /** Platzhaltertext wenn kein Datum gewählt (value leer). */
+  placeholder?: string;
   onOpenChange: (open: boolean) => void;
   onChange: (value: string) => void;
   onComplete?: () => void;
@@ -135,6 +139,8 @@ export function DateTimePicker({
   dateOnly = false,
   allowMidnight = false,
   stage,
+  triggerClassName,
+  placeholder,
   onOpenChange,
   onChange,
   onComplete,
@@ -210,11 +216,16 @@ export function DateTimePicker({
         id={id}
         type="button"
         onClick={() => onOpenChange(!open)}
-        className="flex w-full items-center gap-2 rounded-xl border border-slate-700 bg-slate-800 px-3 py-2.5 text-left text-sm font-medium text-white shadow-sm transition-colors hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-red/40"
+        className={
+          triggerClassName ??
+          "flex w-full items-center gap-2 rounded-xl border border-slate-700 bg-slate-800 px-3 py-2.5 text-left text-sm font-medium text-white shadow-sm transition-colors hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-brand-red/40"
+        }
         aria-expanded={open}
       >
         <CalendarDays className="h-4 w-4 shrink-0 text-red-400" />
-        <span className="truncate">{formatValue(value, dateOnly)}</span>
+        <span className={`truncate ${!value && placeholder ? "text-gray-400" : ""}`}>
+          {!value && placeholder ? placeholder : formatValue(value, dateOnly)}
+        </span>
       </button>
 
       {open && (

--- a/src/components/study-plan/StudyPlanForm.tsx
+++ b/src/components/study-plan/StudyPlanForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Calculator, X } from "lucide-react";
 import { EditableCombobox } from "@/components/calendar/EditableCombobox";
+import { DateTimePicker } from "@/components/calendar/DateTimePicker";
 import { GOAL_TYPE_META, fromDateInputValue, toDateInputValue } from "./planMeta";
 import type { StudyPlanDTO } from "@/lib/study-plan/types";
 import { GOAL_TYPES } from "@/lib/study-plan/types";
@@ -33,6 +34,7 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
   const [credits, setCredits] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [subjectOptions, setSubjectOptions] = useState<string[]>([]);
 
   // Fächer-Vorschläge aus dem Kalender laden (eigene Fächer + DHBW-Veranstaltungen).
@@ -221,19 +223,17 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
             </div>
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label htmlFor="sp-target-date" className="text-xs font-semibold text-gray-700">
-              Zieldatum
-            </label>
-            <input
-              id="sp-target-date"
-              type="date"
-              required
-              value={targetDate}
-              onChange={(e) => setTargetDate(e.target.value)}
-              className={inputClass}
-            />
-          </div>
+          <DateTimePicker
+            id="sp-target-date"
+            label="Zieldatum"
+            value={targetDate ? `${targetDate}T12:00` : ""}
+            open={datePickerOpen}
+            dateOnly
+            placeholder="Datum wählen"
+            triggerClassName="flex w-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-left text-sm text-gray-900 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-red/30 focus:border-brand-red dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:hover:bg-gray-700"
+            onOpenChange={setDatePickerOpen}
+            onChange={(value) => setTargetDate(value.slice(0, 10))}
+          />
 
           <div className="flex flex-col gap-1">
             <label htmlFor="sp-description" className="text-xs font-semibold text-gray-700">

--- a/src/components/study-plan/StudyPlanForm.tsx
+++ b/src/components/study-plan/StudyPlanForm.tsx
@@ -37,6 +37,10 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [subjectOptions, setSubjectOptions] = useState<string[]>([]);
 
+  useEffect(() => {
+    if (!open) setDatePickerOpen(false);
+  }, [open]);
+
   // Fächer-Vorschläge aus dem Kalender laden (eigene Fächer + DHBW-Veranstaltungen).
   // Freitext bleibt weiterhin möglich – die Liste ist nur eine Auswahlhilfe.
   useEffect(() => {

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -195,6 +195,7 @@ export const exactTranslations: Record<string, string> = {
   "1 Tag vorher": "1 day before",
   "3 Tage vorher": "3 days before",
   "Datum": "Date",
+  "Datum wählen": "Choose date",
   "Bearbeiten": "Edit",
   "Beginn": "Start",
   "Benutzer": "Users",


### PR DESCRIPTION
## Summary

- Replaces the browser-native `<input type="date">` in `StudyPlanForm` with the same `DateTimePicker` calendar UI used in the event creation modal
- The calendar popup is visually identical (dark theme, `<`/`>` month navigation, consistent day grid, brand-red highlight for selected day)
- Time selection, start/end stage indicator, and time wheel are all suppressed via `dateOnly={true}` — only the calendar is shown
- The trigger button uses a light style matching the rest of the form (white background, gray border), with dark-mode variants

## Changes

| File | What changed |
|---|---|
| `src/components/calendar/DateTimePicker.tsx` | Added optional `triggerClassName` and `placeholder` props — no breaking changes, existing usage unchanged |
| `src/components/study-plan/StudyPlanForm.tsx` | Replaced `<input type="date">` with `DateTimePicker dateOnly`; added `datePickerOpen` state and inline `YYYY-MM-DD` ↔ `datetime-local` format conversion |
| `src/lib/i18n/translations.ts` | Added `"Datum wählen"` → `"Choose date"` for EN locale |

## Reviewer notes

- `DateTimePicker` receives `value={targetDate ? \`${targetDate}T12:00\` : ""}` — noon is used to avoid timezone-offset edge cases when slicing back to `YYYY-MM-DD`
- The `placeholder` prop shows "Datum wählen" / "Choose date" when no date is selected yet; the existing form validation still enforces `targetDate` is non-empty before submitting
- `triggerClassName` overrides the default dark button only in this one call site — the event modal continues to use the default dark style unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)