### PR TITLE
Kalenderdarstellung verbessern

### DIFF
--- a/src/components/calendar/AllDayBar.tsx
+++ b/src/components/calendar/AllDayBar.tsx
@@ -59,7 +59,7 @@ export function AllDayBar({ days, events, onEventClick }: AllDayBarProps) {
 function isStudyPlanDeadline(event: CalEvent): boolean {
   return (
     event.id.startsWith("plan-deadline-") ||
-    (event.readOnly === true && event.type?.trim().toLowerCase() === "deadline")
+    (event.readOnly === true && event.type?.trim().toLocaleLowerCase("de-DE") === "deadline")
   );
 }
 

--- a/src/components/calendar/AllDayBar.tsx
+++ b/src/components/calendar/AllDayBar.tsx
@@ -2,7 +2,7 @@
 
 import { Star } from "lucide-react";
 import type { CalEvent } from "./events";
-import { eventOverlapsDay } from "./events";
+import { eventOnDay, eventOverlapsDay } from "./events";
 
 interface AllDayBarProps {
   days: Date[];
@@ -25,31 +25,48 @@ export function AllDayBar({ days, events, onEventClick }: AllDayBarProps) {
         Ganztägig
       </div>
       {days.map((day, i) => {
-        const dayEvents = allDay.filter((e) => eventOverlapsDay(e, day));
+        const dayEvents = allDay.filter((e) => eventVisibleOnDay(e, day));
         return (
           <div
             key={i}
-            className="border-r border-gray-200 last:border-r-0 px-1 py-1 min-h-[28px] space-y-0.5"
+            className="min-w-0 border-r border-gray-200 px-1 py-1 last:border-r-0 min-h-[28px] space-y-0.5"
           >
-            {dayEvents.map((ev) => (
-              <button
-                key={ev.id}
-                type="button"
-                title={ev.title}
-                onClick={() => onEventClick?.(ev)}
-                className={`${ev.color} flex w-full items-center gap-1 truncate rounded px-1.5 py-0.5 text-left text-[11px] leading-tight text-white opacity-90 transition-opacity hover:opacity-75 ${
-                  ev.important ? "ring-1 ring-amber-300" : ""
-                }`}
-              >
-                {ev.important && (
-                  <Star className="h-3 w-3 shrink-0" fill="currentColor" />
-                )}
-                <span className="truncate">{ev.title}</span>
-              </button>
-            ))}
+            {dayEvents.map((ev) => {
+              return (
+                <button
+                  key={ev.id}
+                  type="button"
+                  title={ev.title}
+                  onClick={() => onEventClick?.(ev)}
+                  className={`${ev.color} flex w-full min-w-0 items-center gap-1 overflow-hidden rounded px-1.5 py-0.5 text-left text-[11px] leading-tight text-white opacity-90 transition-opacity hover:opacity-75 ${
+                    ev.important ? "ring-1 ring-amber-300" : ""
+                  }`}
+                >
+                  {ev.important && (
+                    <Star className="h-3 w-3 shrink-0" fill="currentColor" />
+                  )}
+                  <span className="min-w-0 truncate">{ev.title}</span>
+                </button>
+              );
+            })}
           </div>
         );
       })}
     </div>
   );
+}
+
+function isStudyPlanDeadline(event: CalEvent): boolean {
+  return (
+    event.id.startsWith("plan-deadline-") ||
+    (event.readOnly === true && event.type?.trim().toLowerCase() === "deadline")
+  );
+}
+
+function eventVisibleOnDay(event: CalEvent, day: Date): boolean {
+  if (isStudyPlanDeadline(event)) {
+    return eventOnDay(event, day);
+  }
+
+  return eventOverlapsDay(event, day);
 }

--- a/src/components/calendar/DateTimePicker.tsx
+++ b/src/components/calendar/DateTimePicker.tsx
@@ -223,7 +223,13 @@ export function DateTimePicker({
         aria-expanded={open}
       >
         <CalendarDays className="h-4 w-4 shrink-0 text-red-400" />
-        <span className={`truncate ${!value && placeholder ? "text-gray-400" : ""}`}>
+        <span
+          className={`truncate ${
+            !value && placeholder
+              ? "text-gray-400 dark:text-white/55"
+              : "text-current dark:text-white"
+          }`}
+        >
           {!value && placeholder ? placeholder : formatValue(value, dateOnly)}
         </span>
       </button>

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -235,6 +235,7 @@ export function EventBlock({
   const renderHeight = preview?.height ?? baseHeight;
   const renderTranslateX = preview?.translateX ?? 0;
   const isReadOnly = !!event.readOnly;
+  const displayTitle = formatEventBlockTitle(event);
 
   return (
     <div
@@ -266,15 +267,15 @@ export function EventBlock({
           isReadOnly ? "cursor-pointer" : "cursor-grab active:cursor-grabbing"
         }`}
       >
-        <div className="flex items-center gap-1 font-semibold leading-tight">
+        <div className="flex min-w-0 items-center gap-1 font-semibold leading-tight">
           {event.important && (
             <Star className="h-3 w-3 shrink-0" fill="currentColor" />
           )}
           {event.taskCompleted && (
             <CircleCheckBig className="h-3 w-3 shrink-0" />
           )}
-          <span className={`truncate ${event.taskCompleted ? "line-through" : ""}`}>
-            {event.title}
+          <span className={`min-w-0 truncate ${event.taskCompleted ? "line-through" : ""}`}>
+            {displayTitle}
           </span>
         </div>
         <div className="opacity-90 leading-tight truncate">
@@ -302,5 +303,20 @@ export function EventBlock({
         </>
       )}
     </div>
+  );
+}
+
+function formatEventBlockTitle(event: CalEvent): string {
+  const title = event.title.trim();
+  if (!isLernsessionTitle(event)) return title;
+
+  const topic = title.replace(/^Lernsession\s*:\s*/i, "").trim();
+  return topic ? `LS: ${topic}` : "LS";
+}
+
+function isLernsessionTitle(event: CalEvent): boolean {
+  return (
+    /^Lernsession\s*:/i.test(event.title) ||
+    event.type?.trim().toLocaleLowerCase("de-DE") === "lernsession"
   );
 }

--- a/src/components/calendar/EventBlock.tsx
+++ b/src/components/calendar/EventBlock.tsx
@@ -315,8 +315,9 @@ function formatEventBlockTitle(event: CalEvent): string {
 }
 
 function isLernsessionTitle(event: CalEvent): boolean {
+  const title = event.title.trim();
   return (
-    /^Lernsession\s*:/i.test(event.title) ||
+    /^Lernsession\s*:/i.test(title) ||
     event.type?.trim().toLocaleLowerCase("de-DE") === "lernsession"
   );
 }


### PR DESCRIPTION
## Änderungen

- Lernplan-Deadlines werden in der Wochen-Ganztagszeile nur am eigentlichen Zieltag angezeigt und der Titel bleibt innerhalb der Tageszelle gekürzt.
- Datumswerte im DateTimePicker sind im Dark Mode wieder gut lesbar.
- Lernsession-Titel werden im Kalenderblock als `LS: ...` angezeigt, damit mehr vom Thema sichtbar ist.

## Hintergrund

Lange Kalendertexte wurden in engen Zellen an der falschen Stelle abgeschnitten oder waren im Dark Mode schlecht lesbar. Die Änderungen betreffen nur die Anzeige, nicht die gespeicherten Event-Titel oder Detailansichten.

## Checks

- `npm.cmd run typecheck`
- `npm.cmd run lint`