### PR TITLE
feat: optional start/end time for study plan deadline

### DIFF
--- a/prisma/migrations/20260626100919_add_study_plan_target_date_end/migration.sql
+++ b/prisma/migrations/20260626100919_add_study_plan_target_date_end/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "StudyPlan" ADD COLUMN     "targetDateEnd" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,9 +75,10 @@ model StudyPlan {
   title       String
   subject     String   // Veranstaltung / Fach
   description String?
-  goalType    GoalType
-  targetDate  DateTime
-  ownerId     String
+  goalType      GoalType
+  targetDate    DateTime
+  targetDateEnd DateTime? // null = ganztägig; gesetzt = Endzeit der Klausur
+  ownerId       String
 
   // Algorithmus-Eingaben (optional, nur gesetzt wenn ein Plan berechnet wurde).
   // Siehe docs/Algorithmus/Algorithmus_neue_Formel.md.

--- a/src/app/api/study-plan/[id]/route.ts
+++ b/src/app/api/study-plan/[id]/route.ts
@@ -99,6 +99,18 @@ export async function PATCH(
     target = t;
   }
 
+  if ("targetDateEnd" in b) {
+    if (b.targetDateEnd === null) {
+      data.targetDateEnd = null;
+    } else if (typeof b.targetDateEnd === "string" && b.targetDateEnd) {
+      const te = new Date(b.targetDateEnd);
+      if (Number.isNaN(te.getTime()) || te.getTime() <= target.getTime()) {
+        return NextResponse.json({ error: "Ungültige Endzeit." }, { status: 400 });
+      }
+      data.targetDateEnd = te;
+    }
+  }
+
   // Algorithmus-Eingaben mergen: aus Body wenn vorhanden, sonst Bestand.
   const diff = "difficulty" in b ? toIntInRange(b.difficulty, 1, 5) : existing.difficulty;
   const know = "priorKnowledge" in b ? toIntInRange(b.priorKnowledge, 1, 5) : existing.priorKnowledge;

--- a/src/app/api/study-plan/route.ts
+++ b/src/app/api/study-plan/route.ts
@@ -74,6 +74,7 @@ export async function POST(req: Request) {
     description,
     goalType,
     targetDate,
+    targetDateEnd,
     difficulty,
     priorKnowledge,
     pages,
@@ -94,9 +95,18 @@ export async function POST(req: Request) {
     );
   }
 
-  const target = new Date(targetDate);
+  const target = new Date(targetDate as string);
   if (Number.isNaN(target.getTime())) {
     return NextResponse.json({ error: "Ungültiges Zieldatum." }, { status: 400 });
+  }
+
+  let targetEnd: Date | null = null;
+  if (typeof targetDateEnd === "string" && targetDateEnd) {
+    const te = new Date(targetDateEnd);
+    if (Number.isNaN(te.getTime()) || te.getTime() <= target.getTime()) {
+      return NextResponse.json({ error: "Ungültige Endzeit." }, { status: 400 });
+    }
+    targetEnd = te;
   }
 
   // Algorithmus-Eingaben (optional). Nur wenn alle vier vorhanden sind, wird gerechnet.
@@ -132,14 +142,15 @@ export async function POST(req: Request) {
 
   const plan = await prisma.studyPlan.create({
     data: {
-      title: title.trim(),
-      subject: subject.trim(),
+      title: (title as string).trim(),
+      subject: (subject as string).trim(),
       description:
         typeof description === "string" && description.trim()
           ? description.trim()
           : null,
-      goalType,
+      goalType: goalType as import("@prisma/client").GoalType,
       targetDate: target,
+      targetDateEnd: targetEnd,
       ownerId: session.userId,
       difficulty: diff,
       priorKnowledge: know,

--- a/src/components/study-plan/StudyPlanDetail.tsx
+++ b/src/components/study-plan/StudyPlanDetail.tsx
@@ -181,6 +181,14 @@ export function StudyPlanDetail({ planId }: StudyPlanDetailProps) {
         <div className="flex items-center gap-2 text-sm text-gray-600">
           <CalendarDays className="w-4 h-4 text-gray-400" />
           <span>{formatDate(plan.targetDate)}</span>
+          {plan.targetDateEnd && (
+            <span className="text-gray-400">
+              {new Date(plan.targetDate).toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" })}
+              {" – "}
+              {new Date(plan.targetDateEnd).toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" })}
+              {" Uhr"}
+            </span>
+          )}
           <span className={cn("text-xs font-medium", remaining.className)}>
             {remaining.text}
           </span>

--- a/src/components/study-plan/StudyPlanForm.tsx
+++ b/src/components/study-plan/StudyPlanForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Calculator, X } from "lucide-react";
+import { Calculator, CalendarDays, X } from "lucide-react";
 import { EditableCombobox } from "@/components/calendar/EditableCombobox";
+import { DateTimePicker } from "@/components/calendar/DateTimePicker";
 import { GOAL_TYPE_META, fromDateInputValue, toDateInputValue } from "./planMeta";
 import type { StudyPlanDTO } from "@/lib/study-plan/types";
 import { GOAL_TYPES } from "@/lib/study-plan/types";
@@ -21,12 +22,20 @@ const inputClass =
 const selectClass =
   "h-9 w-full rounded-lg border border-gray-300 bg-white px-3 text-sm outline-none focus:border-brand-red focus:ring-2 focus:ring-brand-red/20";
 
+function toDatetimeLocal(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormProps) {
   const [title, setTitle] = useState("");
   const [subject, setSubject] = useState("");
   const [description, setDescription] = useState("");
   const [goalType, setGoalType] = useState<string>("KLAUSUR");
-  const [targetDate, setTargetDate] = useState("");
+  const [isAllDay, setIsAllDay] = useState(true);
+  const [examStart, setExamStart] = useState(""); // datetime-local
+  const [examEnd, setExamEnd] = useState("");     // datetime-local
+  const [activePicker, setActivePicker] = useState<"start" | "end" | null>(null);
   const [difficulty, setDifficulty] = useState("3");
   const [priorKnowledge, setPriorKnowledge] = useState("3");
   const [pages, setPages] = useState("");
@@ -35,8 +44,7 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
   const [saving, setSaving] = useState(false);
   const [subjectOptions, setSubjectOptions] = useState<string[]>([]);
 
-  // Fächer-Vorschläge aus dem Kalender laden (eigene Fächer + DHBW-Veranstaltungen).
-  // Freitext bleibt weiterhin möglich – die Liste ist nur eine Auswahlhilfe.
+  // Fächer-Vorschläge aus dem Kalender laden
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -62,12 +70,10 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
         }
         setSubjectOptions([...subjects].sort((a, b) => a.localeCompare(b, "de")));
       } catch {
-        // Kalender nicht erreichbar → keine Vorschläge, Freitext bleibt möglich.
+        // Kalender nicht erreichbar → keine Vorschläge
       }
     })();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [open]);
 
   // Felder beim Öffnen befüllen (Bearbeiten) bzw. zurücksetzen (Anlegen)
@@ -77,13 +83,25 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
     setSubject(plan?.subject ?? "");
     setDescription(plan?.description ?? "");
     setGoalType(plan?.goalType ?? "KLAUSUR");
-    setTargetDate(plan ? toDateInputValue(plan.targetDate) : "");
     setDifficulty(plan?.difficulty ? String(plan.difficulty) : "3");
     setPriorKnowledge(plan?.priorKnowledge ? String(plan.priorKnowledge) : "3");
     setPages(plan?.pages ? String(plan.pages) : "");
     setCredits(plan?.credits ? String(plan.credits) : "");
     setError(null);
     setSaving(false);
+    setActivePicker(null);
+
+    if (plan?.targetDateEnd) {
+      // Bestehender Plan mit Uhrzeit
+      setIsAllDay(false);
+      setExamStart(toDatetimeLocal(new Date(plan.targetDate)));
+      setExamEnd(toDatetimeLocal(new Date(plan.targetDateEnd)));
+    } else {
+      // Ganztägig (neu oder bestehend ohne Endzeit)
+      setIsAllDay(true);
+      setExamStart(plan ? toDateInputValue(plan.targetDate) + "T12:00" : "");
+      setExamEnd("");
+    }
   }, [open, plan]);
 
   // ESC schließt Modal
@@ -98,19 +116,61 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
 
   if (!open) return null;
 
+  function handleAllDayChange(nextAllDay: boolean) {
+    setIsAllDay(nextAllDay);
+    setActivePicker(null);
+    const dateStr = examStart.slice(0, 10) || toDateInputValue(new Date(Date.now() + 86_400_000).toISOString());
+    if (nextAllDay) {
+      setExamStart(dateStr + "T12:00");
+      setExamEnd("");
+    } else {
+      setExamStart(dateStr + "T09:00");
+      setExamEnd(dateStr + "T11:00");
+    }
+  }
+
+  function handleStartChange(nextStart: string) {
+    setExamStart(nextStart);
+    const startDate = new Date(nextStart);
+    const endDate = new Date(examEnd);
+    if (isNaN(endDate.getTime()) || endDate.getTime() <= startDate.getTime()) {
+      setExamEnd(toDatetimeLocal(new Date(startDate.getTime() + 2 * 60 * 60 * 1000)));
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
 
-    if (!title.trim() || !subject.trim() || !targetDate) {
+    const dateStr = examStart.slice(0, 10);
+    if (!title.trim() || !subject.trim() || !dateStr) {
       setError("Bitte Titel, Fach und Zieldatum ausfüllen.");
       return;
     }
 
-    const target = fromDateInputValue(targetDate);
-    if (!plan && target.getTime() < new Date().setHours(0, 0, 0, 0)) {
-      setError("Das Zieldatum muss in der Zukunft liegen.");
-      return;
+    let targetDateISO: string;
+    let targetDateEndISO: string | null = null;
+
+    if (isAllDay) {
+      const target = fromDateInputValue(dateStr);
+      if (!plan && target.getTime() < new Date().setHours(0, 0, 0, 0)) {
+        setError("Das Zieldatum muss in der Zukunft liegen.");
+        return;
+      }
+      targetDateISO = target.toISOString();
+    } else {
+      const start = new Date(examStart);
+      const end = new Date(examEnd);
+      if (isNaN(start.getTime()) || isNaN(end.getTime()) || !examEnd) {
+        setError("Bitte gültige Start- und Endzeit wählen.");
+        return;
+      }
+      if (end.getTime() <= start.getTime()) {
+        setError("Die Endzeit muss nach der Startzeit liegen.");
+        return;
+      }
+      targetDateISO = start.toISOString();
+      targetDateEndISO = end.toISOString();
     }
 
     const body = {
@@ -118,7 +178,8 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
       subject: subject.trim(),
       description: description.trim() || null,
       goalType,
-      targetDate: target.toISOString(),
+      targetDate: targetDateISO,
+      targetDateEnd: targetDateEndISO,
       difficulty: Number(difficulty),
       priorKnowledge: Number(priorKnowledge),
       pages: pages.trim() ? Number(pages) : null,
@@ -221,18 +282,67 @@ export function StudyPlanForm({ open, plan, onClose, onSaved }: StudyPlanFormPro
             </div>
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label htmlFor="sp-target-date" className="text-xs font-semibold text-gray-700">
-              Zieldatum
-            </label>
-            <input
-              id="sp-target-date"
-              type="date"
-              required
-              value={targetDate}
-              onChange={(e) => setTargetDate(e.target.value)}
-              className={inputClass}
-            />
+          {/* Zieldatum: Ganztägig-Toggle + Picker */}
+          <div className="flex flex-col gap-2">
+            <p className="text-xs font-semibold text-gray-700">Zieldatum</p>
+
+            <button
+              type="button"
+              role="switch"
+              aria-checked={isAllDay}
+              onClick={() => handleAllDayChange(!isAllDay)}
+              className={`flex items-center justify-between rounded-xl border px-3 py-2.5 text-left transition-colors ${
+                isAllDay
+                  ? "border-brand-red bg-red-50 text-brand-red"
+                  : "border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100"
+              }`}
+            >
+              <span className="flex items-center gap-2 text-sm font-semibold">
+                <CalendarDays className="h-4 w-4" />
+                Ganztägig
+              </span>
+              <span
+                className={`relative h-5 w-9 rounded-full transition-colors ${
+                  isAllDay ? "bg-brand-red" : "bg-gray-300"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                    isAllDay ? "translate-x-[18px]" : "translate-x-0.5"
+                  }`}
+                />
+              </span>
+            </button>
+
+            <div className={isAllDay ? "" : "grid grid-cols-2 gap-3"}>
+              <DateTimePicker
+                id="sp-exam-start"
+                label={isAllDay ? "Datum" : "Beginn"}
+                value={examStart}
+                open={activePicker === "start"}
+                dateOnly={isAllDay}
+                stage={isAllDay ? undefined : "start"}
+                onOpenChange={(o) => setActivePicker(o ? "start" : null)}
+                onChange={isAllDay
+                  ? (v) => setExamStart(v.slice(0, 10) + "T12:00")
+                  : handleStartChange
+                }
+                onComplete={isAllDay ? undefined : () => setActivePicker("end")}
+              />
+              {!isAllDay && (
+                <DateTimePicker
+                  id="sp-exam-end"
+                  label="Ende"
+                  value={examEnd}
+                  open={activePicker === "end"}
+                  align="right"
+                  allowMidnight
+                  stage="end"
+                  onOpenChange={(o) => setActivePicker(o ? "end" : null)}
+                  onChange={setExamEnd}
+                />
+              )}
+            </div>
           </div>
 
           <div className="flex flex-col gap-1">

--- a/src/lib/study-plan/types.ts
+++ b/src/lib/study-plan/types.ts
@@ -38,7 +38,8 @@ export interface StudyPlanDTO {
   subject: string;
   description: string | null;
   goalType: GoalType;
-  targetDate: string; // ISO
+  targetDate: string; // ISO – Startzeit (oder Mitternacht wenn ganztägig)
+  targetDateEnd: string | null; // ISO – Endzeit; null = ganztägig
   // Algorithmus-Eingaben
   difficulty: number | null;
   priorKnowledge: number | null;
@@ -100,6 +101,7 @@ export function serializeStudyPlan(p: StudyPlan): StudyPlanDTO {
     description: p.description,
     goalType: p.goalType,
     targetDate: p.targetDate.toISOString(),
+    targetDateEnd: p.targetDateEnd ? p.targetDateEnd.toISOString() : null,
     difficulty: p.difficulty,
     priorKnowledge: p.priorKnowledge,
     pages: p.pages,


### PR DESCRIPTION
## Summary

- Adds a **Ganztägig** toggle to the study plan form's deadline field — same toggle style as in the event creation modal
- When ganztägig is off, the UI switches to **Beginn + Ende** pickers with start/end stage indicator (identical UX to creating a timed calendar event)
- Existing all-day study plans are unaffected (null `targetDateEnd` = all-day)
- Study plan detail view shows the exam time range when a specific time is set

## Changes

| File | What changed |
|---|---|
| `prisma/schema.prisma` | Added `targetDateEnd DateTime?` to `StudyPlan` |
| `prisma/migrations/…` | Migration SQL for the new nullable column |
| `src/lib/study-plan/types.ts` | Added `targetDateEnd: string \| null` to `StudyPlanDTO` + `serializeStudyPlan` |
| `src/app/api/study-plan/route.ts` | POST accepts + validates `targetDateEnd` |
| `src/app/api/study-plan/[id]/route.ts` | PATCH accepts + validates `targetDateEnd` |
| `src/components/study-plan/StudyPlanForm.tsx` | Ganztägig toggle + conditional DateTimePicker(s) replacing native date input |
| `src/components/study-plan/StudyPlanDetail.tsx` | Shows exam time range in header when `targetDateEnd` is set |

## Reviewer notes

- `targetDate` stores the start datetime (or local midnight for all-day); the scheduler still uses it as the deadline — an exam at 09:00 means study sessions are planned to finish before 09:00 on that day
- Migration is additive (nullable column), no data loss for existing plans
- After pulling: `npm run prisma:deploy` to apply the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)